### PR TITLE
Allocator selector in multicontract.toml

### DIFF
--- a/contracts/benchmarks/str-repeat/multicontract.toml
+++ b/contracts/benchmarks/str-repeat/multicontract.toml
@@ -1,0 +1,7 @@
+[settings]
+main = "str-repeat"
+
+# the only purpose of this config is to specify the allocator
+[contracts.str-repeat]
+add-unlabelled = true
+allocator = "wee_alloc"

--- a/contracts/benchmarks/str-repeat/wasm/src/lib.rs
+++ b/contracts/benchmarks/str-repeat/wasm/src/lib.rs
@@ -12,7 +12,7 @@
 #![no_std]
 #![feature(lang_items)]
 
-multiversx_sc_wasm_adapter::allocator!();
+multiversx_sc_wasm_adapter::allocator!(wee_alloc);
 multiversx_sc_wasm_adapter::panic_handler!();
 
 multiversx_sc_wasm_adapter::endpoints! {

--- a/contracts/feature-tests/alloc-features/multicontract.toml
+++ b/contracts/feature-tests/alloc-features/multicontract.toml
@@ -1,0 +1,7 @@
+[settings]
+main = "alloc-features"
+
+# the only purpose of this config is to specify the allocator
+[contracts.alloc-features]
+add-unlabelled = true
+allocator = "wee_alloc"

--- a/contracts/feature-tests/alloc-features/wasm/src/lib.rs
+++ b/contracts/feature-tests/alloc-features/wasm/src/lib.rs
@@ -12,7 +12,7 @@
 #![no_std]
 #![feature(lang_items)]
 
-multiversx_sc_wasm_adapter::allocator!();
+multiversx_sc_wasm_adapter::allocator!(wee_alloc);
 multiversx_sc_wasm_adapter::panic_handler!();
 
 multiversx_sc_wasm_adapter::endpoints! {

--- a/contracts/feature-tests/composability/proxy-test-first/multicontract.toml
+++ b/contracts/feature-tests/composability/proxy-test-first/multicontract.toml
@@ -1,0 +1,7 @@
+[settings]
+main = "proxy-test-first"
+
+# the only purpose of this config is to specify the allocator
+[contracts.proxy-test-first]
+add-unlabelled = true
+allocator = "wee_alloc"

--- a/contracts/feature-tests/composability/proxy-test-first/wasm-no-managed-ei/src/lib.rs
+++ b/contracts/feature-tests/composability/proxy-test-first/wasm-no-managed-ei/src/lib.rs
@@ -12,7 +12,7 @@
 #![no_std]
 #![feature(lang_items)]
 
-multiversx_sc_wasm_adapter::allocator!();
+multiversx_sc_wasm_adapter::allocator!(wee_alloc);
 multiversx_sc_wasm_adapter::panic_handler!();
 
 multiversx_sc_wasm_adapter::endpoints! {

--- a/contracts/feature-tests/composability/proxy-test-first/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/proxy-test-first/wasm/src/lib.rs
@@ -12,7 +12,7 @@
 #![no_std]
 #![feature(lang_items)]
 
-multiversx_sc_wasm_adapter::allocator!();
+multiversx_sc_wasm_adapter::allocator!(wee_alloc);
 multiversx_sc_wasm_adapter::panic_handler!();
 
 multiversx_sc_wasm_adapter::endpoints! {

--- a/contracts/feature-tests/composability/proxy-test-second/multicontract.toml
+++ b/contracts/feature-tests/composability/proxy-test-second/multicontract.toml
@@ -1,0 +1,7 @@
+[settings]
+main = "proxy-test-second"
+
+# the only purpose of this config is to specify the allocator
+[contracts.proxy-test-second]
+add-unlabelled = true
+allocator = "wee_alloc"

--- a/contracts/feature-tests/composability/proxy-test-second/wasm-no-managed-ei/src/lib.rs
+++ b/contracts/feature-tests/composability/proxy-test-second/wasm-no-managed-ei/src/lib.rs
@@ -12,7 +12,7 @@
 #![no_std]
 #![feature(lang_items)]
 
-multiversx_sc_wasm_adapter::allocator!();
+multiversx_sc_wasm_adapter::allocator!(wee_alloc);
 multiversx_sc_wasm_adapter::panic_handler!();
 
 multiversx_sc_wasm_adapter::endpoints! {

--- a/contracts/feature-tests/composability/proxy-test-second/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/proxy-test-second/wasm/src/lib.rs
@@ -12,7 +12,7 @@
 #![no_std]
 #![feature(lang_items)]
 
-multiversx_sc_wasm_adapter::allocator!();
+multiversx_sc_wasm_adapter::allocator!(wee_alloc);
 multiversx_sc_wasm_adapter::panic_handler!();
 
 multiversx_sc_wasm_adapter::endpoints! {

--- a/contracts/feature-tests/erc-style-contracts/erc1155-marketplace/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/erc1155-marketplace/Cargo.toml
@@ -15,6 +15,7 @@ path = "../erc1155"
 [dependencies.multiversx-sc]
 version = "0.40.1"
 path = "../../../../framework/base"
+features = ["alloc"]
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.40.1"

--- a/contracts/feature-tests/erc-style-contracts/erc1155-marketplace/multicontract.toml
+++ b/contracts/feature-tests/erc-style-contracts/erc1155-marketplace/multicontract.toml
@@ -1,0 +1,7 @@
+[settings]
+main = "erc1155-marketplace"
+
+# the only purpose of this config is to specify the allocator
+[contracts.erc1155-marketplace]
+add-unlabelled = true
+allocator = "wee_alloc"

--- a/contracts/feature-tests/erc-style-contracts/erc1155-marketplace/wasm/src/lib.rs
+++ b/contracts/feature-tests/erc-style-contracts/erc1155-marketplace/wasm/src/lib.rs
@@ -12,7 +12,7 @@
 #![no_std]
 #![feature(lang_items)]
 
-multiversx_sc_wasm_adapter::allocator!();
+multiversx_sc_wasm_adapter::allocator!(wee_alloc);
 multiversx_sc_wasm_adapter::panic_handler!();
 
 multiversx_sc_wasm_adapter::endpoints! {

--- a/contracts/feature-tests/erc-style-contracts/erc1155/multicontract.toml
+++ b/contracts/feature-tests/erc-style-contracts/erc1155/multicontract.toml
@@ -1,0 +1,7 @@
+[settings]
+main = "erc1155"
+
+# the only purpose of this config is to specify the allocator
+[contracts.erc1155]
+add-unlabelled = true
+allocator = "wee_alloc"

--- a/contracts/feature-tests/erc-style-contracts/erc1155/wasm/src/lib.rs
+++ b/contracts/feature-tests/erc-style-contracts/erc1155/wasm/src/lib.rs
@@ -12,7 +12,7 @@
 #![no_std]
 #![feature(lang_items)]
 
-multiversx_sc_wasm_adapter::allocator!();
+multiversx_sc_wasm_adapter::allocator!(wee_alloc);
 multiversx_sc_wasm_adapter::panic_handler!();
 
 multiversx_sc_wasm_adapter::endpoints! {

--- a/contracts/feature-tests/erc-style-contracts/lottery-erc20/multicontract.toml
+++ b/contracts/feature-tests/erc-style-contracts/lottery-erc20/multicontract.toml
@@ -1,0 +1,7 @@
+[settings]
+main = "lottery-erc20"
+
+# the only purpose of this config is to specify the allocator
+[contracts.lottery-erc20]
+add-unlabelled = true
+allocator = "wee_alloc"

--- a/contracts/feature-tests/erc-style-contracts/lottery-erc20/wasm/src/lib.rs
+++ b/contracts/feature-tests/erc-style-contracts/lottery-erc20/wasm/src/lib.rs
@@ -12,7 +12,7 @@
 #![no_std]
 #![feature(lang_items)]
 
-multiversx_sc_wasm_adapter::allocator!();
+multiversx_sc_wasm_adapter::allocator!(wee_alloc);
 multiversx_sc_wasm_adapter::panic_handler!();
 
 multiversx_sc_wasm_adapter::endpoints! {

--- a/contracts/feature-tests/legacy-examples/crypto-bubbles-legacy/multicontract.toml
+++ b/contracts/feature-tests/legacy-examples/crypto-bubbles-legacy/multicontract.toml
@@ -1,0 +1,7 @@
+[settings]
+main = "crypto-bubbles-legacy"
+
+# the only purpose of this config is to specify the allocator
+[contracts.crypto-bubbles-legacy]
+add-unlabelled = true
+allocator = "wee_alloc"

--- a/contracts/feature-tests/legacy-examples/crypto-bubbles-legacy/wasm/src/lib.rs
+++ b/contracts/feature-tests/legacy-examples/crypto-bubbles-legacy/wasm/src/lib.rs
@@ -12,7 +12,7 @@
 #![no_std]
 #![feature(lang_items)]
 
-multiversx_sc_wasm_adapter::allocator!();
+multiversx_sc_wasm_adapter::allocator!(wee_alloc);
 multiversx_sc_wasm_adapter::panic_handler!();
 
 multiversx_sc_wasm_adapter::endpoints! {

--- a/contracts/feature-tests/panic-message-features/scenarios/panic-message.scen.json
+++ b/contracts/feature-tests/panic-message-features/scenarios/panic-message.scen.json
@@ -23,14 +23,16 @@
                 "from": "address:an_account",
                 "to": "sc:panic_features",
                 "function": "panicWithMessage",
-                "arguments": [],
+                "arguments": [
+                    "123"
+                ],
                 "gasLimit": "50,000,000",
                 "gasPrice": "0"
             },
             "expect": {
                 "out": [],
                 "status": "0x04",
-                "message": "str:panic occurred: example panic message",
+                "message": "str:panic occurred: example panic message 123",
                 "logs": "*",
                 "gas": "*",
                 "refund": "*"

--- a/contracts/feature-tests/panic-message-features/src/panic_features.rs
+++ b/contracts/feature-tests/panic-message-features/src/panic_features.rs
@@ -11,7 +11,7 @@ pub trait PanicMessageFeatures {
     fn init(&self) {}
 
     #[endpoint(panicWithMessage)]
-    fn panic_with_message(&self) {
-        panic!("example panic message");
+    fn panic_with_message(&self, some_value: u32) {
+        panic!("example panic message {some_value}");
     }
 }

--- a/contracts/feature-tests/rust-testing-framework-tester/multicontract.toml
+++ b/contracts/feature-tests/rust-testing-framework-tester/multicontract.toml
@@ -1,0 +1,7 @@
+[settings]
+main = "rust-testing-framework-tester"
+
+# the only purpose of this config is to specify the allocator
+[contracts.rust-testing-framework-tester]
+add-unlabelled = true
+allocator = "wee_alloc"

--- a/contracts/feature-tests/rust-testing-framework-tester/wasm/src/lib.rs
+++ b/contracts/feature-tests/rust-testing-framework-tester/wasm/src/lib.rs
@@ -12,7 +12,7 @@
 #![no_std]
 #![feature(lang_items)]
 
-multiversx_sc_wasm_adapter::allocator!();
+multiversx_sc_wasm_adapter::allocator!(wee_alloc);
 multiversx_sc_wasm_adapter::panic_handler!();
 
 multiversx_sc_wasm_adapter::endpoints! {

--- a/framework/base/src/types/managed/wrapped/managed_buffer_cached_builder.rs
+++ b/framework/base/src/types/managed/wrapped/managed_buffer_cached_builder.rs
@@ -64,7 +64,7 @@ where
     }
 
     fn flush_to_managed_buffer(&mut self) {
-        let old_static_cache = core::mem::replace(&mut self.static_cache, None);
+        let old_static_cache = core::mem::take(&mut self.static_cache);
         if let Some(static_cache) = &old_static_cache {
             static_cache.with_buffer_contents(|bytes| {
                 self.managed_buffer.append_bytes(bytes);
@@ -85,7 +85,7 @@ where
     }
 
     pub fn append_managed_buffer(&mut self, item: &ManagedBuffer<M>) {
-        let mut static_cache_mut = core::mem::replace(&mut self.static_cache, None);
+        let mut static_cache_mut = core::mem::take(&mut self.static_cache);
         if let Some(static_cache) = &mut static_cache_mut {
             let success = static_cache.try_extend_from_copy_bytes(item.len(), |dest_slice| {
                 let _ = item.load_slice(0, dest_slice);

--- a/framework/meta/src/output_contract/mod.rs
+++ b/framework/meta/src/output_contract/mod.rs
@@ -1,5 +1,6 @@
 pub mod ei;
 mod multi_contract_serde;
+mod output_contract_allocator;
 mod output_contract_builder;
 mod output_contract_model;
 mod print_util;
@@ -9,6 +10,7 @@ mod wasm_crate_gen;
 mod wasm_update;
 
 pub use multi_contract_serde::*;
+pub use output_contract_allocator::*;
 pub use output_contract_builder::*;
 pub use output_contract_model::*;
 pub use wasm_build::*;

--- a/framework/meta/src/output_contract/multi_contract_serde.rs
+++ b/framework/meta/src/output_contract/multi_contract_serde.rs
@@ -3,6 +3,8 @@ use std::collections::HashMap;
 
 use crate::ei::EIVersion;
 
+use super::ContractAllocator;
+
 #[derive(Deserialize, Debug)]
 pub struct MultiContractConfigSerde {
     #[serde(default)]
@@ -42,6 +44,9 @@ pub struct OutputContractSerde {
     pub ei: Option<String>,
 
     #[serde(default)]
+    pub allocator: Option<String>,
+
+    #[serde(default)]
     pub features: Vec<String>,
 }
 
@@ -62,4 +67,11 @@ pub fn parse_check_ei(ei: &Option<String>) -> Option<EIVersion> {
     } else {
         Some(EIVersion::default())
     }
+}
+
+pub fn parse_allocator(allocator: &Option<String>) -> ContractAllocator {
+    allocator
+        .as_ref()
+        .map(|s| ContractAllocator::parse_or_panic(s))
+        .unwrap_or_default()
 }

--- a/framework/meta/src/output_contract/output_contract_allocator.rs
+++ b/framework/meta/src/output_contract/output_contract_allocator.rs
@@ -1,0 +1,32 @@
+#[derive(Default, Clone, PartialEq, Eq)]
+pub enum ContractAllocator {
+    /// No allocation is allowed. Any attempt causes `signalError` to be thrown.
+    #[default]
+    AllocationForbidden,
+
+    /// Backwards compatibility, for now.
+    WeeAlloc,
+}
+
+impl ContractAllocator {
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "fail" => Some(ContractAllocator::AllocationForbidden),
+            "wee_alloc" => Some(ContractAllocator::WeeAlloc),
+            _ => None,
+        }
+    }
+
+    pub fn parse_or_panic(s: &str) -> Self {
+        Self::parse(s).unwrap_or_else(|| {
+            panic!("Unknown allocator option '{s}'. Valid options are: 'fail', 'wee_alloc'.")
+        })
+    }
+
+    pub fn to_allocator_macro_selector(&self) -> &'static str {
+        match self {
+            ContractAllocator::AllocationForbidden => "",
+            ContractAllocator::WeeAlloc => "wee_alloc",
+        }
+    }
+}

--- a/framework/meta/src/output_contract/output_contract_builder.rs
+++ b/framework/meta/src/output_contract/output_contract_builder.rs
@@ -6,8 +6,8 @@ use std::{
 };
 
 use super::{
-    parse_check_ei, MultiContractConfigSerde, OutputContract, OutputContractConfig,
-    OutputContractSerde, OutputContractSettings,
+    parse_allocator, parse_check_ei, MultiContractConfigSerde, OutputContract,
+    OutputContractConfig, OutputContractSerde, OutputContractSettings,
 };
 
 /// Temporary structure, to help create instances of `OutputContract`. Not publicly exposed.
@@ -55,6 +55,7 @@ impl OutputContractBuilder {
                     external_view: cms.external_view.unwrap_or_default(),
                     panic_message: cms.panic_message.unwrap_or_default(),
                     check_ei: parse_check_ei(&cms.ei),
+                    allocator: parse_allocator(&cms.allocator),
                     features: cms.features.clone(),
                 },
                 ..Default::default()

--- a/framework/meta/src/output_contract/output_contract_model.rs
+++ b/framework/meta/src/output_contract/output_contract_model.rs
@@ -2,6 +2,8 @@ use multiversx_sc::abi::ContractAbi;
 
 use crate::{cli_args::BuildArgs, ei::EIVersion};
 
+use super::ContractAllocator;
+
 pub const DEFAULT_LABEL: &str = "default";
 
 #[derive(Debug)]
@@ -78,6 +80,9 @@ pub struct OutputContractSettings {
     /// Post-processing check of the VM hooks is based on this.
     pub check_ei: Option<EIVersion>,
 
+    /// Allocator config, i.e which allocator to choose for the contract.
+    pub allocator: ContractAllocator,
+
     /// Features that are activated on the contract crate, from wasm.
     pub features: Vec<String>,
 }
@@ -88,6 +93,7 @@ impl Default for OutputContractSettings {
             external_view: Default::default(),
             panic_message: Default::default(),
             check_ei: Some(EIVersion::default()),
+            allocator: Default::default(),
             features: Default::default(),
         }
     }

--- a/framework/meta/src/output_contract/wasm_crate_gen.rs
+++ b/framework/meta/src/output_contract/wasm_crate_gen.rs
@@ -22,13 +22,19 @@ const PREFIX_NO_STD: &str = "
 #![no_std]
 #![feature(lang_items)]
 
-multiversx_sc_wasm_adapter::allocator!();
 ";
 
 impl OutputContract {
     /// Makes sure that all the necessary wasm crate directories exist.
     pub fn create_wasm_crate_dir(&self) {
         fs::create_dir_all(PathBuf::from(&self.wasm_crate_path()).join("src")).unwrap();
+    }
+
+    fn allocator_macro_invocation(&self) -> String {
+        format!(
+            "multiversx_sc_wasm_adapter::allocator!({});",
+            self.settings.allocator.to_allocator_macro_selector()
+        )
     }
 
     fn panic_handler_macro_invocation(&self) -> &'static str {
@@ -62,9 +68,8 @@ impl OutputContract {
         self.write_stat_comments(wasm_lib_file);
         wasm_lib_file.write_all(PREFIX_NO_STD.as_bytes()).unwrap();
 
-        wasm_lib_file
-            .write_all(self.panic_handler_macro_invocation().as_bytes())
-            .unwrap();
+        writeln!(wasm_lib_file, "{}", self.allocator_macro_invocation()).unwrap();
+        writeln!(wasm_lib_file, "{}", self.panic_handler_macro_invocation()).unwrap();
 
         let mut all_endpoint_names = explicit_endpoint_names;
         if self.abi.has_callback {
@@ -124,7 +129,7 @@ fn write_endpoints_macro<'a, I>(
 ) where
     I: Iterator<Item = &'a String>,
 {
-    writeln!(wasm_lib_file, "\n").unwrap();
+    writeln!(wasm_lib_file).unwrap();
     writeln!(wasm_lib_file, "{full_macro_name} {{").unwrap();
     writeln!(wasm_lib_file, "    {contract_module_name}").unwrap();
     writeln!(wasm_lib_file, "    (").unwrap();

--- a/framework/wasm-adapter/src/wasm_deps.rs
+++ b/framework/wasm-adapter/src/wasm_deps.rs
@@ -1,21 +1,11 @@
 mod fail_allocator;
+mod panic_fmt;
 
-pub use alloc::alloc::Layout;
-pub use core::panic::PanicInfo;
-pub use wee_alloc::WeeAlloc;
 pub use fail_allocator::FailAllocator;
+pub use panic_fmt::{panic_fmt, panic_fmt_with_message};
 
-pub fn panic_fmt(_: &PanicInfo) -> ! {
-    crate::error_hook::signal_error(multiversx_sc::err_msg::PANIC_OCCURRED.as_bytes())
-}
+/// Used in wasm crate macros.
+pub use core::panic::PanicInfo;
 
-pub fn panic_fmt_with_message(panic_info: &PanicInfo) -> ! {
-    use alloc::string::String;
-    let panic_msg = if let Some(s) = panic_info.message() {
-        alloc::format!("panic occurred: {s:?}")
-    } else {
-        String::from("unknown panic occurred")
-    };
-
-    crate::error_hook::signal_error(panic_msg.as_bytes())
-}
+/// TODO: remove.
+pub use wee_alloc::WeeAlloc;

--- a/framework/wasm-adapter/src/wasm_deps.rs
+++ b/framework/wasm-adapter/src/wasm_deps.rs
@@ -1,6 +1,9 @@
+mod fail_allocator;
+
 pub use alloc::alloc::Layout;
 pub use core::panic::PanicInfo;
 pub use wee_alloc::WeeAlloc;
+pub use fail_allocator::FailAllocator;
 
 pub fn panic_fmt(_: &PanicInfo) -> ! {
     crate::error_hook::signal_error(multiversx_sc::err_msg::PANIC_OCCURRED.as_bytes())

--- a/framework/wasm-adapter/src/wasm_deps/fail_allocator.rs
+++ b/framework/wasm-adapter/src/wasm_deps/fail_allocator.rs
@@ -1,0 +1,18 @@
+use core::alloc::{GlobalAlloc, Layout};
+
+fn signal_allocation_not_allowed() -> ! {
+    crate::error_hook::signal_error(&b"memory allocation forbidden"[..])
+}
+
+/// Allocator that fails (with signal error) whenever an allocation is attempted.
+pub struct FailAllocator;
+
+unsafe impl GlobalAlloc for FailAllocator {
+    unsafe fn alloc(&self, _layout: Layout) -> *mut u8 {
+        signal_allocation_not_allowed()
+    }
+
+    unsafe fn dealloc(&self, _ptr: *mut u8, _layout: Layout) {
+        signal_allocation_not_allowed()
+    }
+}

--- a/framework/wasm-adapter/src/wasm_deps/panic_fmt.rs
+++ b/framework/wasm-adapter/src/wasm_deps/panic_fmt.rs
@@ -1,0 +1,45 @@
+use crate::api::VmApiImpl;
+pub use alloc::alloc::Layout;
+pub use core::panic::PanicInfo;
+use multiversx_sc::{
+    api::{ErrorApi, ErrorApiImpl},
+    types::{ManagedBuffer, ManagedType},
+};
+
+/// Default panic handler for all contracts.
+pub fn panic_fmt(_: &PanicInfo) -> ! {
+    crate::error_hook::signal_error(multiversx_sc::err_msg::PANIC_OCCURRED.as_bytes())
+}
+
+/// Panic handler that formats and sends the original message.
+/// 
+/// Mostly used for debugging, the additional code is normally not deemed to be worth it.
+pub fn panic_fmt_with_message(panic_info: &PanicInfo) -> ! {
+    let mut panic_msg = ManagedPanicMessage::default();
+    if let Some(args) = panic_info.message() {
+        panic_msg.append_str("panic occurred: ");
+        let _ = core::fmt::write(&mut panic_msg, *args);
+    } else {
+        panic_msg.append_str("unknown panic occurred");
+    };
+
+    VmApiImpl::error_api_impl().signal_error_from_buffer(panic_msg.buffer.get_handle())
+}
+
+#[derive(Default)]
+struct ManagedPanicMessage {
+    buffer: ManagedBuffer<VmApiImpl>,
+}
+
+impl ManagedPanicMessage {
+    fn append_str(&mut self, s: &str) {
+        self.buffer.append_bytes(s.as_bytes());
+    }
+}
+
+impl core::fmt::Write for ManagedPanicMessage {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        self.append_str(s);
+        Ok(())
+    }
+}

--- a/framework/wasm-adapter/src/wasm_macros.rs
+++ b/framework/wasm-adapter/src/wasm_macros.rs
@@ -2,6 +2,11 @@
 macro_rules! allocator {
     () => {
         #[global_allocator]
+        static ALLOC: multiversx_sc_wasm_adapter::wasm_deps::FailAllocator =
+            multiversx_sc_wasm_adapter::wasm_deps::FailAllocator;
+    };
+    (wee_alloc) => {
+        #[global_allocator]
         static ALLOC: multiversx_sc_wasm_adapter::wasm_deps::WeeAlloc =
             multiversx_sc_wasm_adapter::wasm_deps::WeeAlloc::INIT;
     };


### PR DESCRIPTION
Each contract can choose for itself what allocator to use.

The default is one that crashes any time memory allocation is attempted.