### PR TITLE
sc-meta improvements

### DIFF
--- a/framework/meta/src/cli_args/cli_args_standalone.rs
+++ b/framework/meta/src/cli_args/cli_args_standalone.rs
@@ -29,6 +29,11 @@ pub struct StandaloneCliArgs {
 #[derive(Clone, PartialEq, Eq, Debug, Subcommand)]
 pub enum StandaloneCliAction {
     #[command(
+        about = "General info about the contract an libraries residing in the targetted directory.."
+    )]
+    Info(InfoArgs),
+
+    #[command(
         about = "Calls the meta crates for all contracts under given path with the given arguments."
     )]
     All(AllArgs),
@@ -37,6 +42,19 @@ pub enum StandaloneCliAction {
         about = "Upgrades a contract to the latest version. Multiple contract crates are allowed."
     )]
     Upgrade(UpgradeArgs),
+}
+
+#[derive(Default, Clone, PartialEq, Eq, Debug, Args)]
+pub struct InfoArgs {
+    /// Target directory to retrieve info from.
+    /// Will be current directory if not specified.
+    #[arg(long, verbatim_doc_comment)]
+    pub path: Option<String>,
+
+    /// Ignore all directories with these names.
+    #[arg(long, verbatim_doc_comment)]
+    #[clap(global = true, default_value = "target")]
+    pub ignore: Vec<String>,
 }
 
 #[derive(Default, Clone, PartialEq, Eq, Debug, Args)]

--- a/framework/meta/src/cli_args/cli_args_standalone.rs
+++ b/framework/meta/src/cli_args/cli_args_standalone.rs
@@ -50,6 +50,11 @@ pub struct AllArgs {
     #[clap(global = true)]
     pub path: Option<String>,
 
+    /// Ignore all directories with these names.
+    #[arg(long, verbatim_doc_comment)]
+    #[clap(global = true, default_value = "target")]
+    pub ignore: Vec<String>,
+
     #[arg(
         long = "no-abi-git-version",
         help = "Skips loading the Git version into the ABI",
@@ -75,6 +80,11 @@ pub struct UpgradeArgs {
     /// Will be current directory if not specified.
     #[arg(long, verbatim_doc_comment)]
     pub path: Option<String>,
+
+    /// Ignore all directories with these names.
+    #[arg(long, verbatim_doc_comment)]
+    #[clap(global = true, default_value = "target")]
+    pub ignore: Vec<String>,
 
     /// Overrides the version to upgrade to.
     /// By default it will be the last version out.

--- a/framework/meta/src/folder_structure/mod.rs
+++ b/framework/meta/src/folder_structure/mod.rs
@@ -1,5 +1,7 @@
+mod pretty_print;
 mod relevant_directory;
 mod version_req;
 
+pub use pretty_print::*;
 pub use relevant_directory::*;
 pub use version_req::*;

--- a/framework/meta/src/folder_structure/pretty_print.rs
+++ b/framework/meta/src/folder_structure/pretty_print.rs
@@ -1,0 +1,103 @@
+use super::RelevantDirectory;
+use std::{
+    collections::BTreeMap,
+    path::{Component, Path},
+};
+
+const PIPE_L: &str = " └─";
+const PIPE_T: &str = " ├─";
+const INDENT_PIPE: &str = " │ ";
+const INDENT_SPACE: &str = "   ";
+
+struct PrettyPrintTreeNode {
+    name: String,
+    dir: Option<RelevantDirectory>,
+    children: BTreeMap<String, PrettyPrintTreeNode>,
+}
+
+impl PrettyPrintTreeNode {
+    fn new(name: String) -> Self {
+        PrettyPrintTreeNode {
+            name,
+            dir: None,
+            children: BTreeMap::new(),
+        }
+    }
+
+    fn add_path(&mut self, path: &Path, dir: &RelevantDirectory) {
+        let components: Vec<Component> = path
+            .components()
+            .filter(|component| component.as_os_str().to_string_lossy() != "/")
+            .collect();
+        self.add_components(&components[..], dir);
+    }
+
+    fn add_components(&mut self, components: &[Component], dir: &RelevantDirectory) {
+        if components.is_empty() {
+            return;
+        }
+
+        let first = components[0].as_os_str().to_string_lossy().into_owned();
+        let child = self
+            .children
+            .entry(first.to_string())
+            .or_insert_with(|| PrettyPrintTreeNode::new(first));
+
+        let remaining_components = &components[1..];
+        if remaining_components.is_empty() {
+            child.dir = Some(dir.clone());
+        } else {
+            child.add_components(remaining_components, dir);
+        }
+    }
+
+    fn coalesce_single_children(&mut self) {
+        for child in self.children.values_mut() {
+            child.coalesce_single_children();
+        }
+
+        if self.children.len() == 1 {
+            let only_child = self.children.first_entry().unwrap().remove();
+            self.name = format!("{}/{}", &self.name, &only_child.name);
+            self.children = only_child.children;
+        }
+    }
+
+    fn print<PrintName>(&self, prefix: &str, child_prefix: &str, print_name: &PrintName)
+    where
+        PrintName: Fn(&RelevantDirectory),
+    {
+        let num_children = self.children.len();
+        print!("{prefix} {}", &self.name);
+        if let Some(dir) = &self.dir {
+            print_name(dir);
+        }
+        println!();
+
+        for (i, child) in self.children.values().enumerate() {
+            let (l_pipe, vertical_pipe) = if i == num_children - 1 {
+                (PIPE_L, INDENT_SPACE)
+            } else {
+                (PIPE_T, INDENT_PIPE)
+            };
+
+            let next_prefix = format!("{child_prefix}{l_pipe}");
+            let next_child_prefix = format!("{child_prefix}{vertical_pipe}"); // or grandchild prefix
+            child.print(next_prefix.as_str(), next_child_prefix.as_str(), print_name);
+        }
+    }
+}
+
+pub fn dir_pretty_print<'a, I, PrintName>(dir_iter: I, prefix: &str, print_name: &PrintName)
+where
+    I: Iterator<Item = &'a RelevantDirectory>,
+    PrintName: Fn(&RelevantDirectory),
+{
+    let mut root = PrettyPrintTreeNode::new("".to_string());
+    for dir in dir_iter {
+        root.add_path(dir.path.as_ref(), dir);
+    }
+    root.coalesce_single_children();
+
+    root.print(prefix, prefix, print_name);
+}

--- a/framework/meta/src/folder_structure/relevant_directory.rs
+++ b/framework/meta/src/folder_structure/relevant_directory.rs
@@ -34,7 +34,7 @@ pub struct RelevantDirectory {
     pub dir_type: DirectoryType,
 }
 
-pub struct RelevantDirectories(Vec<RelevantDirectory>);
+pub struct RelevantDirectories(pub(crate) Vec<RelevantDirectory>);
 
 impl RelevantDirectories {
     pub fn find_all(path: impl AsRef<Path>, ignore: &[String]) -> Self {

--- a/framework/meta/src/folder_structure/relevant_directory.rs
+++ b/framework/meta/src/folder_structure/relevant_directory.rs
@@ -37,10 +37,17 @@ pub struct RelevantDirectory {
 pub struct RelevantDirectories(Vec<RelevantDirectory>);
 
 impl RelevantDirectories {
-    pub fn find_all(path: impl AsRef<Path>) -> Self {
-        let canonicalized = fs::canonicalize(path).expect("error canonicalizing input path");
+    pub fn find_all(path: impl AsRef<Path>, ignore: &[String]) -> Self {
+        let path_ref = path.as_ref();
+        let canonicalized = fs::canonicalize(path_ref).unwrap_or_else(|err| {
+            panic!(
+                "error canonicalizing input path {}: {}",
+                path_ref.display(),
+                err,
+            )
+        });
         let mut dirs = Vec::new();
-        populate_directories(canonicalized.as_path(), &mut dirs);
+        populate_directories(canonicalized.as_path(), ignore, &mut dirs);
         RelevantDirectories(dirs)
     }
 
@@ -89,15 +96,15 @@ impl RelevantDirectories {
     }
 }
 
-fn populate_directories(path: &Path, result: &mut Vec<RelevantDirectory>) {
+fn populate_directories(path: &Path, ignore: &[String], result: &mut Vec<RelevantDirectory>) {
     let is_contract = is_marked_contract_crate_dir(path);
 
     if !is_contract && path.is_dir() {
         let read_dir = fs::read_dir(path).expect("error reading directory");
         for child_result in read_dir {
             let child = child_result.unwrap();
-            if can_continue_recursion(&child) {
-                populate_directories(child.path().as_path(), result);
+            if can_continue_recursion(&child, ignore) {
+                populate_directories(child.path().as_path(), ignore, result);
             }
         }
     }
@@ -120,12 +127,16 @@ fn is_marked_contract_crate_dir(path: &Path) -> bool {
     path.join("multiversx.json").is_file() || path.join("elrond.json").is_file()
 }
 
-fn can_continue_recursion(dir_entry: &DirEntry) -> bool {
+fn can_continue_recursion(dir_entry: &DirEntry, blacklist: &[String]) -> bool {
     if !dir_entry.file_type().unwrap().is_dir() {
         return false;
     }
 
     if let Some(dir_name_str) = dir_entry.file_name().to_str() {
+        if blacklist.iter().any(|ignored| ignored == dir_name_str) {
+            return false;
+        }
+
         // do not explore hidden folders
         !dir_name_str.starts_with('.')
     } else {

--- a/framework/meta/src/lib.rs
+++ b/framework/meta/src/lib.rs
@@ -11,6 +11,7 @@ mod meta_validate_abi;
 mod meta_wasm_tools;
 pub mod output_contract;
 mod sc_upgrade;
+mod meta_info;
 
 pub use cargo_toml_contents::CargoTomlContents;
 pub use meta_cli::{cli_main, cli_main_standalone, multi_contract_config};

--- a/framework/meta/src/lib.rs
+++ b/framework/meta/src/lib.rs
@@ -7,11 +7,11 @@ mod meta_abi;
 mod meta_all;
 mod meta_cli;
 mod meta_config;
+mod meta_info;
 mod meta_validate_abi;
 mod meta_wasm_tools;
 pub mod output_contract;
 mod sc_upgrade;
-mod meta_info;
 
 pub use cargo_toml_contents::CargoTomlContents;
 pub use meta_cli::{cli_main, cli_main_standalone, multi_contract_config};

--- a/framework/meta/src/meta_all.rs
+++ b/framework/meta/src/meta_all.rs
@@ -4,7 +4,7 @@ use colored::Colorize;
 
 use crate::{
     cli_args::{AllArgs, CliArgsToRaw},
-    folder_structure::RelevantDirectories,
+    folder_structure::{dir_pretty_print, RelevantDirectories},
 };
 
 pub fn call_all_meta(args: &AllArgs) {
@@ -19,6 +19,8 @@ pub fn call_all_meta(args: &AllArgs) {
 
 fn perform_call_all_meta(path: impl AsRef<Path>, ignore: &[String], raw_args: Vec<String>) {
     let dirs = RelevantDirectories::find_all(path, ignore);
+    dir_pretty_print(dirs.iter_contract_crates(), "", &|_| {});
+
     println!(
         "Found {} contract crates.\n",
         dirs.iter_contract_crates().count(),

--- a/framework/meta/src/meta_all.rs
+++ b/framework/meta/src/meta_all.rs
@@ -14,11 +14,11 @@ pub fn call_all_meta(args: &AllArgs) {
         "./"
     };
 
-    perform_call_all_meta(path, args.to_raw());
+    perform_call_all_meta(path, args.ignore.as_slice(), args.to_raw());
 }
 
-fn perform_call_all_meta(path: impl AsRef<Path>, raw_args: Vec<String>) {
-    let dirs = RelevantDirectories::find_all(path);
+fn perform_call_all_meta(path: impl AsRef<Path>, ignore: &[String], raw_args: Vec<String>) {
+    let dirs = RelevantDirectories::find_all(path, ignore);
     println!(
         "Found {} contract crates.\n",
         dirs.iter_contract_crates().count(),
@@ -34,6 +34,11 @@ fn perform_call_all_meta(path: impl AsRef<Path>, raw_args: Vec<String>) {
 
 pub fn call_contract_meta(contract_crate_path: &Path, cargo_run_args: &[String]) {
     let meta_path = contract_crate_path.join("meta");
+    assert!(
+        meta_path.exists(),
+        "Contract meta crate not found at {}",
+        meta_path.as_path().display()
+    );
 
     println!(
         "\n{} `cargo run {}` in {}",

--- a/framework/meta/src/meta_cli.rs
+++ b/framework/meta/src/meta_cli.rs
@@ -4,6 +4,7 @@ use super::{
 use crate::{
     cli_args::{ContractCliAction, ContractCliArgs, StandaloneCliAction, StandaloneCliArgs},
     meta_all::call_all_meta,
+    meta_info::call_info,
     sc_upgrade::upgrade_sc,
 };
 use clap::Parser;
@@ -13,6 +14,7 @@ use multiversx_sc::contract_base::ContractAbiProvider;
 pub fn cli_main_standalone() {
     let cli_args = StandaloneCliArgs::parse();
     match &cli_args.command {
+        Some(StandaloneCliAction::Info(args)) => call_info(args),
         Some(StandaloneCliAction::All(args)) => call_all_meta(args),
         Some(StandaloneCliAction::Upgrade(args)) => {
             upgrade_sc(args);

--- a/framework/meta/src/meta_info.rs
+++ b/framework/meta/src/meta_info.rs
@@ -1,7 +1,7 @@
-use crate::folder_structure::dir_pretty_print;
-use crate::sc_upgrade::DEFAULT_LAST_VERSION;
 use crate::{
-    cli_args::InfoArgs, folder_structure::RelevantDirectories, sc_upgrade::print_tree_dir_metadata,
+    cli_args::InfoArgs,
+    folder_structure::{dir_pretty_print, RelevantDirectories},
+    sc_upgrade::{print_tree_dir_metadata, DEFAULT_LAST_VERSION},
 };
 
 pub fn call_info(args: &InfoArgs) {

--- a/framework/meta/src/meta_info.rs
+++ b/framework/meta/src/meta_info.rs
@@ -1,0 +1,18 @@
+use crate::folder_structure::dir_pretty_print;
+use crate::sc_upgrade::DEFAULT_LAST_VERSION;
+use crate::{
+    cli_args::InfoArgs, folder_structure::RelevantDirectories, sc_upgrade::print_tree_dir_metadata,
+};
+
+pub fn call_info(args: &InfoArgs) {
+    let path = if let Some(some_path) = &args.path {
+        some_path.as_str()
+    } else {
+        "./"
+    };
+
+    let dirs = RelevantDirectories::find_all(path, args.ignore.as_slice());
+    dir_pretty_print(dirs.iter(), "", &|dir| {
+        print_tree_dir_metadata(dir, DEFAULT_LAST_VERSION)
+    });
+}

--- a/framework/meta/src/sc_upgrade/mod.rs
+++ b/framework/meta/src/sc_upgrade/mod.rs
@@ -1,3 +1,5 @@
+mod upgrade_0_31;
+mod upgrade_0_32;
 mod upgrade_0_39;
 mod upgrade_common;
 mod upgrade_print;

--- a/framework/meta/src/sc_upgrade/mod.rs
+++ b/framework/meta/src/sc_upgrade/mod.rs
@@ -4,4 +4,6 @@ mod upgrade_print;
 mod upgrade_selector;
 mod upgrade_versions;
 
+pub use upgrade_print::print_tree_dir_metadata;
 pub use upgrade_selector::upgrade_sc;
+pub use upgrade_versions::DEFAULT_LAST_VERSION;

--- a/framework/meta/src/sc_upgrade/upgrade_0_31.rs
+++ b/framework/meta/src/sc_upgrade/upgrade_0_31.rs
@@ -1,0 +1,20 @@
+use super::upgrade_common::{replace_in_files, version_bump_in_cargo_toml};
+use crate::folder_structure::RelevantDirectory;
+use ruplacer::Query;
+use std::path::Path;
+
+/// Migrate `0.30` to `0.31.0`, including the version bump.
+pub fn upgrade_to_31_0(dir: &RelevantDirectory) {
+    v_0_31_replace_in_files(dir.path.as_ref());
+
+    let (from_version, to_version) = dir.upgrade_in_progress.unwrap();
+    version_bump_in_cargo_toml(&dir.path, from_version, to_version);
+}
+
+fn v_0_31_replace_in_files(sc_crate_path: &Path) {
+    replace_in_files(
+        sc_crate_path,
+        "*rs",
+        &[Query::substring("#[var_args]", "")][..],
+    );
+}

--- a/framework/meta/src/sc_upgrade/upgrade_0_32.rs
+++ b/framework/meta/src/sc_upgrade/upgrade_0_32.rs
@@ -1,0 +1,23 @@
+use super::upgrade_common::{replace_in_files, version_bump_in_cargo_toml};
+use crate::folder_structure::RelevantDirectory;
+use ruplacer::Query;
+use std::path::Path;
+
+/// Migrate `0.30` to `0.31.0`, including the version bump.
+pub fn upgrade_to_32_0(dir: &RelevantDirectory) {
+    v_0_32_replace_in_files(dir.path.as_ref());
+
+    let (from_version, to_version) = dir.upgrade_in_progress.unwrap();
+    version_bump_in_cargo_toml(&dir.path, from_version, to_version);
+}
+
+fn v_0_32_replace_in_files(sc_crate_path: &Path) {
+    replace_in_files(
+        sc_crate_path,
+        "*rs",
+        &[Query::substring(
+            "TokenIdentifier::egld()",
+            "EgldOrEsdtTokenIdentifier::egld()",
+        )][..],
+    );
+}

--- a/framework/meta/src/sc_upgrade/upgrade_common.rs
+++ b/framework/meta/src/sc_upgrade/upgrade_common.rs
@@ -1,5 +1,9 @@
 use ruplacer::{Console, DirectoryPatcher, Query, Settings};
-use std::{fs, path::Path};
+use std::{
+    fs,
+    path::Path,
+    process::{self, Command},
+};
 use toml::Value;
 
 use crate::{
@@ -190,4 +194,21 @@ pub fn re_generate_wasm_crate(dir: &RelevantDirectory) {
         &dir.path,
         &["abi".to_string(), "--no-abi-git-version".to_string()],
     );
+}
+
+pub fn cargo_check(dir: &RelevantDirectory) {
+    print_cargo_check(dir);
+
+    let result = Command::new("cargo")
+        .current_dir(&dir.path)
+        .args(["check", "--tests"])
+        .spawn()
+        .expect("failed to spawn cargo check process")
+        .wait()
+        .expect("cargo check was not running");
+
+    if !result.success() {
+        print_cargo_check_fail();
+        process::exit(1);
+    }
 }

--- a/framework/meta/src/sc_upgrade/upgrade_print.rs
+++ b/framework/meta/src/sc_upgrade/upgrade_print.rs
@@ -5,15 +5,30 @@ use crate::folder_structure::{
 use colored::Colorize;
 use std::path::Path;
 
-pub fn print_upgrading(dir: &RelevantDirectory, from_version: &str, to_version: &str) {
-    println!(
-        "\n{}",
-        format!(
-            "Upgrading from {from_version} to {to_version} in {}\n",
-            dir.path.display(),
-        )
-        .purple()
-    );
+pub fn print_upgrading(dir: &RelevantDirectory) {
+    if let Some((from_version, to_version)) = dir.upgrade_in_progress {
+        println!(
+            "\n{}",
+            format!(
+                "Upgrading from {from_version} to {to_version} in {}\n",
+                dir.path.display(),
+            )
+            .purple()
+        );
+    }
+}
+
+pub fn print_post_processing(dir: &RelevantDirectory) {
+    if let Some((from_version, to_version)) = dir.upgrade_in_progress {
+        println!(
+            "\n{}",
+            format!(
+                "Post-processing after upgrade from {from_version} to {to_version} in {}\n",
+                dir.path.display(),
+            )
+            .purple()
+        );
+    }
 }
 
 pub fn print_upgrading_all(from_version: &str, to_version: &str) {
@@ -68,4 +83,39 @@ pub fn print_tree_dir_metadata(dir: &RelevantDirectory, last_version: &str) {
     } else {
         print!(" {}", version_string.red());
     };
+}
+
+pub fn print_cargo_dep_remove(path: &Path, dep_name: &str) {
+    println!(
+        "{}/dependencies/{}",
+        path.display(),
+        dep_name.red().strikethrough(),
+    );
+}
+
+pub fn print_cargo_dep_add(path: &Path, dep_name: &str) {
+    println!(
+        "{}/dependencies/{}",
+        path.display(),
+        dep_name.red().strikethrough(),
+    );
+}
+
+pub fn print_cargo_check(dir: &RelevantDirectory) {
+    println!(
+        "\n{}",
+        format!(
+            "Running cargo check after upgrading to version {} in {}\n",
+            dir.version.semver,
+            dir.path.display(),
+        )
+        .purple()
+    );
+}
+
+pub fn print_cargo_check_fail() {
+    let message =
+        "Automatic upgrade failed to fix all issues. Fix them manually, make `cargo check` pass, then continue automatic upgrade!"
+        .red();
+    println!("\n{message}");
 }

--- a/framework/meta/src/sc_upgrade/upgrade_print.rs
+++ b/framework/meta/src/sc_upgrade/upgrade_print.rs
@@ -1,8 +1,9 @@
-use std::path::Path;
-
+use crate::folder_structure::{
+    DirectoryType::{Contract, Lib},
+    RelevantDirectory,
+};
 use colored::Colorize;
-
-use crate::folder_structure::RelevantDirectory;
+use std::path::Path;
 
 pub fn print_upgrading(dir: &RelevantDirectory, from_version: &str, to_version: &str) {
     println!(
@@ -53,4 +54,18 @@ pub fn print_postprocessing_after_39_1(path: &Path) {
         format!("Post-processing after 0.39.1 in {} ...", path.display()).green(),
         "Re-generating wasm crate ...".green(),
     );
+}
+
+pub fn print_tree_dir_metadata(dir: &RelevantDirectory, last_version: &str) {
+    match dir.dir_type {
+        Contract => print!(" {}", "[contract]".blue()),
+        Lib => print!(" {}", "[lib]".magenta()),
+    }
+
+    let version_string = format!("[{}]", &dir.version.semver);
+    if dir.version.semver == last_version {
+        print!(" {}", version_string.green());
+    } else {
+        print!(" {}", version_string.red());
+    };
 }

--- a/framework/meta/src/sc_upgrade/upgrade_selector.rs
+++ b/framework/meta/src/sc_upgrade/upgrade_selector.rs
@@ -26,7 +26,7 @@ pub fn upgrade_sc(args: &UpgradeArgs) {
         "Invalid requested version: {last_version}",
     );
 
-    let mut dirs = RelevantDirectories::find_all(path);
+    let mut dirs = RelevantDirectories::find_all(path, args.ignore.as_slice());
     println!(
         "Found {} directories to upgrade, out of which {} are contract crates.\n",
         dirs.len(),

--- a/framework/meta/src/sc_upgrade/upgrade_selector.rs
+++ b/framework/meta/src/sc_upgrade/upgrade_selector.rs
@@ -1,6 +1,6 @@
 use crate::{
     cli_args::UpgradeArgs,
-    folder_structure::{RelevantDirectories, RelevantDirectory},
+    folder_structure::{dir_pretty_print, RelevantDirectories, RelevantDirectory},
     sc_upgrade::{
         upgrade_0_39::{postprocessing_after_39_1, upgrade_to_39_0},
         upgrade_common::version_bump_in_cargo_toml,
@@ -32,6 +32,9 @@ pub fn upgrade_sc(args: &UpgradeArgs) {
         dirs.len(),
         dirs.iter_contract_crates().count(),
     );
+    dir_pretty_print(dirs.iter(), "", &|dir| {
+        print_tree_dir_metadata(dir, last_version.as_str())
+    });
 
     for (from_version, to_version) in versions_iter(last_version) {
         if dirs.count_for_version(from_version) == 0 {

--- a/framework/meta/src/sc_upgrade/upgrade_selector.rs
+++ b/framework/meta/src/sc_upgrade/upgrade_selector.rs
@@ -2,11 +2,15 @@ use crate::{
     cli_args::UpgradeArgs,
     folder_structure::{dir_pretty_print, RelevantDirectories, RelevantDirectory},
     sc_upgrade::{
-        upgrade_0_39::{postprocessing_after_39_1, upgrade_to_39_0},
+        upgrade_0_39::{postprocessing_after_39_0, upgrade_to_39_0},
         upgrade_common::version_bump_in_cargo_toml,
         upgrade_print::*,
         upgrade_versions::{versions_iter, DEFAULT_LAST_VERSION, VERSIONS},
     },
+};
+
+use super::{
+    upgrade_0_31::upgrade_to_31_0, upgrade_0_32::upgrade_to_32_0, upgrade_common::cargo_check,
 };
 
 pub fn upgrade_sc(args: &UpgradeArgs) {
@@ -42,37 +46,55 @@ pub fn upgrade_sc(args: &UpgradeArgs) {
         }
 
         print_upgrading_all(from_version, to_version);
+        dirs.start_upgrade(from_version, to_version);
         for dir in dirs.iter_version(from_version) {
-            print_upgrading(dir, from_version, to_version);
-            upgrade_function_selector(dir, from_version, to_version);
+            upgrade_function_selector(dir);
         }
 
         for dir in dirs.iter_version(from_version) {
             upgrade_post_processing(dir);
         }
 
-        // change the version in memory for the next iteration (dirs is not reloaded from disk)
-        dirs.update_versions_in_memory(from_version, to_version);
+        // // change the version in memory for the next iteration (dirs is not reloaded from disk)
+        // dirs.update_versions_in_memory(from_version, to_version);
+        dirs.finish_upgrade();
     }
 }
 
-fn upgrade_function_selector(dir: &RelevantDirectory, from_version: &str, to_version: &str) {
-    #[allow(clippy::single_match)]
-    match dir.version.semver.as_str() {
-        "0.38.0" => {
+fn upgrade_function_selector(dir: &RelevantDirectory) {
+    if dir.upgrade_in_progress.is_some() {
+        print_upgrading(dir);
+    }
+
+    match dir.upgrade_in_progress {
+        Some((_, "0.31.0")) => {
+            upgrade_to_31_0(dir);
+        },
+        Some((_, "0.32.0")) => {
+            upgrade_to_32_0(dir);
+        },
+        Some((_, "0.38.0")) => {
             upgrade_to_39_0(dir);
         },
-        _ => {
+        Some((from_version, to_version)) => {
             version_bump_in_cargo_toml(&dir.path, from_version, to_version);
         },
+        None => {},
     }
 }
 
 fn upgrade_post_processing(dir: &RelevantDirectory) {
-    #[allow(clippy::single_match)]
-    match dir.version.semver.as_str() {
-        "0.39.0" => {
-            postprocessing_after_39_1(dir);
+    match dir.upgrade_in_progress {
+        Some((_, "0.28.0")) | Some((_, "0.29.0")) | Some((_, "0.30.0")) | Some((_, "0.31.0"))
+        | Some((_, "0.32.0")) | Some((_, "0.33.0")) | Some((_, "0.34.0")) | Some((_, "0.35.0"))
+        | Some((_, "0.36.0")) | Some((_, "0.37.0")) => {
+            print_post_processing(dir);
+            cargo_check(dir);
+        },
+        Some((_, "0.39.0")) => {
+            print_post_processing(dir);
+            postprocessing_after_39_0(dir);
+            cargo_check(dir);
         },
         _ => {},
     }

--- a/framework/meta/src/sc_upgrade/upgrade_versions.rs
+++ b/framework/meta/src/sc_upgrade/upgrade_versions.rs
@@ -3,8 +3,25 @@
 /// Indicates where to stop with the upgrades.
 pub const DEFAULT_LAST_VERSION: &str = "0.39.2";
 
+/// Known version for the upgrader.
 #[rustfmt::skip]
 pub const VERSIONS: &[&str] = &[
+    "0.28.0",
+    "0.29.0",
+    "0.29.2",
+    "0.29.3",
+    "0.30.0",
+    "0.31.0",
+    "0.31.1",
+    "0.32.0",
+    "0.33.0",
+    "0.33.1",
+    "0.34.0",
+    "0.34.1",
+    "0.35.0",
+    "0.36.0",
+    "0.36.1",
+    "0.37.0",
     "0.38.0",
     "0.39.0",
     "0.39.1",


### PR DESCRIPTION
- New command: `sc-meta info` shows a pretty tree with all contracts and contract libraries in a folder
- Upgrade supports releases as early as `0.28.0`. 