### PR TITLE
call value payments as `ManagedRef`

### DIFF
--- a/contracts/core/wegld-swap/src/wegld.rs
+++ b/contracts/core/wegld-swap/src/wegld.rs
@@ -17,7 +17,7 @@ pub trait EgldEsdtSwap: multiversx_sc_modules::pause::PauseModule {
         self.require_not_paused();
 
         let payment_amount = self.call_value().egld_value();
-        require!(payment_amount > 0u32, "Payment must be more than 0");
+        require!(*payment_amount > 0u32, "Payment must be more than 0");
 
         let wrapped_egld_token_id = self.wrapped_egld_token_id().get();
         self.send()
@@ -27,7 +27,7 @@ pub trait EgldEsdtSwap: multiversx_sc_modules::pause::PauseModule {
         self.send()
             .direct_esdt(&caller, &wrapped_egld_token_id, 0, &payment_amount);
 
-        EsdtTokenPayment::new(wrapped_egld_token_id, 0, payment_amount)
+        EsdtTokenPayment::new(wrapped_egld_token_id, 0, payment_amount.clone_value())
     }
 
     #[payable("*")]

--- a/contracts/examples/crypto-bubbles/src/crypto_bubbles.rs
+++ b/contracts/examples/crypto-bubbles/src/crypto_bubbles.rs
@@ -16,7 +16,7 @@ pub trait CryptoBubbles {
         let payment = self.call_value().egld_value();
         let caller = self.blockchain().get_caller();
         self.player_balance(&caller)
-            .update(|balance| *balance += &payment);
+            .update(|balance| *balance += &*payment);
 
         self.top_up_event(&caller, &payment);
     }

--- a/contracts/examples/crypto-kitties/kitty-auction/src/lib.rs
+++ b/contracts/examples/crypto-kitties/kitty-auction/src/lib.rs
@@ -169,15 +169,15 @@ pub trait KittyAuction {
             "auction ended already!"
         );
         require!(
-            payment >= auction.starting_price,
+            *payment >= auction.starting_price,
             "bid amount must be higher than or equal to starting price!"
         );
         require!(
-            payment > auction.current_bid,
+            *payment > auction.current_bid,
             "bid amount must be higher than current winning bid!"
         );
         require!(
-            payment <= auction.ending_price,
+            *payment <= auction.ending_price,
             "bid amount must be less than or equal to ending price!"
         );
 
@@ -188,7 +188,7 @@ pub trait KittyAuction {
         }
 
         // update auction bid and winner
-        auction.current_bid = payment;
+        auction.current_bid = payment.clone_value();
         auction.current_winner = caller;
         self.auction(kitty_id).set(auction);
     }

--- a/contracts/examples/crypto-kitties/kitty-ownership/src/lib.rs
+++ b/contracts/examples/crypto-kitties/kitty-ownership/src/lib.rs
@@ -289,7 +289,7 @@ pub trait KittyOwnership {
         let auto_birth_fee = self.birth_fee().get();
         let caller = self.blockchain().get_caller();
 
-        require!(payment == auto_birth_fee, "Wrong fee!");
+        require!(*payment == auto_birth_fee, "Wrong fee!");
         require!(
             caller == self.kitty_owner(matron_id).get(),
             "Only the owner of the matron can call this function!"

--- a/contracts/examples/crypto-zombies/src/zombie_helper.rs
+++ b/contracts/examples/crypto-zombies/src/zombie_helper.rs
@@ -21,7 +21,7 @@ pub trait ZombieHelper: storage::Storage {
     fn level_up(&self, zombie_id: usize) {
         let payment_amount = self.call_value().egld_value();
         let fee = self.level_up_fee().get();
-        require!(payment_amount == fee, "Payment must be must be 0.001 EGLD");
+        require!(*payment_amount == fee, "Payment must be must be 0.001 EGLD");
         self.zombies(&zombie_id)
             .update(|my_zombie| my_zombie.level += 1);
     }

--- a/contracts/examples/esdt-transfer-with-fee/src/esdt_transfer_with_fee.rs
+++ b/contracts/examples/esdt-transfer-with-fee/src/esdt_transfer_with_fee.rs
@@ -48,7 +48,7 @@ pub trait EsdtTransferWithFee {
     #[endpoint]
     fn transfer(&self, address: ManagedAddress) {
         require!(
-            self.call_value().egld_value() == 0,
+            *self.call_value().egld_value() == 0,
             "EGLD transfers not allowed"
         );
         let payments = self.call_value().all_esdt_transfers();

--- a/contracts/examples/fractional-nfts/src/fractional_nfts.rs
+++ b/contracts/examples/fractional-nfts/src/fractional_nfts.rs
@@ -22,7 +22,7 @@ pub trait FractionalNfts: default_issue_callbacks::DefaultIssueCallbacksModule {
         let issue_cost = self.call_value().egld_value();
         self.fractional_token().issue_and_set_all_roles(
             EsdtTokenType::SemiFungible,
-            issue_cost,
+            issue_cost.clone_value(),
             token_display_name,
             token_ticker,
             num_decimals,

--- a/contracts/examples/nft-minter/src/nft_module.rs
+++ b/contracts/examples/nft-minter/src/nft_module.rs
@@ -25,7 +25,7 @@ pub trait NftModule {
         self.send()
             .esdt_system_sc_proxy()
             .issue_non_fungible(
-                payment_amount,
+                payment_amount.clone_value(),
                 &token_name,
                 &token_ticker,
                 NonFungibleTokenProperties {

--- a/contracts/examples/nft-storage-prepay/src/nft_storage_prepay.rs
+++ b/contracts/examples/nft-storage-prepay/src/nft_storage_prepay.rs
@@ -52,7 +52,8 @@ pub trait NftStoragePrepay {
     fn deposit_payment_for_storage(&self) {
         let payment = self.call_value().egld_value();
         let caller = self.blockchain().get_caller();
-        self.deposit(&caller).update(|deposit| *deposit += &*payment);
+        self.deposit(&caller)
+            .update(|deposit| *deposit += &*payment);
     }
 
     /// defaults to max amount

--- a/contracts/examples/nft-storage-prepay/src/nft_storage_prepay.rs
+++ b/contracts/examples/nft-storage-prepay/src/nft_storage_prepay.rs
@@ -52,7 +52,7 @@ pub trait NftStoragePrepay {
     fn deposit_payment_for_storage(&self) {
         let payment = self.call_value().egld_value();
         let caller = self.blockchain().get_caller();
-        self.deposit(&caller).update(|deposit| *deposit += payment);
+        self.deposit(&caller).update(|deposit| *deposit += &*payment);
     }
 
     /// defaults to max amount

--- a/contracts/examples/ping-pong-egld/src/ping_pong.rs
+++ b/contracts/examples/ping-pong-egld/src/ping_pong.rs
@@ -54,7 +54,7 @@ pub trait PingPong {
         let payment = self.call_value().egld_value();
 
         require!(
-            payment == self.ping_amount().get(),
+            *payment == self.ping_amount().get(),
             "the payment must match the fixed sum"
         );
 
@@ -74,7 +74,7 @@ pub trait PingPong {
                 &self
                     .blockchain()
                     .get_sc_balance(&EgldOrEsdtTokenIdentifier::egld(), 0)
-                    + &payment
+                    + &*payment
                     <= max_funds,
                 "smart contract full"
             );

--- a/contracts/examples/seed-nft-minter/src/nft_module.rs
+++ b/contracts/examples/seed-nft-minter/src/nft_module.rs
@@ -28,7 +28,7 @@ pub trait NftModule:
         let issue_cost = self.call_value().egld_value();
         self.nft_token_id().issue_and_set_all_roles(
             EsdtTokenType::NonFungible,
-            issue_cost,
+            issue_cost.clone_value(),
             token_display_name,
             token_ticker,
             0,

--- a/contracts/feature-tests/basic-features/src/storage_mapper_fungible_token.rs
+++ b/contracts/feature-tests/basic-features/src/storage_mapper_fungible_token.rs
@@ -13,7 +13,7 @@ pub trait FungibleTokenMapperFeatures:
     ) {
         let payment_amount = self.call_value().egld_value();
         self.fungible_token_mapper().issue(
-            payment_amount,
+            payment_amount.clone_value(),
             ManagedBuffer::new(),
             token_ticker,
             initial_supply,
@@ -33,7 +33,7 @@ pub trait FungibleTokenMapperFeatures:
         };
 
         self.fungible_token_mapper().issue(
-            payment,
+            payment.clone_value(),
             ManagedBuffer::new(),
             token_ticker,
             initial_supply,
@@ -71,7 +71,7 @@ pub trait FungibleTokenMapperFeatures:
     fn issue_and_set_all_roles_fungible(&self, token_ticker: ManagedBuffer) {
         let payment = self.call_value().egld_value();
         self.fungible_token_mapper().issue_and_set_all_roles(
-            payment,
+            payment.clone_value(),
             ManagedBuffer::new(),
             token_ticker,
             0,

--- a/contracts/feature-tests/basic-features/src/storage_mapper_non_fungible_token.rs
+++ b/contracts/feature-tests/basic-features/src/storage_mapper_non_fungible_token.rs
@@ -18,7 +18,7 @@ pub trait NonFungibleTokenMapperFeatures:
         let payment = self.call_value().egld_value();
         self.non_fungible_token_mapper().issue_and_set_all_roles(
             EsdtTokenType::Meta,
-            payment,
+            payment.clone_value(),
             ManagedBuffer::new(),
             token_ticker,
             0,

--- a/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/child/src/lib.rs
+++ b/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/child/src/lib.rs
@@ -21,7 +21,7 @@ pub trait Child {
         self.send()
             .esdt_system_sc_proxy()
             .issue_fungible(
-                issue_cost,
+                issue_cost.clone_value(),
                 &token_display_name,
                 &token_ticker,
                 &initial_supply,

--- a/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/parent/src/lib.rs
+++ b/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/parent/src/lib.rs
@@ -43,7 +43,7 @@ pub trait Parent {
         let _: IgnoreValue = self
             .child_proxy(child_contract_adress)
             .issue_wrapped_egld(token_display_name, token_ticker, initial_supply)
-            .with_egld_transfer(issue_cost)
+            .with_egld_transfer(issue_cost.clone_value())
             .with_gas_limit(ISSUE_EXPECTED_GAS_COST)
             .execute_on_dest_context();
     }

--- a/contracts/feature-tests/composability/forwarder-raw/src/forwarder_raw.rs
+++ b/contracts/feature-tests/composability/forwarder-raw/src/forwarder_raw.rs
@@ -88,7 +88,7 @@ pub trait ForwarderRaw {
         self.forward_contract_call(
             to,
             EgldOrEsdtTokenIdentifier::egld(),
-            payment,
+            payment.clone_value(),
             endpoint_name,
             args,
         )
@@ -245,11 +245,11 @@ pub trait ForwarderRaw {
         let payments = self.call_value().all_esdt_transfers();
         if payments.is_empty() {
             let egld_value = self.call_value().egld_value();
-            if egld_value > 0 {
+            if *egld_value > 0 {
                 let _ = self.callback_payments().push(&(
                     EgldOrEsdtTokenIdentifier::egld(),
                     0,
-                    egld_value,
+                    egld_value.clone_value(),
                 ));
             }
         } else {
@@ -304,7 +304,7 @@ pub trait ForwarderRaw {
     ) {
         let payment = self.call_value().egld_value();
         let one_third_gas = self.blockchain().get_gas_left() / 3;
-        let half_payment = payment / 2u32;
+        let half_payment = &*payment / 2u32;
         let arg_buffer = args.to_arg_buffer();
 
         let result = self.send_raw().execute_on_dest_context_raw(

--- a/contracts/feature-tests/composability/forwarder/src/call_queue.rs
+++ b/contracts/feature-tests/composability/forwarder/src/call_queue.rs
@@ -54,7 +54,7 @@ pub trait ForwarderQueuedCallModule {
         self.forward_queued_calls_event(
             max_call_depth,
             &self.call_value().egld_value(),
-            &esdt_transfers_multi.into_multi_value(),
+            &esdt_transfers_multi.clone_value().into_multi_value(),
         );
 
         if max_call_depth == 0 {

--- a/contracts/feature-tests/composability/forwarder/src/call_sync.rs
+++ b/contracts/feature-tests/composability/forwarder/src/call_sync.rs
@@ -128,19 +128,20 @@ pub trait ForwarderSyncCallModule {
     #[endpoint]
     fn forward_sync_retrieve_funds_with_accept_func(
         &self,
-        #[payment_multi] payments: ManagedVec<EsdtTokenPayment<Self::Api>>,
         to: ManagedAddress,
         token: TokenIdentifier,
         amount: BigUint,
     ) {
+        let payments = self.call_value().all_esdt_transfers();
+
         self.vault_proxy()
             .contract(to)
             .retrieve_funds_with_transfer_exec(
-                payments,
                 token,
                 amount,
                 OptionalValue::<ManagedBuffer>::Some(b"accept_funds_func".into()),
             )
+            .with_multi_token_transfer(payments.clone_value())
             .execute_on_dest_context::<()>();
     }
 

--- a/contracts/feature-tests/composability/forwarder/src/esdt.rs
+++ b/contracts/feature-tests/composability/forwarder/src/esdt.rs
@@ -96,7 +96,7 @@ pub trait ForwarderEsdtModule: storage::ForwarderStorageModule {
         self.send()
             .esdt_system_sc_proxy()
             .issue_fungible(
-                issue_cost,
+                issue_cost.clone_value(),
                 &token_display_name,
                 &token_ticker,
                 &initial_supply,

--- a/contracts/feature-tests/composability/forwarder/src/nft.rs
+++ b/contracts/feature-tests/composability/forwarder/src/nft.rs
@@ -56,7 +56,7 @@ pub trait ForwarderNftModule: storage::ForwarderStorageModule {
         self.send()
             .esdt_system_sc_proxy()
             .issue_non_fungible(
-                issue_cost,
+                issue_cost.clone_value(),
                 &token_display_name,
                 &token_ticker,
                 NonFungibleTokenProperties {

--- a/contracts/feature-tests/composability/forwarder/src/sft.rs
+++ b/contracts/feature-tests/composability/forwarder/src/sft.rs
@@ -13,7 +13,7 @@ pub trait ForwarderSftModule: storage::ForwarderStorageModule {
         self.send()
             .esdt_system_sc_proxy()
             .issue_semi_fungible(
-                issue_cost,
+                issue_cost.clone_value(),
                 &token_display_name,
                 &token_ticker,
                 SemiFungibleTokenProperties {

--- a/contracts/feature-tests/composability/local-esdt-and-nft/src/lib.rs
+++ b/contracts/feature-tests/composability/local-esdt-and-nft/src/lib.rs
@@ -32,7 +32,7 @@ pub trait LocalEsdtAndEsdtNft {
         self.send()
             .esdt_system_sc_proxy()
             .issue_fungible(
-                issue_cost,
+                issue_cost.clone_value(),
                 &token_display_name,
                 &token_ticker,
                 &initial_supply,
@@ -74,7 +74,7 @@ pub trait LocalEsdtAndEsdtNft {
         self.send()
             .esdt_system_sc_proxy()
             .issue_non_fungible(
-                issue_cost,
+                issue_cost.clone_value(),
                 &token_display_name,
                 &token_ticker,
                 NonFungibleTokenProperties {
@@ -179,7 +179,7 @@ pub trait LocalEsdtAndEsdtNft {
         self.send()
             .esdt_system_sc_proxy()
             .issue_semi_fungible(
-                issue_cost,
+                issue_cost.clone_value(),
                 &token_display_name,
                 &token_ticker,
                 SemiFungibleTokenProperties {

--- a/contracts/feature-tests/composability/proxy-test-first/src/proxy-test-first.rs
+++ b/contracts/feature-tests/composability/proxy-test-first/src/proxy-test-first.rs
@@ -65,7 +65,7 @@ pub trait ProxyTestFirst {
         let (address, init_result) = self
             .message_me_proxy()
             .init(123)
-            .with_egld_transfer(payment)
+            .with_egld_transfer(payment.clone_value())
             .deploy_contract::<i32>(&code, CodeMetadata::DEFAULT);
         self.set_other_contract(&address);
         init_result + 1
@@ -80,7 +80,7 @@ pub trait ProxyTestFirst {
         self.message_me_proxy()
             .contract(other_contract)
             .init(456)
-            .with_egld_transfer(payment)
+            .with_egld_transfer(payment.clone_value())
             .upgrade_contract(&code, CodeMetadata::DEFAULT);
     }
 
@@ -92,7 +92,7 @@ pub trait ProxyTestFirst {
         self.pay_me_proxy()
             .contract(other_contract)
             .pay_me(0x56)
-            .with_egld_transfer(payment)
+            .with_egld_transfer(payment.clone_value())
             .async_call()
             .call_and_exit()
     }
@@ -105,7 +105,7 @@ pub trait ProxyTestFirst {
         self.pay_me_proxy()
             .contract(other_contract)
             .pay_me_with_result(0x56)
-            .with_egld_transfer(payment)
+            .with_egld_transfer(payment.clone_value())
             .async_call()
             .with_callback(self.callbacks().pay_callback())
             .call_and_exit()

--- a/contracts/feature-tests/composability/transfer-role-features/src/lib.rs
+++ b/contracts/feature-tests/composability/transfer-role-features/src/lib.rs
@@ -30,7 +30,7 @@ pub trait TransferRoleFeatures:
         }
 
         if !self.blockchain().is_smart_contract(&dest) {
-            self.transfer_to_user(original_caller, dest, payments, endpoint_name);
+            self.transfer_to_user(original_caller, dest, payments.clone_value(), endpoint_name);
         } else {
             let mut args_buffer = ManagedArgBuffer::new();
             for arg in args {
@@ -40,7 +40,7 @@ pub trait TransferRoleFeatures:
             self.transfer_to_contract_raw(
                 original_caller,
                 dest,
-                payments,
+                payments.clone_value(),
                 endpoint_name,
                 args_buffer,
                 None,

--- a/contracts/feature-tests/composability/vault/src/vault.rs
+++ b/contracts/feature-tests/composability/vault/src/vault.rs
@@ -38,7 +38,10 @@ pub trait Vault {
     }
 
     fn esdt_transfers_multi(&self) -> MultiValueEncoded<EsdtTokenPaymentMultiValue> {
-        self.call_value().all_esdt_transfers().into_multi_value()
+        self.call_value()
+            .all_esdt_transfers()
+            .clone_value()
+            .into_multi_value()
     }
 
     #[payable("*")]
@@ -84,7 +87,6 @@ pub trait Vault {
     #[endpoint]
     fn retrieve_funds_with_transfer_exec(
         &self,
-        #[payment_multi] _payments: ManagedVec<EsdtTokenPayment<Self::Api>>,
         token: TokenIdentifier,
         amount: BigUint,
         opt_receive_func: OptionalValue<ManagedBuffer>,

--- a/contracts/feature-tests/composability/vault/src/vault.rs
+++ b/contracts/feature-tests/composability/vault/src/vault.rs
@@ -63,7 +63,7 @@ pub trait Vault {
         self.call_counts(ManagedBuffer::from(b"accept_funds_echo_payment"))
             .update(|c| *c += 1);
 
-        (egld_value, esdt_transfers_multi).into()
+        (egld_value.clone_value(), esdt_transfers_multi).into()
     }
 
     #[payable("*")]

--- a/contracts/feature-tests/legacy-examples/crypto-bubbles-legacy/src/crypto_bubbles_legacy.rs
+++ b/contracts/feature-tests/legacy-examples/crypto-bubbles-legacy/src/crypto_bubbles_legacy.rs
@@ -16,7 +16,7 @@ pub trait CryptoBubbles {
         let payment = self.call_value().egld_value();
         let caller = self.blockchain().get_caller_legacy();
         self.player_balance(&caller)
-            .update(|balance| *balance += &payment);
+            .update(|balance| *balance += &*payment);
 
         self.top_up_event(&caller, &payment);
     }

--- a/contracts/feature-tests/payable-features/src/payable_features.rs
+++ b/contracts/feature-tests/payable-features/src/payable_features.rs
@@ -16,7 +16,7 @@ pub trait PayableFeatures {
         &self,
     ) -> MultiValue2<BigUint, ManagedVec<Self::Api, EsdtTokenPayment<Self::Api>>> {
         (
-            self.call_value().egld_value(),
+            self.call_value().egld_value().clone_value(),
             self.call_value().all_esdt_transfers(),
         )
             .into()
@@ -81,7 +81,7 @@ pub trait PayableFeatures {
         &self,
         #[payment_token] token: EgldOrEsdtTokenIdentifier,
     ) -> MultiValue2<BigUint, EgldOrEsdtTokenIdentifier> {
-        let payment = self.call_value().egld_value();
+        let payment = self.call_value().egld_value().clone_value();
         (payment, token).into()
     }
 
@@ -101,7 +101,7 @@ pub trait PayableFeatures {
         &self,
         #[payment_token] token: EgldOrEsdtTokenIdentifier,
     ) -> MultiValue2<BigUint, EgldOrEsdtTokenIdentifier> {
-        let payment = self.call_value().egld_value();
+        let payment = self.call_value().egld_value().clone_value();
         (payment, token).into()
     }
 
@@ -110,7 +110,7 @@ pub trait PayableFeatures {
     fn payable_egld_4(&self) -> MultiValue2<BigUint, EgldOrEsdtTokenIdentifier> {
         let payment = self.call_value().egld_value();
         let token = self.call_value().egld_or_single_esdt().token_identifier;
-        (payment, token).into()
+        (payment.clone_value(), token).into()
     }
 
     #[endpoint]

--- a/contracts/feature-tests/payable-features/src/payable_features.rs
+++ b/contracts/feature-tests/payable-features/src/payable_features.rs
@@ -17,7 +17,7 @@ pub trait PayableFeatures {
     ) -> MultiValue2<BigUint, ManagedVec<Self::Api, EsdtTokenPayment<Self::Api>>> {
         (
             self.call_value().egld_value().clone_value(),
-            self.call_value().all_esdt_transfers(),
+            self.call_value().all_esdt_transfers().clone_value(),
         )
             .into()
     }
@@ -26,9 +26,9 @@ pub trait PayableFeatures {
     #[payable("*")]
     fn payment_multiple(
         &self,
-        #[payment_multi] payments: ManagedVec<EsdtTokenPayment<Self::Api>>,
+        #[payment_multi] payments: ManagedRef<'static, ManagedVec<EsdtTokenPayment<Self::Api>>>,
     ) -> ManagedVec<EsdtTokenPayment<Self::Api>> {
-        payments
+        payments.clone_value()
     }
 
     #[endpoint]

--- a/contracts/feature-tests/rust-testing-framework-tester/src/lib.rs
+++ b/contracts/feature-tests/rust-testing-framework-tester/src/lib.rs
@@ -98,7 +98,7 @@ pub trait RustTestingFrameworkTester: dummy_module::DummyModule {
     #[payable("*")]
     #[endpoint]
     fn receive_multi_esdt(&self) -> ManagedVec<EsdtTokenPayment<Self::Api>> {
-        self.call_value().all_esdt_transfers()
+        self.call_value().all_esdt_transfers().clone_value()
     }
 
     #[payable("*")]

--- a/contracts/feature-tests/rust-testing-framework-tester/src/lib.rs
+++ b/contracts/feature-tests/rust-testing-framework-tester/src/lib.rs
@@ -55,14 +55,14 @@ pub trait RustTestingFrameworkTester: dummy_module::DummyModule {
     #[payable("EGLD")]
     #[endpoint]
     fn receive_egld(&self) -> BigUint {
-        self.call_value().egld_value()
+        self.call_value().egld_value().clone_value()
     }
 
     #[payable("EGLD")]
     #[endpoint]
     fn recieve_egld_half(&self) {
         let caller = self.blockchain().get_caller();
-        let payment_amount = self.call_value().egld_value() / 2u32;
+        let payment_amount = &*self.call_value().egld_value() / 2u32;
         self.send().direct(
             &caller,
             &EgldOrEsdtTokenIdentifier::egld(),

--- a/contracts/feature-tests/rust-testing-framework-tester/tests/rust_mandos_v1_test.rs
+++ b/contracts/feature-tests/rust-testing-framework-tester/tests/rust_mandos_v1_test.rs
@@ -1416,20 +1416,7 @@ fn test_back_and_forth_transfers() {
 
     wrapper
         .execute_esdt_multi_transfer(&user, &forwarder_wrapper, &transfers, |sc| {
-            let mut managed_payments = ManagedVec::new();
-            managed_payments.push(EsdtTokenPayment::new(
-                managed_token_id!(&first_token_id[..]),
-                0,
-                managed_biguint!(first_token_amount.to_u64().unwrap()),
-            ));
-            managed_payments.push(EsdtTokenPayment::new(
-                managed_token_id!(&second_token_id[..]),
-                0,
-                managed_biguint!(second_token_amount.to_u64().unwrap()),
-            ));
-
             sc.forward_sync_retrieve_funds_with_accept_func(
-                managed_payments,
                 managed_address!(vault_wrapper.address_ref()),
                 managed_token_id!(&third_token_id[..]),
                 managed_biguint!(third_token_amount.to_u64().unwrap()),

--- a/contracts/feature-tests/use-module/src/token_merge_mod_impl.rs
+++ b/contracts/feature-tests/use-module/src/token_merge_mod_impl.rs
@@ -28,7 +28,7 @@ pub trait TokenMergeModImpl:
     fn merge_tokens_endpoint(&self) -> EsdtTokenPayment {
         let payments = self.call_value().all_esdt_transfers();
         let attributes_creator = DefaultMergedAttributesWrapper::new();
-        self.merge_tokens(payments, &attributes_creator)
+        self.merge_tokens(&*payments, &attributes_creator)
     }
 
     #[payable("*")]
@@ -36,14 +36,14 @@ pub trait TokenMergeModImpl:
     fn merge_tokens_custom_attributes_endpoint(&self) -> EsdtTokenPayment {
         let payments = self.call_value().all_esdt_transfers();
         let attributes_creator = CustomMergedAttributesWrapper::new();
-        self.merge_tokens(payments, &attributes_creator)
+        self.merge_tokens(&*payments, &attributes_creator)
     }
 
     #[payable("*")]
     #[endpoint(splitTokens)]
     fn split_tokens_endpoint(&self) -> ManagedVec<EsdtTokenPayment> {
         let payments = self.call_value().all_esdt_transfers();
-        self.split_tokens(payments)
+        self.split_tokens(&*payments)
     }
 
     #[payable("*")]

--- a/contracts/modules/src/default_issue_callbacks.rs
+++ b/contracts/modules/src/default_issue_callbacks.rs
@@ -44,7 +44,7 @@ pub trait DefaultIssueCallbacksModule {
 
     fn return_failed_issue_funds(&self, initial_caller: ManagedAddress) {
         let egld_returned = self.call_value().egld_value();
-        if egld_returned > 0u32 {
+        if *egld_returned > 0u32 {
             self.send().direct_egld(&initial_caller, &egld_returned);
         }
     }

--- a/contracts/modules/src/dns.rs
+++ b/contracts/modules/src/dns.rs
@@ -25,7 +25,7 @@ pub trait DnsModule {
     #[only_owner]
     #[endpoint(dnsRegister)]
     fn dns_register(&self, dns_address: ManagedAddress, name: ManagedBuffer) {
-        let payment = self.call_value().egld_value();
+        let payment = self.call_value().egld_value().clone_value();
         self.dns_proxy(dns_address)
             .register(&name)
             .with_egld_transfer(payment)

--- a/contracts/modules/src/esdt.rs
+++ b/contracts/modules/src/esdt.rs
@@ -34,7 +34,7 @@ pub trait EsdtModule {
     ) {
         require!(self.token_id().is_empty(), "Token already issued");
 
-        let issue_cost = self.call_value().egld_value();
+        let issue_cost = self.call_value().egld_value().clone_value();
         let num_decimals = match opt_num_decimals {
             OptionalValue::Some(d) => d,
             OptionalValue::None => 0,
@@ -64,7 +64,7 @@ pub trait EsdtModule {
                 // return payment to initial caller
                 let initial_caller = self.blockchain().get_owner_address();
                 let egld_returned = self.call_value().egld_value();
-                if egld_returned > 0u32 {
+                if *egld_returned > 0u32 {
                     self.send().direct_egld(&initial_caller, &egld_returned);
                 }
             },

--- a/contracts/modules/src/token_merge/merged_token_setup.rs
+++ b/contracts/modules/src/token_merge/merged_token_setup.rs
@@ -17,7 +17,7 @@ pub trait MergedTokenSetupModule {
         let payment_amount = self.call_value().egld_value();
         self.merged_token().issue_and_set_all_roles(
             EsdtTokenType::NonFungible,
-            payment_amount,
+            payment_amount.clone_value(),
             token_display_name,
             token_ticker,
             0,

--- a/contracts/modules/src/token_merge/mod.rs
+++ b/contracts/modules/src/token_merge/mod.rs
@@ -21,7 +21,7 @@ pub trait TokenMergeModule:
 {
     fn merge_tokens<AttributesCreator: MergedTokenAttributesCreator<ScType = Self>>(
         &self,
-        payments: ManagedVec<EsdtTokenPayment>,
+        payments: &ManagedVec<EsdtTokenPayment>,
         attr_creator: &AttributesCreator,
     ) -> EsdtTokenPayment {
         self.require_not_paused();
@@ -36,7 +36,7 @@ pub trait TokenMergeModule:
 
         let mut already_merged_tokens = ArrayVec::<_, MAX_MERGED_TOKENS>::new();
         let mut single_tokens = ArrayVec::<_, MAX_MERGED_TOKENS>::new();
-        for token in &payments {
+        for token in payments {
             if token.token_identifier == merged_token_id {
                 let token_data = self.blockchain().get_esdt_token_data(
                     &sc_address,
@@ -81,7 +81,10 @@ pub trait TokenMergeModule:
         merged_token_payment
     }
 
-    fn split_tokens(&self, payments: ManagedVec<EsdtTokenPayment>) -> ManagedVec<EsdtTokenPayment> {
+    fn split_tokens(
+        &self,
+        payments: &ManagedVec<EsdtTokenPayment>,
+    ) -> ManagedVec<EsdtTokenPayment> {
         self.require_not_paused();
         require!(!payments.is_empty(), "No payments");
 
@@ -89,7 +92,7 @@ pub trait TokenMergeModule:
         let sc_address = self.blockchain().get_sc_address();
 
         let mut output_payments = ManagedVec::new();
-        for token in &payments {
+        for token in payments {
             require!(
                 token.token_identifier == merged_token_id,
                 "Invalid token to split"

--- a/framework/base/src/contract_base/wrappers/call_value_wrapper.rs
+++ b/framework/base/src/contract_base/wrappers/call_value_wrapper.rs
@@ -45,14 +45,14 @@ where
     /// Returns all ESDT transfers that accompany this SC call.
     /// Will return 0 results if nothing was transfered, or just EGLD.
     /// Fully managed underlying types, very efficient.
-    pub fn all_esdt_transfers(&self) -> ManagedVec<A, EsdtTokenPayment<A>> {
+    pub fn all_esdt_transfers(&self) -> ManagedRef<'static, A, ManagedVec<A, EsdtTokenPayment<A>>> {
         let mut call_value_handle = A::static_var_api_impl().get_call_value_multi_esdt_handle();
         if call_value_handle == const_handles::UNINITIALIZED_HANDLE {
             call_value_handle = use_raw_handle(const_handles::CALL_VALUE_MULTI_ESDT);
             A::static_var_api_impl().set_call_value_multi_esdt_handle(call_value_handle.clone());
             A::call_value_api_impl().load_all_esdt_transfers(call_value_handle.clone());
         }
-        ManagedVec::from_handle(call_value_handle) // unsafe, TODO: replace with ManagedRef<...>
+        unsafe { ManagedRef::wrap_handle(call_value_handle) }
     }
 
     /// Verify and casts the received multi ESDT transfer in to an array.

--- a/framework/base/src/contract_base/wrappers/call_value_wrapper.rs
+++ b/framework/base/src/contract_base/wrappers/call_value_wrapper.rs
@@ -91,15 +91,6 @@ where
         (payment.token_identifier, payment.amount)
     }
 
-    /// Retrieves the ESDT call value from the VM.
-    /// Will return 0 in case of an EGLD transfer (cannot have both EGLD and ESDT transfer simultaneously).
-    pub fn esdt_value(&self) -> BigUint<A> {
-        let call_value_single_esdt: A::BigIntHandle =
-            use_raw_handle(const_handles::CALL_VALUE_SINGLE_ESDT);
-        A::call_value_api_impl().load_single_esdt_value(call_value_single_esdt.clone());
-        BigUint::from_handle(call_value_single_esdt)
-    }
-
     /// Accepts and returns either an EGLD payment, or a single ESDT token.
     ///
     /// Will halt execution if more than one ESDT transfer was received.

--- a/framework/base/src/contract_base/wrappers/call_value_wrapper.rs
+++ b/framework/base/src/contract_base/wrappers/call_value_wrapper.rs
@@ -8,7 +8,7 @@ use crate::{
     err_msg,
     types::{
         BigUint, EgldOrEsdtTokenIdentifier, EgldOrEsdtTokenPayment, EsdtTokenPayment, ManagedRef,
-        ManagedType, ManagedVec, TokenIdentifier,
+        ManagedVec, TokenIdentifier,
     },
 };
 

--- a/framework/base/src/contract_base/wrappers/call_value_wrapper.rs
+++ b/framework/base/src/contract_base/wrappers/call_value_wrapper.rs
@@ -7,8 +7,8 @@ use crate::{
     },
     err_msg,
     types::{
-        BigUint, EgldOrEsdtTokenIdentifier, EgldOrEsdtTokenPayment, EsdtTokenPayment, ManagedType,
-        ManagedVec, TokenIdentifier,
+        BigUint, EgldOrEsdtTokenIdentifier, EgldOrEsdtTokenPayment, EsdtTokenPayment, ManagedRef,
+        ManagedType, ManagedVec, TokenIdentifier,
     },
 };
 
@@ -32,14 +32,14 @@ where
 
     /// Retrieves the EGLD call value from the VM.
     /// Will return 0 in case of an ESDT transfer (cannot have both EGLD and ESDT transfer simultaneously).
-    pub fn egld_value(&self) -> BigUint<A> {
+    pub fn egld_value(&self) -> ManagedRef<'static, A, BigUint<A>> {
         let mut call_value_handle = A::static_var_api_impl().get_call_value_egld_handle();
         if call_value_handle == const_handles::UNINITIALIZED_HANDLE {
             call_value_handle = use_raw_handle(const_handles::CALL_VALUE_EGLD);
             A::static_var_api_impl().set_call_value_egld_handle(call_value_handle.clone());
             A::call_value_api_impl().load_egld_value(call_value_handle.clone());
         }
-        BigUint::from_handle(call_value_handle) // unsafe, TODO: replace with ManagedRef<...>
+        unsafe { ManagedRef::wrap_handle(call_value_handle) }
     }
 
     /// Returns all ESDT transfers that accompany this SC call.
@@ -111,7 +111,7 @@ where
             0 => EgldOrEsdtTokenPayment {
                 token_identifier: EgldOrEsdtTokenIdentifier::egld(),
                 token_nonce: 0,
-                amount: self.egld_value(),
+                amount: self.egld_value().clone_value(),
             },
             1 => esdt_transfers.get(0).into(),
             _ => A::error_api_impl().signal_error(err_msg::INCORRECT_NUM_ESDT_TRANSFERS.as_bytes()),

--- a/framework/base/src/io/call_value_init.rs
+++ b/framework/base/src/io/call_value_init.rs
@@ -5,7 +5,9 @@ use crate::{
     },
     contract_base::CallValueWrapper,
     err_msg,
-    types::{BigUint, EgldOrEsdtTokenIdentifier, EsdtTokenPayment, ManagedType, ManagedVec},
+    types::{
+        BigUint, EgldOrEsdtTokenIdentifier, EsdtTokenPayment, ManagedRef, ManagedType, ManagedVec,
+    },
 };
 
 /// Called initially in the generated code whenever no payable annotation is provided.
@@ -88,7 +90,7 @@ where
 }
 
 /// Initializes an argument annotated with `#[payment_multi]`.
-pub fn arg_payment_multi<A>() -> ManagedVec<A, EsdtTokenPayment<A>>
+pub fn arg_payment_multi<A>() -> ManagedRef<'static, A, ManagedVec<A, EsdtTokenPayment<A>>>
 where
     A: CallValueApi + ManagedTypeApi,
 {

--- a/framework/base/src/types/managed/wrapped/managed_ref.rs
+++ b/framework/base/src/types/managed/wrapped/managed_ref.rs
@@ -49,6 +49,16 @@ where
     }
 }
 
+impl<'a, M, T> ManagedRef<'a, M, T>
+where
+    M: ManagedTypeApi,
+    T: ManagedType<M> + Clone,
+{
+    pub fn clone_value(&self) -> T {
+        self.deref().clone()
+    }
+}
+
 impl<'a, M, T> Clone for ManagedRef<'a, M, T>
 where
     M: ManagedTypeApi,


### PR DESCRIPTION
An old forgotten TODO is causing people from the community to experience bugs.

The egld and multi-ESDT call values are cached, but we offer a writable reference, which can in some cases ruin the cache. Makine them `ManagedRef`s makes them readonly