### PR TITLE
removed api single esdt methods

### DIFF
--- a/framework/base/src/api/call_value_api.rs
+++ b/framework/base/src/api/call_value_api.rs
@@ -1,5 +1,4 @@
-use super::{handle_to_be_bytes, ErrorApiImpl, HandleTypeInfo, ManagedTypeApiImpl};
-use crate::types::EsdtTokenType;
+use super::{ErrorApiImpl, HandleTypeInfo, ManagedTypeApiImpl};
 
 pub trait CallValueApi: HandleTypeInfo {
     type CallValueApiImpl: CallValueApiImpl
@@ -21,54 +20,11 @@ pub trait CallValueApiImpl: ErrorApiImpl + ManagedTypeApiImpl + Sized {
     fn load_egld_value(&self, dest_handle: Self::BigIntHandle);
 
     /// Loads all ESDT call values into a managed vec. Overwrites destination.
-    fn load_all_esdt_transfers(&self, dest_handle: Self::ManagedBufferHandle) {
-        load_all_esdt_transfers_from_unmanaged(self, dest_handle);
-    }
+    fn load_all_esdt_transfers(&self, dest_handle: Self::ManagedBufferHandle);
 
+    /// Gets the total number of ESDT transfers (Fungible/SFT/NFT).
+    /// 
+    /// It is redundant, since the number can also be retrieved from `load_all_esdt_transfers`,
+    /// but it is easier and cheaper to call when the content of those transfers is of no interest.
     fn esdt_num_transfers(&self) -> usize;
-
-    /// Retrieves the ESDT call value from the VM.
-    /// Will return 0 in case of an EGLD transfer (cannot have both EGLD and ESDT transfer simultaneously).
-    fn load_single_esdt_value(&self, dest_handle: Self::BigIntHandle);
-
-    /// Returns the call value token identifier of the current call.
-    /// The identifier is wrapped in a TokenIdentifier object, to hide underlying logic.
-    fn token(&self) -> Option<Self::ManagedBufferHandle>;
-
-    /// Returns the nonce of the received ESDT token.
-    /// Will return 0 in case of EGLD or fungible ESDT transfer.
-    fn esdt_token_nonce(&self) -> u64;
-
-    /// Returns the ESDT token type.
-    /// Will return "Fungible" for EGLD.
-    fn esdt_token_type(&self) -> EsdtTokenType;
-
-    fn esdt_value_by_index(&self, index: usize) -> Self::BigIntHandle;
-
-    fn token_by_index(&self, index: usize) -> Self::ManagedBufferHandle;
-
-    fn esdt_token_nonce_by_index(&self, index: usize) -> u64;
-
-    fn esdt_token_type_by_index(&self, index: usize) -> EsdtTokenType;
-}
-
-pub fn load_all_esdt_transfers_from_unmanaged<A>(api: &A, dest_handle: A::ManagedBufferHandle)
-where
-    A: CallValueApiImpl,
-{
-    let num_transfers = api.esdt_num_transfers();
-    api.mb_overwrite(dest_handle.clone(), &[]);
-
-    for i in 0..num_transfers {
-        let token_identifier_handle = api.token_by_index(i);
-        let token_nonce = api.esdt_token_nonce_by_index(i);
-        let amount_handle = api.esdt_value_by_index(i);
-
-        api.mb_append_bytes(
-            dest_handle.clone(),
-            &handle_to_be_bytes(token_identifier_handle)[..],
-        );
-        api.mb_append_bytes(dest_handle.clone(), &token_nonce.to_be_bytes()[..]);
-        api.mb_append_bytes(dest_handle.clone(), &handle_to_be_bytes(amount_handle)[..]);
-    }
 }

--- a/framework/base/src/api/uncallable/call_value_api_uncallable.rs
+++ b/framework/base/src/api/uncallable/call_value_api_uncallable.rs
@@ -1,6 +1,5 @@
 use crate::{
     api::{CallValueApi, CallValueApiImpl},
-    types::EsdtTokenType,
 };
 
 use super::UncallableApi;
@@ -22,39 +21,11 @@ impl CallValueApiImpl for UncallableApi {
         unreachable!()
     }
 
-    fn load_single_esdt_value(&self, _dest: Self::BigIntHandle) {
-        unreachable!()
-    }
-
-    fn token(&self) -> Option<Self::ManagedBufferHandle> {
-        unreachable!()
-    }
-
-    fn esdt_token_nonce(&self) -> u64 {
-        unreachable!()
-    }
-
-    fn esdt_token_type(&self) -> EsdtTokenType {
+    fn load_all_esdt_transfers(&self, _dest_handle: Self::ManagedBufferHandle) {
         unreachable!()
     }
 
     fn esdt_num_transfers(&self) -> usize {
-        unreachable!()
-    }
-
-    fn esdt_value_by_index(&self, _index: usize) -> Self::BigIntHandle {
-        unreachable!()
-    }
-
-    fn token_by_index(&self, _index: usize) -> Self::ManagedBufferHandle {
-        unreachable!()
-    }
-
-    fn esdt_token_nonce_by_index(&self, _index: usize) -> u64 {
-        unreachable!()
-    }
-
-    fn esdt_token_type_by_index(&self, _index: usize) -> EsdtTokenType {
         unreachable!()
     }
 }

--- a/framework/base/src/contract_base/wrappers/call_value_wrapper.rs
+++ b/framework/base/src/contract_base/wrappers/call_value_wrapper.rs
@@ -91,15 +91,6 @@ where
         (payment.token_identifier, payment.amount)
     }
 
-    /// Retrieves the ESDT call value from the VM.
-    /// Will return 0 in case of an EGLD transfer (cannot have both EGLD and ESDT transfer simultaneously).
-    pub fn esdt_value(&self) -> BigUint<A> {
-        let call_value_single_esdt: A::BigIntHandle =
-            use_raw_handle(const_handles::CALL_VALUE_SINGLE_ESDT);
-        A::call_value_api_impl().load_single_esdt_value(call_value_single_esdt.clone());
-        BigUint::from_handle(call_value_single_esdt)
-    }
-
     /// Accepts and returns either an EGLD payment, or a single ESDT token.
     ///
     /// Will halt execution if more than one ESDT transfer was received.

--- a/framework/wasm-adapter/src/api/call_value_api_node.rs
+++ b/framework/wasm-adapter/src/api/call_value_api_node.rs
@@ -1,10 +1,7 @@
 use super::VmApiImpl;
 use multiversx_sc::{
-    api::{CallValueApi, CallValueApiImpl, StaticVarApiImpl},
-    types::{EsdtTokenType, ManagedType, TokenIdentifier},
+    api::{CallValueApi, CallValueApiImpl},
 };
-
-const MAX_POSSIBLE_TOKEN_IDENTIFIER_LENGTH: usize = 32;
 
 extern "C" {
     fn checkNoPayment();
@@ -14,18 +11,6 @@ extern "C" {
     fn managedGetMultiESDTCallValue(resultHandle: i32);
 
     fn getNumESDTTransfers() -> i32;
-
-    // single ESDT transfer
-    fn bigIntGetESDTCallValue(dest: i32);
-    fn getESDTTokenName(resultOffset: *const u8) -> i32;
-    fn getESDTTokenNonce() -> i64;
-    fn getESDTTokenType() -> i32;
-
-    // ESDT by index
-    fn bigIntGetESDTCallValueByIndex(dest: i32, index: i32);
-    fn getESDTTokenNameByIndex(resultOffset: *const u8, index: i32) -> i32;
-    fn getESDTTokenNonceByIndex(index: i32) -> i64;
-    fn getESDTTokenTypeByIndex(index: i32) -> i32;
 }
 
 impl CallValueApi for VmApiImpl {
@@ -59,60 +44,5 @@ impl CallValueApiImpl for VmApiImpl {
 
     fn esdt_num_transfers(&self) -> usize {
         unsafe { getNumESDTTransfers() as usize }
-    }
-
-    fn load_single_esdt_value(&self, dest: Self::BigIntHandle) {
-        unsafe {
-            bigIntGetESDTCallValue(dest);
-        }
-    }
-
-    fn token(&self) -> Option<Self::ManagedBufferHandle> {
-        unsafe {
-            let mut name_buffer = [0u8; MAX_POSSIBLE_TOKEN_IDENTIFIER_LENGTH];
-            let name_len = getESDTTokenName(name_buffer.as_mut_ptr());
-            if name_len == 0 {
-                None
-            } else {
-                Some(
-                    TokenIdentifier::<Self>::from_esdt_bytes(&name_buffer[..name_len as usize])
-                        .get_raw_handle(),
-                )
-            }
-        }
-    }
-
-    fn esdt_token_nonce(&self) -> u64 {
-        unsafe { getESDTTokenNonce() as u64 }
-    }
-
-    fn esdt_token_type(&self) -> EsdtTokenType {
-        unsafe { (getESDTTokenType() as u8).into() }
-    }
-
-    fn esdt_value_by_index(&self, index: usize) -> Self::BigIntHandle {
-        unsafe {
-            let value_handle = self.next_handle();
-            bigIntGetESDTCallValueByIndex(value_handle, index as i32);
-            value_handle
-        }
-    }
-
-    fn token_by_index(&self, index: usize) -> Self::ManagedBufferHandle {
-        unsafe {
-            let mut name_buffer = [0u8; MAX_POSSIBLE_TOKEN_IDENTIFIER_LENGTH];
-            let name_len = getESDTTokenNameByIndex(name_buffer.as_mut_ptr(), index as i32);
-
-            TokenIdentifier::<Self>::from_esdt_bytes(&name_buffer[..name_len as usize])
-                .get_raw_handle()
-        }
-    }
-
-    fn esdt_token_nonce_by_index(&self, index: usize) -> u64 {
-        unsafe { getESDTTokenNonceByIndex(index as i32) as u64 }
-    }
-
-    fn esdt_token_type_by_index(&self, index: usize) -> EsdtTokenType {
-        unsafe { (getESDTTokenTypeByIndex(index as i32) as u8).into() }
     }
 }

--- a/vm/src/api/call_value_api_mock.rs
+++ b/vm/src/api/call_value_api_mock.rs
@@ -1,21 +1,9 @@
 use crate::{num_bigint, tx_mock::TxPanic, DebugApi};
 use multiversx_sc::{
-    api::{CallValueApi, CallValueApiImpl},
+    api::{CallValueApi, CallValueApiImpl, ManagedBufferApi, handle_to_be_bytes},
     err_msg,
-    types::EsdtTokenType,
 };
 use num_traits::Zero;
-
-impl DebugApi {
-    fn fail_if_more_than_one_esdt_transfer(&self) {
-        if self.esdt_num_transfers() > 1 {
-            std::panic::panic_any(TxPanic {
-                status: 10,
-                message: err_msg::TOO_MANY_ESDT_TRANSFERS.to_string(),
-            });
-        }
-    }
-}
 
 impl CallValueApi for DebugApi {
     type CallValueApiImpl = DebugApi;
@@ -41,94 +29,28 @@ impl CallValueApiImpl for DebugApi {
         }
     }
 
-    #[inline]
     fn load_egld_value(&self, dest: Self::BigIntHandle) {
         self.set_big_uint(dest, self.input_ref().received_egld().clone())
     }
 
-    #[inline]
-    fn load_single_esdt_value(&self, dest: Self::BigIntHandle) {
-        self.fail_if_more_than_one_esdt_transfer();
-        if let Some(esdt_value) = self.input_ref().received_esdt().get(0) {
-            self.set_big_uint(dest, esdt_value.value.clone());
-        } else {
-            std::panic::panic_any(TxPanic {
-                status: 10,
-                message: err_msg::ESDT_INVALID_TOKEN_INDEX.to_string(),
-            });
+    fn load_all_esdt_transfers(&self, dest_handle: Self::ManagedBufferHandle) {
+        let transfers = self.input_ref().received_esdt();
+        self.mb_overwrite(dest_handle.clone(), &[]);
+
+        for transfer in transfers {
+            let token_identifier_handle = self.mb_new_from_bytes(&transfer.token_identifier);
+            let amount_handle = self.bi_new_from_big_int(transfer.value.clone().into());
+
+            self.mb_append_bytes(
+                dest_handle.clone(),
+                &handle_to_be_bytes(token_identifier_handle)[..],
+            );
+            self.mb_append_bytes(dest_handle.clone(), &transfer.nonce.to_be_bytes()[..]);
+            self.mb_append_bytes(dest_handle.clone(), &handle_to_be_bytes(amount_handle)[..]);
         }
     }
 
-    #[inline]
-    fn token(&self) -> Option<Self::ManagedBufferHandle> {
-        self.fail_if_more_than_one_esdt_transfer();
-
-        if self.esdt_num_transfers() > 0 {
-            Some(self.token_by_index(0))
-        } else {
-            None
-        }
-    }
-
-    #[inline]
-    fn esdt_token_nonce(&self) -> u64 {
-        self.fail_if_more_than_one_esdt_transfer();
-        self.esdt_token_nonce_by_index(0)
-    }
-
-    #[inline]
-    fn esdt_token_type(&self) -> EsdtTokenType {
-        self.fail_if_more_than_one_esdt_transfer();
-        self.esdt_token_type_by_index(0)
-    }
-
-    #[inline]
     fn esdt_num_transfers(&self) -> usize {
         self.input_ref().received_esdt().len()
-    }
-
-    #[inline]
-    fn esdt_value_by_index(&self, index: usize) -> Self::BigIntHandle {
-        if let Some(esdt_value) = self.input_ref().received_esdt().get(index) {
-            self.insert_new_big_uint(esdt_value.value.clone())
-        } else {
-            std::panic::panic_any(TxPanic {
-                status: 10,
-                message: err_msg::ESDT_INVALID_TOKEN_INDEX.to_string(),
-            });
-        }
-    }
-
-    #[inline]
-    fn token_by_index(&self, index: usize) -> Self::ManagedBufferHandle {
-        if let Some(esdt_value) = self.input_ref().received_esdt().get(index) {
-            self.insert_new_managed_buffer(esdt_value.token_identifier.clone())
-        } else {
-            std::panic::panic_any(TxPanic {
-                status: 10,
-                message: err_msg::ESDT_INVALID_TOKEN_INDEX.to_string(),
-            });
-        }
-    }
-
-    #[inline]
-    fn esdt_token_nonce_by_index(&self, index: usize) -> u64 {
-        if let Some(esdt_value) = self.input_ref().received_esdt().get(index) {
-            esdt_value.nonce
-        } else {
-            std::panic::panic_any(TxPanic {
-                status: 10,
-                message: err_msg::ESDT_INVALID_TOKEN_INDEX.to_string(),
-            });
-        }
-    }
-
-    #[inline]
-    fn esdt_token_type_by_index(&self, index: usize) -> EsdtTokenType {
-        if self.esdt_token_nonce_by_index(index) == 0 {
-            EsdtTokenType::Fungible
-        } else {
-            EsdtTokenType::NonFungible
-        }
     }
 }

--- a/vm/src/api/managed_types/big_int_api_mock.rs
+++ b/vm/src/api/managed_types/big_int_api_mock.rs
@@ -66,6 +66,14 @@ macro_rules! unary_op_method {
 }
 
 impl DebugApi {
+    pub(crate) fn bi_new_from_big_int(
+        &self,
+        value: num_bigint::BigInt,
+    ) -> <Self as HandleTypeInfo>::BigIntHandle {
+        let mut managed_types = self.m_types_borrow_mut();
+        managed_types.big_int_map.insert_new_handle(value)
+    }
+
     pub(crate) fn bi_overwrite(
         &self,
         destination: <Self as HandleTypeInfo>::BigIntHandle,
@@ -89,10 +97,7 @@ impl DebugApi {
 impl BigIntApi for DebugApi {
     #[allow(dead_code)]
     fn bi_new(&self, value: i64) -> Self::BigIntHandle {
-        let mut managed_types = self.m_types_borrow_mut();
-        managed_types
-            .big_int_map
-            .insert_new_handle(num_bigint::BigInt::from(value))
+        self.bi_new_from_big_int(num_bigint::BigInt::from(value))
     }
 
     fn bi_set_int64(&self, destination: Self::BigIntHandle, value: i64) {


### PR DESCRIPTION
Little PR brother of https://github.com/multiversx/mx-sdk-rs/pull/1045

Since it is cleanup season, decided to also get rid of the old single ESDT call value API methods. They don't work well in the context of multi-transfer, so they have been long out of use.