### PR TITLE
Add `.concat()` method to ManagedBuffer

### DIFF
--- a/framework/base/src/types/managed/basic/managed_buffer.rs
+++ b/framework/base/src/types/managed/basic/managed_buffer.rs
@@ -274,6 +274,14 @@ impl<M: ManagedTypeApi> ManagedBuffer<M> {
         M::managed_type_impl().mb_append_bytes(self.handle.clone(), &item.to_be_bytes()[..]);
     }
 
+    /// Concatenates 2 managed buffers. Consumes both arguments in the process.
+    #[inline]
+    #[must_use]
+    pub fn concat(mut self, other: ManagedBuffer<M>) -> Self {
+        self.append(&other);
+        self
+    }
+
     /// Convenience method for quickly getting a top-decoded u64 from the managed buffer.
     ///
     /// TODO: remove this method once TopDecodeInput is implemented for ManagedBuffer reference.


### PR DESCRIPTION
The `ManagedArgBuffer` has a `.concat` method:

https://github.com/multiversx/mx-sdk-rs/blob/master/framework/base/src/types/interaction/arg_buffer_managed.rs#L149

This PR adds this `.concat` method to ManagedBuffer.