### PR TITLE
validating var-args based on ABI when building

### DIFF
--- a/framework/base/src/abi/contract_abi.rs
+++ b/framework/base/src/abi/contract_abi.rs
@@ -48,4 +48,11 @@ impl ContractAbi {
             ..Default::default()
         }
     }
+
+    pub fn iter_all_functions(&self) -> impl Iterator<Item = &EndpointAbi> {
+        self.constructors
+            .iter()
+            .chain(self.endpoints.iter())
+            .chain(self.promise_callbacks.iter())
+    }
 }

--- a/framework/base/src/abi/contract_abi.rs
+++ b/framework/base/src/abi/contract_abi.rs
@@ -49,7 +49,8 @@ impl ContractAbi {
         }
     }
 
-    pub fn iter_all_functions(&self) -> impl Iterator<Item = &EndpointAbi> {
+    /// All exported functions: init, endpoints, promises callbacks.
+    pub fn iter_all_exports(&self) -> impl Iterator<Item = &EndpointAbi> {
         self.constructors
             .iter()
             .chain(self.endpoints.iter())

--- a/framework/meta/src/meta_validate_abi.rs
+++ b/framework/meta/src/meta_validate_abi.rs
@@ -1,14 +1,39 @@
-use multiversx_sc::abi::ContractAbi;
+use multiversx_sc::abi::{ContractAbi, EndpointAbi};
 
-fn validate_abi_constructor(abi: &ContractAbi) -> Result<(), &'static str> {
+pub fn validate_abi(abi: &ContractAbi) -> Result<(), String> {
+    check_single_constructor(abi)?;
+    validate_contract_var_args(abi)?;
+    Ok(())
+}
+
+fn check_single_constructor(abi: &ContractAbi) -> Result<(), String> {
     match abi.constructors.len() {
-        0 => Err("Missing constructor. Add a method annotated with `#[init]`."),
+        0 => Err("Missing constructor. Add a method annotated with `#[init]`.".to_string()),
         1 => Ok(()),
-        _ => Err("More than one contrctructor present. Exactly one method annotated with `#[init]` is required."),
+        _ => Err("More than one contrctructor present. Exactly one method annotated with `#[init]` is required.".to_string()),
     }
 }
 
-pub fn validate_abi(abi: &ContractAbi) -> Result<(), &'static str> {
-    validate_abi_constructor(abi)?;
+fn validate_contract_var_args(abi: &ContractAbi) -> Result<(), String> {
+    for endpoint_abi in abi.iter_all_functions() {
+        validate_endpoint_var_args(endpoint_abi)?;
+    }
+    Ok(())
+}
+
+fn validate_endpoint_var_args(endpoint_abi: &EndpointAbi) -> Result<(), String> {
+    let mut var_args_encountered = false;
+    for arg in &endpoint_abi.inputs {
+        if arg.multi_arg {
+            var_args_encountered = true;
+        } else {
+            if var_args_encountered {
+                return Err(format!(
+                    "Found regular arguments after var-args in method {}. This is not allowed, because it makes it impossible to parse the arguments.",
+                    &endpoint_abi.rust_method_name));
+            }
+        }
+    }
+
     Ok(())
 }

--- a/framework/meta/src/meta_validate_abi.rs
+++ b/framework/meta/src/meta_validate_abi.rs
@@ -15,7 +15,7 @@ fn check_single_constructor(abi: &ContractAbi) -> Result<(), String> {
 }
 
 fn validate_contract_var_args(abi: &ContractAbi) -> Result<(), String> {
-    for endpoint_abi in abi.iter_all_functions() {
+    for endpoint_abi in abi.iter_all_exports() {
         validate_endpoint_var_args(endpoint_abi)?;
     }
     Ok(())
@@ -26,12 +26,10 @@ fn validate_endpoint_var_args(endpoint_abi: &EndpointAbi) -> Result<(), String> 
     for arg in &endpoint_abi.inputs {
         if arg.multi_arg {
             var_args_encountered = true;
-        } else {
-            if var_args_encountered {
-                return Err(format!(
+        } else if var_args_encountered {
+            return Err(format!(
                     "Found regular arguments after var-args in method {}. This is not allowed, because it makes it impossible to parse the arguments.",
                     &endpoint_abi.rust_method_name));
-            }
         }
     }
 

--- a/framework/meta/src/meta_validate_abi.rs
+++ b/framework/meta/src/meta_validate_abi.rs
@@ -14,8 +14,9 @@ fn check_single_constructor(abi: &ContractAbi) -> Result<(), String> {
     }
 }
 
+/// Note: promise callbacks not included, since they have `#[call_value]` arguments, that are currently not modelled.
 fn validate_contract_var_args(abi: &ContractAbi) -> Result<(), String> {
-    for endpoint_abi in abi.iter_all_exports() {
+    for endpoint_abi in abi.constructors.iter().chain(abi.endpoints.iter()) {
         validate_endpoint_var_args(endpoint_abi)?;
     }
     Ok(())


### PR DESCRIPTION
Prevents developers from accidentally mixing var-args and regular ones the wrong way.

We can also reduce it to just a warning in the future, if somebody needs it. However, I don't currently see why that might be.