### PR TITLE
Add migrateUserName builtin function mock

### DIFF
--- a/framework/base/src/api/builtin_function_names.rs
+++ b/framework/base/src/api/builtin_function_names.rs
@@ -11,4 +11,5 @@ pub const ESDT_TRANSFER_FUNC_NAME: &str = "ESDTTransfer";
 pub const CHANGE_OWNER_BUILTIN_FUNC_NAME: &str = "ChangeOwnerAddress";
 pub const CLAIM_DEVELOPER_REWARDS_FUNC_NAME: &str = "ClaimDeveloperRewards";
 pub const SET_USERNAME_FUNC_NAME: &str = "SetUserName";
+pub const MIGRATE_USERNAME_FUNC_NAME: &str = "migrateUserName";
 pub const UPGRADE_CONTRACT_FUNC_NAME: &str = "upgradeContract";

--- a/framework/debug/src/tx_execution/builtin_function_mocks/general/migrate_username_mock.rs
+++ b/framework/debug/src/tx_execution/builtin_function_mocks/general/migrate_username_mock.rs
@@ -1,0 +1,46 @@
+use mx_sc::api::MIGRATE_USERNAME_FUNC_NAME;
+
+use crate::tx_mock::{BlockchainUpdate, TxCache, TxInput, TxResult};
+
+use super::super::builtin_func_trait::BuiltinFunction;
+
+pub struct MigrateUserName;
+
+type BlockchainResult = Result<(TxResult, BlockchainUpdate), TxResult>;
+
+impl BuiltinFunction for MigrateUserName {
+    fn name(&self) -> &str {
+        MIGRATE_USERNAME_FUNC_NAME
+    }
+
+    fn execute(&self, tx_input: TxInput, tx_cache: TxCache) -> (TxResult, BlockchainUpdate) {
+        self.execute_with_result(tx_input, tx_cache)
+            .unwrap_or_else(|err_result| (err_result, BlockchainUpdate::empty()))
+    }
+}
+
+impl MigrateUserName {
+    #[allow(clippy::result_large_err)]
+    fn execute_with_result(&self, tx_input: TxInput, tx_cache: TxCache) -> BlockchainResult {
+        if tx_input.args.len() != 1 {
+            return Result::Err(TxResult::from_vm_error(
+                "migrateUserName expects 1 argument",
+            ));
+        }
+
+        let username = tx_input.args[0].clone();
+        tx_cache.with_account_mut(&tx_input.to, |account| {
+            if account.username != username {
+                return Result::Err(TxResult::from_vm_error("username mismatch"));
+            }
+            if let Some(name_without_suffix) = username.strip_suffix(".elrond".as_bytes()) {
+                account.username = [name_without_suffix, ".x".as_bytes()].concat();
+                Ok(())
+            } else {
+                Result::Err(TxResult::from_vm_error("expected .elrond suffix"))
+            }
+        })?;
+
+        Result::Ok((TxResult::empty(), tx_cache.into_blockchain_updates()))
+    }
+}

--- a/framework/debug/src/tx_execution/builtin_function_mocks/general/mod.rs
+++ b/framework/debug/src/tx_execution/builtin_function_mocks/general/mod.rs
@@ -1,5 +1,6 @@
 mod change_owner_mock;
 mod claim_developer_rewards_mock;
+mod migrate_username_mock;
 mod set_username_mock;
 mod upgrade_contract;
 


### PR DESCRIPTION
- add mock for the `migrateUserName` builtin function, which migrates a username from `.elrond` to a `.x` suffix