### PR TITLE
Enable token send from fungible mapper

### DIFF
--- a/contracts/feature-tests/basic-features/src/storage_mapper_fungible_token.rs
+++ b/contracts/feature-tests/basic-features/src/storage_mapper_fungible_token.rs
@@ -117,6 +117,11 @@ pub trait FungibleTokenMapperFeatures:
     }
 
     #[endpoint]
+    fn send_fungible(&self, to: ManagedAddress, amount: BigUint) {
+        self.fungible_token_mapper().send(&to, &amount);
+    }
+
+    #[endpoint]
     fn get_balance_fungible(&self) -> BigUint {
         self.fungible_token_mapper().get_balance()
     }

--- a/elrond-wasm/src/storage/mappers/fungible_token_mapper.rs
+++ b/elrond-wasm/src/storage/mappers/fungible_token_mapper.rs
@@ -157,6 +157,12 @@ where
         payment
     }
 
+    pub fn send(&self, to: &ManagedAddress<SA>, amount: &BigUint<SA>) {
+        let send_wrapper = SendWrapper::<SA>::new();
+        let token_id = self.get_token_id();
+        send_wrapper.direct_esdt(to, &token_id, 0, amount);
+    }
+
     pub fn burn(&self, amount: &BigUint<SA>) {
         let send_wrapper = SendWrapper::<SA>::new();
         let token_id = self.get_token_id();


### PR DESCRIPTION
I find it useful for FungibleTokenMapper to have the ability to send a payment from the mapper of the token without creating the normal flow of self.send().direct_esdt(....)

