### PR TITLE
allocator syntax changes for rustc 1.71.0

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   contracts:
     name: Contracts
-    uses: multiversx/mx-sc-actions/.github/workflows/contracts.yml@v2
+    uses: multiversx/mx-sc-actions/.github/workflows/contracts.yml@5e81211c4a5bdd5117d96b85821b0d1292b6e33b
     with:
       rust-toolchain: nightly-2023-04-24
       vmtools-version: v1.4.60

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   contracts:
     name: Contracts
-    uses: multiversx/mx-sc-actions/.github/workflows/contracts.yml@dc40bf9e693fa6e0a0b0f8d5b50506de34646a66
+    uses: multiversx/mx-sc-actions/.github/workflows/contracts.yml@8c34b6a8184c0adc1c46a8d61af2c1d3e61e4527
     with:
       rust-toolchain: nightly-2023-04-24
       vmtools-version: v1.4.60

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   contracts:
     name: Contracts
-    uses: multiversx/mx-sc-actions/.github/workflows/contracts.yml@5e81211c4a5bdd5117d96b85821b0d1292b6e33b
+    uses: multiversx/mx-sc-actions/.github/workflows/contracts.yml@52443c50f5bc2de4fdd321c0bb87102260868755
     with:
       rust-toolchain: nightly-2023-04-24
       vmtools-version: v1.4.60

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -15,7 +15,7 @@ jobs:
     name: Contracts
     uses: multiversx/mx-sc-actions/.github/workflows/contracts.yml@v2
     with:
-      rust-toolchain: nightly-2022-12-08
+      rust-toolchain: nightly-2023-04-24
       vmtools-version: v1.4.60
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   contracts:
     name: Contracts
-    uses: multiversx/mx-sc-actions/.github/workflows/contracts.yml@52443c50f5bc2de4fdd321c0bb87102260868755
+    uses: multiversx/mx-sc-actions/.github/workflows/contracts.yml@dc40bf9e693fa6e0a0b0f8d5b50506de34646a66
     with:
       rust-toolchain: nightly-2023-04-24
       vmtools-version: v1.4.60

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   contracts:
     name: Contracts
-    uses: multiversx/mx-sc-actions/.github/workflows/contracts.yml@8c34b6a8184c0adc1c46a8d61af2c1d3e61e4527
+    uses: multiversx/mx-sc-actions/.github/workflows/contracts.yml@v2.3
     with:
       rust-toolchain: nightly-2023-04-24
       vmtools-version: v1.4.60

--- a/contracts/benchmarks/mappers/linked-list-repeat/wasm/src/lib.rs
+++ b/contracts/benchmarks/mappers/linked-list-repeat/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:  10
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/benchmarks/mappers/map-repeat/wasm/src/lib.rs
+++ b/contracts/benchmarks/mappers/map-repeat/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:   8
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/benchmarks/mappers/queue-repeat/wasm/src/lib.rs
+++ b/contracts/benchmarks/mappers/queue-repeat/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:  10
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/benchmarks/mappers/set-repeat/wasm/src/lib.rs
+++ b/contracts/benchmarks/mappers/set-repeat/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:  10
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/benchmarks/mappers/single-value-repeat/wasm/src/lib.rs
+++ b/contracts/benchmarks/mappers/single-value-repeat/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:   8
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/benchmarks/mappers/vec-repeat/wasm/src/lib.rs
+++ b/contracts/benchmarks/mappers/vec-repeat/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:  10
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/benchmarks/send-tx-repeat/wasm/src/lib.rs
+++ b/contracts/benchmarks/send-tx-repeat/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:   3
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/benchmarks/str-repeat/wasm/src/lib.rs
+++ b/contracts/benchmarks/str-repeat/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:   5
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/core/price-aggregator/wasm/src/lib.rs
+++ b/contracts/core/price-aggregator/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:  21
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/core/wegld-swap/wasm/src/lib.rs
+++ b/contracts/core/wegld-swap/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:   9
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/examples/adder/wasm/src/lib.rs
+++ b/contracts/examples/adder/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:   4
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/examples/bonding-curve-contract/wasm/src/lib.rs
+++ b/contracts/examples/bonding-curve-contract/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:  12
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/examples/crowdfunding-esdt/wasm/src/lib.rs
+++ b/contracts/examples/crowdfunding-esdt/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:  10
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/examples/crypto-bubbles/wasm/src/lib.rs
+++ b/contracts/examples/crypto-bubbles/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:   8
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/examples/crypto-kitties/kitty-auction/wasm/src/lib.rs
+++ b/contracts/examples/crypto-kitties/kitty-auction/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:  11
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/examples/crypto-kitties/kitty-genetic-alg/wasm/src/lib.rs
+++ b/contracts/examples/crypto-kitties/kitty-genetic-alg/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:   3
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/examples/crypto-kitties/kitty-ownership/wasm/src/lib.rs
+++ b/contracts/examples/crypto-kitties/kitty-ownership/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:  23
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/examples/crypto-zombies/wasm/src/lib.rs
+++ b/contracts/examples/crypto-zombies/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:  19
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/examples/digital-cash/wasm/src/lib.rs
+++ b/contracts/examples/digital-cash/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:   8
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/examples/empty/wasm/src/lib.rs
+++ b/contracts/examples/empty/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:   2
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/examples/esdt-transfer-with-fee/wasm/src/lib.rs
+++ b/contracts/examples/esdt-transfer-with-fee/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:   8
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/examples/factorial/wasm/src/lib.rs
+++ b/contracts/examples/factorial/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:   3
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/examples/fractional-nfts/wasm/src/lib.rs
+++ b/contracts/examples/fractional-nfts/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:   6
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/examples/lottery-esdt/wasm/src/lib.rs
+++ b/contracts/examples/lottery-esdt/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:   9
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/examples/multisig/wasm-multisig-full/src/lib.rs
+++ b/contracts/examples/multisig/wasm-multisig-full/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:  30
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/examples/multisig/wasm-multisig-view/src/lib.rs
+++ b/contracts/examples/multisig/wasm-multisig-view/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:  10
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/examples/multisig/wasm/src/lib.rs
+++ b/contracts/examples/multisig/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:  22
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/examples/nft-minter/wasm/src/lib.rs
+++ b/contracts/examples/nft-minter/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:   8
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/examples/nft-storage-prepay/wasm/src/lib.rs
+++ b/contracts/examples/nft-storage-prepay/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:  10
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/examples/order-book/factory/wasm/src/lib.rs
+++ b/contracts/examples/order-book/factory/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:   4
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/examples/order-book/pair/wasm/src/lib.rs
+++ b/contracts/examples/order-book/pair/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:  15
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/examples/ping-pong-egld/wasm/src/lib.rs
+++ b/contracts/examples/ping-pong-egld/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:  12
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/examples/proxy-pause/wasm/src/lib.rs
+++ b/contracts/examples/proxy-pause/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:  10
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/examples/rewards-distribution/wasm/src/lib.rs
+++ b/contracts/examples/rewards-distribution/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:  15
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/examples/seed-nft-minter/wasm/src/lib.rs
+++ b/contracts/examples/seed-nft-minter/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:  11
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/examples/token-release/wasm/src/lib.rs
+++ b/contracts/examples/token-release/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:  15
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/abi-tester/wasm-abi-tester-ev/src/lib.rs
+++ b/contracts/feature-tests/abi-tester/wasm-abi-tester-ev/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:   5
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/abi-tester/wasm/src/lib.rs
+++ b/contracts/feature-tests/abi-tester/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:  29
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/alloc-features/wasm/src/lib.rs
+++ b/contracts/feature-tests/alloc-features/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:  76
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/basic-features/wasm/src/lib.rs
+++ b/contracts/feature-tests/basic-features/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions: 342
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/big-float-features/wasm/src/lib.rs
+++ b/contracts/feature-tests/big-float-features/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:  72
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/composability/esdt-contract-pair/first-contract/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/esdt-contract-pair/first-contract/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:   9
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/composability/esdt-contract-pair/second-contract/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/esdt-contract-pair/second-contract/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:   5
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/child/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/child/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:   4
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/parent/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/parent/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:   6
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/composability/forwarder-raw/wasm-no-managed-ei/src/lib.rs
+++ b/contracts/feature-tests/composability/forwarder-raw/wasm-no-managed-ei/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:  27
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/composability/forwarder-raw/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/forwarder-raw/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:  27
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/composability/forwarder/wasm-no-managed-ei/src/lib.rs
+++ b/contracts/feature-tests/composability/forwarder/wasm-no-managed-ei/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:  71
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/composability/forwarder/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/forwarder/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:  71
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/composability/local-esdt-and-nft/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/local-esdt-and-nft/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:  20
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/composability/promises-features/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/promises-features/wasm/src/lib.rs
@@ -11,7 +11,7 @@
 // Total number of exported functions:  11
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/composability/proxy-test-first/wasm-no-managed-ei/src/lib.rs
+++ b/contracts/feature-tests/composability/proxy-test-first/wasm-no-managed-ei/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:   8
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/composability/proxy-test-first/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/proxy-test-first/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:   8
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/composability/proxy-test-second/wasm-no-managed-ei/src/lib.rs
+++ b/contracts/feature-tests/composability/proxy-test-second/wasm-no-managed-ei/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:   5
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/composability/proxy-test-second/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/proxy-test-second/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:   5
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/composability/recursive-caller/wasm-no-managed-ei/src/lib.rs
+++ b/contracts/feature-tests/composability/recursive-caller/wasm-no-managed-ei/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:   3
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/composability/recursive-caller/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/recursive-caller/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:   3
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/composability/transfer-role-features/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/transfer-role-features/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:   3
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/composability/vault/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/vault/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:  15
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/erc-style-contracts/crowdfunding-erc20/wasm/src/lib.rs
+++ b/contracts/feature-tests/erc-style-contracts/crowdfunding-erc20/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:  10
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/erc-style-contracts/erc1155-marketplace/wasm/src/lib.rs
+++ b/contracts/feature-tests/erc-style-contracts/erc1155-marketplace/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:  14
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/erc-style-contracts/erc1155-user-mock/wasm/src/lib.rs
+++ b/contracts/feature-tests/erc-style-contracts/erc1155-user-mock/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:   4
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/erc-style-contracts/erc1155/wasm/src/lib.rs
+++ b/contracts/feature-tests/erc-style-contracts/erc1155/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:  15
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/erc-style-contracts/erc20/wasm/src/lib.rs
+++ b/contracts/feature-tests/erc-style-contracts/erc20/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:   8
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/erc-style-contracts/erc721/wasm/src/lib.rs
+++ b/contracts/feature-tests/erc-style-contracts/erc721/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:  10
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/erc-style-contracts/lottery-erc20/wasm/src/lib.rs
+++ b/contracts/feature-tests/erc-style-contracts/lottery-erc20/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:   9
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/esdt-system-sc-mock/wasm/src/lib.rs
+++ b/contracts/feature-tests/esdt-system-sc-mock/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:   8
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/formatted-message-features/wasm/src/lib.rs
+++ b/contracts/feature-tests/formatted-message-features/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:  17
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/legacy-examples/crypto-bubbles-legacy/wasm/src/lib.rs
+++ b/contracts/feature-tests/legacy-examples/crypto-bubbles-legacy/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:   8
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/multi-contract-features/wasm-multi-contract-example-feature/src/lib.rs
+++ b/contracts/feature-tests/multi-contract-features/wasm-multi-contract-example-feature/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:   4
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/multi-contract-features/wasm-multi-contract-features-view/src/lib.rs
+++ b/contracts/feature-tests/multi-contract-features/wasm-multi-contract-features-view/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:   5
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/multi-contract-features/wasm/src/lib.rs
+++ b/contracts/feature-tests/multi-contract-features/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:   4
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/panic-message-features/wasm/src/lib.rs
+++ b/contracts/feature-tests/panic-message-features/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:   3
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler_with_message!();

--- a/contracts/feature-tests/payable-features/wasm/src/lib.rs
+++ b/contracts/feature-tests/payable-features/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:  17
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/rust-snippets-generator-test/wasm/src/lib.rs
+++ b/contracts/feature-tests/rust-snippets-generator-test/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:  18
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/rust-testing-framework-tester/wasm/src/lib.rs
+++ b/contracts/feature-tests/rust-testing-framework-tester/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:  28
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/use-module/wasm-use-module-view/src/lib.rs
+++ b/contracts/feature-tests/use-module/wasm-use-module-view/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:   4
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/contracts/feature-tests/use-module/wasm/src/lib.rs
+++ b/contracts/feature-tests/use-module/wasm/src/lib.rs
@@ -10,7 +10,7 @@
 // Total number of exported functions:  64
 
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 multiversx_sc_wasm_adapter::panic_handler!();

--- a/framework/meta/src/output_contract/wasm_crate_gen.rs
+++ b/framework/meta/src/output_contract/wasm_crate_gen.rs
@@ -20,7 +20,7 @@ const NUM_ASYNC_CB: usize = 1;
 
 const PREFIX_NO_STD: &str = "
 #![no_std]
-#![feature(alloc_error_handler, lang_items)]
+#![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
 ";

--- a/framework/wasm-adapter/src/wasm_deps.rs
+++ b/framework/wasm-adapter/src/wasm_deps.rs
@@ -2,10 +2,6 @@ pub use alloc::alloc::Layout;
 pub use core::panic::PanicInfo;
 pub use wee_alloc::WeeAlloc;
 
-pub fn alloc_error_handler(_layout: Layout) -> ! {
-    crate::error_hook::signal_error(&b"allocation error"[..])
-}
-
 pub fn panic_fmt(_: &PanicInfo) -> ! {
     crate::error_hook::signal_error(multiversx_sc::err_msg::PANIC_OCCURRED.as_bytes())
 }

--- a/framework/wasm-adapter/src/wasm_macros.rs
+++ b/framework/wasm-adapter/src/wasm_macros.rs
@@ -10,11 +10,6 @@ macro_rules! allocator {
 #[macro_export]
 macro_rules! panic_handler {
     () => {
-        #[alloc_error_handler]
-        fn alloc_error_handler(layout: multiversx_sc_wasm_adapter::wasm_deps::Layout) -> ! {
-            multiversx_sc_wasm_adapter::wasm_deps::alloc_error_handler(layout)
-        }
-
         #[panic_handler]
         fn panic_fmt(panic_info: &multiversx_sc_wasm_adapter::wasm_deps::PanicInfo) -> ! {
             multiversx_sc_wasm_adapter::wasm_deps::panic_fmt(panic_info)
@@ -28,11 +23,6 @@ macro_rules! panic_handler {
 #[macro_export]
 macro_rules! panic_handler_with_message {
     () => {
-        #[alloc_error_handler]
-        fn alloc_error_handler(layout: multiversx_sc_wasm_adapter::wasm_deps::Layout) -> ! {
-            multiversx_sc_wasm_adapter::wasm_deps::alloc_error_handler(layout)
-        }
-
         #[panic_handler]
         fn panic_fmt(panic_info: &multiversx_sc_wasm_adapter::wasm_deps::PanicInfo) -> ! {
             multiversx_sc_wasm_adapter::wasm_deps::panic_fmt_with_message(panic_info)


### PR DESCRIPTION
Minor changes required so that SC wasm crates compile under the new rustc 1.71.0.