### PR TITLE
vault: transfer_execute instead of async call

### DIFF
--- a/contracts/feature-tests/composability/vault/src/vault.rs
+++ b/contracts/feature-tests/composability/vault/src/vault.rs
@@ -138,8 +138,7 @@ pub trait Vault {
                 .contract_call::<()>(caller.clone(), endpoint_name.clone())
                 .with_egld_or_single_esdt_transfer(return_payment.clone())
                 .with_gas_limit(self.blockchain().get_gas_left() / 2)
-                .async_call_promise()
-                .register_promise();
+                .transfer_execute()
         }
     }
 


### PR DESCRIPTION
Vault, as a child SC will respond with transfer_execute instead of async_call to parent.