### PR TITLE
Add ticker method to TokenIdentifier

### DIFF
--- a/framework/base/src/api/managed_types/managed_type_api_impl.rs
+++ b/framework/base/src/api/managed_types/managed_type_api_impl.rs
@@ -56,4 +56,8 @@ pub trait ManagedTypeApiImpl:
 
         super::token_identifier_util::validate_token_identifier(static_buffer_slice)
     }
+
+    fn get_token_ticker_len(&self, token_id_len: usize) -> usize {
+        super::token_identifier_util::get_token_ticker_len(token_id_len)
+    }
 }

--- a/framework/base/src/api/managed_types/token_identifier_util.rs
+++ b/framework/base/src/api/managed_types/token_identifier_util.rs
@@ -24,7 +24,7 @@ pub fn validate_token_identifier(token_id_slice: &[u8]) -> bool {
     let number_range = b'0'..=b'9';
 
     // ticker must be all uppercase alphanumeric
-    let ticker_len = length - ADDITIONAL_RANDOM_CHARS_LENGTH - 1;
+    let ticker_len = get_token_ticker_len(length);
     let ticker = &token_id_slice[..ticker_len];
     for ticker_char in ticker {
         let is_uppercase_letter = uppercase_letter_range.contains(ticker_char);
@@ -52,4 +52,8 @@ pub fn validate_token_identifier(token_id_slice: &[u8]) -> bool {
     }
 
     true
+}
+
+pub fn get_token_ticker_len(token_id_len: usize) -> usize {
+    token_id_len - ADDITIONAL_RANDOM_CHARS_LENGTH - 1
 }

--- a/framework/base/src/err_msg.rs
+++ b/framework/base/src/err_msg.rs
@@ -3,6 +3,7 @@ pub const PANIC_OCCURRED: &str = "panic occurred";
 pub const NON_PAYABLE_FUNC_EGLD: &str = "function does not accept EGLD payment";
 pub const NON_PAYABLE_FUNC_ESDT: &str = "function does not accept ESDT payment";
 pub const BAD_TOKEN_PROVIDED: &str = "bad call value token provided";
+pub const BAD_TOKEN_TICKER_FORMAT: &[u8] = b"bad token ticker format";
 pub const SINGLE_ESDT_EXPECTED: &str = "function expects single ESDT payment";
 pub const TOO_MANY_ESDT_TRANSFERS: &str = "too many ESDT transfers";
 pub const ESDT_INVALID_TOKEN_INDEX: &str = "invalid token index";

--- a/framework/base/src/types/managed/wrapped/token_identifier.rs
+++ b/framework/base/src/types/managed/wrapped/token_identifier.rs
@@ -64,6 +64,12 @@ impl<M: ManagedTypeApi> TokenIdentifier<M> {
     pub fn is_valid_esdt_identifier(&self) -> bool {
         M::managed_type_impl().validate_token_identifier(self.buffer.handle.clone())
     }
+
+    pub fn ticker(&self) -> ManagedBuffer<M> {
+        let token_id_len = self.buffer.len();
+        let ticker_len = M::managed_type_impl().get_token_ticker_len(token_id_len);
+        self.buffer.copy_slice(0, ticker_len).unwrap()
+    }
 }
 
 impl<M: ManagedTypeApi> From<ManagedBuffer<M>> for TokenIdentifier<M> {

--- a/framework/base/src/types/managed/wrapped/token_identifier.rs
+++ b/framework/base/src/types/managed/wrapped/token_identifier.rs
@@ -1,7 +1,8 @@
 use crate::{
     abi::{TypeAbi, TypeName},
-    api::{HandleConstraints, ManagedTypeApi, ManagedTypeApiImpl},
+    api::{ErrorApi, ErrorApiImpl, HandleConstraints, ManagedTypeApi, ManagedTypeApiImpl},
     codec::*,
+    err_msg,
     formatter::{FormatByteReceiver, SCDisplay, SCLowerHex},
     types::{ManagedBuffer, ManagedType},
 };
@@ -15,7 +16,7 @@ use super::EgldOrEsdtTokenIdentifier;
 /// Not yet implemented, but we might add additional restrictions when deserializing as argument.
 #[repr(transparent)]
 #[derive(Clone)]
-pub struct TokenIdentifier<M: ManagedTypeApi> {
+pub struct TokenIdentifier<M: ErrorApi + ManagedTypeApi> {
     buffer: ManagedBuffer<M>,
 }
 
@@ -68,7 +69,9 @@ impl<M: ManagedTypeApi> TokenIdentifier<M> {
     pub fn ticker(&self) -> ManagedBuffer<M> {
         let token_id_len = self.buffer.len();
         let ticker_len = M::managed_type_impl().get_token_ticker_len(token_id_len);
-        self.buffer.copy_slice(0, ticker_len).unwrap()
+        self.buffer.copy_slice(0, ticker_len).unwrap_or_else(|| {
+            M::error_api_impl().signal_error(err_msg::BAD_TOKEN_TICKER_FORMAT)
+        })
     }
 }
 

--- a/framework/scenario/tests/token_identifier_test.rs
+++ b/framework/scenario/tests/token_identifier_test.rs
@@ -1,6 +1,6 @@
 use multiversx_sc::types::{
     BoxedBytes, EgldOrEsdtTokenIdentifier, EgldOrEsdtTokenPayment, EsdtTokenPayment,
-    TokenIdentifier,
+    TokenIdentifier, ManagedBuffer,
 };
 use multiversx_sc_scenario::{
     managed_egld_token_id, managed_token_id, managed_token_id_wrapped,
@@ -67,6 +67,72 @@ fn test_is_valid_esdt_identifier() {
 
     // ticker too long
     assert!(!TokenIdentifier::<DebugApi>::from("ALCCCCCCCCC-6258d2").is_valid_esdt_identifier());
+}
+
+#[test]
+#[rustfmt::skip]
+fn test_ticker() {
+    let _ = DebugApi::dummy();
+
+    // valid identifier
+    assert_eq!(
+        TokenIdentifier::<DebugApi>::from("ALC-6258d2").ticker(),
+        ManagedBuffer::<DebugApi>::from("ALC"),
+    );
+
+    // valid identifier with numbers in ticker
+    assert_eq!(
+        TokenIdentifier::<DebugApi>::from("ALC123-6258d2").ticker(),
+        ManagedBuffer::<DebugApi>::from("ALC123"),
+    );
+
+    // valid ticker only numbers
+    assert_eq!(
+        TokenIdentifier::<DebugApi>::from("12345-6258d2").ticker(),
+        ManagedBuffer::<DebugApi>::from("12345"),
+    );
+
+    // missing dash
+    assert_eq!(
+        TokenIdentifier::<DebugApi>::from("ALC6258d2").ticker(),
+        ManagedBuffer::<DebugApi>::from("AL"),
+    );
+
+    // wrong dash position
+    assert_eq!(
+        TokenIdentifier::<DebugApi>::from("AL-C6258d2").ticker(),
+        ManagedBuffer::<DebugApi>::from("AL-"),
+    );
+
+    // lowercase ticker
+    assert_eq!(
+        TokenIdentifier::<DebugApi>::from("alc-6258d2").ticker(),
+        ManagedBuffer::<DebugApi>::from("alc"),
+    );
+
+    // uppercase random chars
+    assert_eq!(
+        TokenIdentifier::<DebugApi>::from("ALC-6258D2").ticker(),
+        ManagedBuffer::<DebugApi>::from("ALC"),
+    );
+
+    // too many random chars
+    assert_eq!(
+        TokenIdentifier::<DebugApi>::from("ALC-6258d2ff").ticker(),
+        ManagedBuffer::<DebugApi>::from("ALC-6"),
+    );
+
+    // ticker too short
+    assert_eq!(
+        TokenIdentifier::<DebugApi>::from("AL-6258d2").ticker(),
+        ManagedBuffer::<DebugApi>::from("AL"),
+    );
+
+    // ticker too long
+    assert_eq!(
+        TokenIdentifier::<DebugApi>::from("ALCCCCCCCCC-6258d2").ticker(),
+        ManagedBuffer::<DebugApi>::from("ALCCCCCCCCC"),
+    );
 }
 
 #[test]


### PR DESCRIPTION
The `ticker` method returns the ticker of the token identifier.