### PR TITLE
count api calls and provide them in tx_results

### DIFF
--- a/framework/scenario/src/whitebox/contract_obj_wrapper.rs
+++ b/framework/scenario/src/whitebox/contract_obj_wrapper.rs
@@ -747,9 +747,10 @@ impl BlockchainStateWrapper {
         let exec_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| tx_fn(sc)));
 
         let api_after_exec = Rc::try_unwrap(TxContextStack::static_pop()).unwrap();
+        let api_calls = (*api_after_exec.api_calls.borrow()).clone();
         let updates = api_after_exec.into_blockchain_updates();
         let tx_result = match exec_result {
-            Ok(()) => TxResult::empty(),
+            Ok(()) => TxResult::with_api_calls(api_calls),
             Err(panic_any) => interpret_panic_as_tx_result(panic_any, false),
         };
 

--- a/vm/src/api/send_api_mock.rs
+++ b/vm/src/api/send_api_mock.rs
@@ -236,6 +236,7 @@ impl SendApiImpl for DebugApi {
             self.big_uint_handle_to_value(amount.get_handle().cast_or_signal_error::<M, _>());
         let recipient = to.to_address();
 
+        DebugApi::count_transfers(1);
         let _ = self.perform_transfer_execute(
             recipient,
             egld_value,
@@ -262,6 +263,7 @@ impl SendApiImpl for DebugApi {
         let mut args = vec![token_bytes, amount_bytes];
         Self::append_endpoint_name_and_args(&mut args, endpoint_name, arg_buffer);
 
+        DebugApi::count_transfers(1);
         let _ = self.perform_transfer_execute(
             recipient,
             num_bigint::BigUint::zero(),
@@ -298,6 +300,7 @@ impl SendApiImpl for DebugApi {
 
         Self::append_endpoint_name_and_args(&mut args, endpoint_name, arg_buffer);
 
+        DebugApi::count_transfers(1);
         let _ = self.perform_transfer_execute(
             contract_address,
             num_bigint::BigUint::zero(),
@@ -342,6 +345,7 @@ impl SendApiImpl for DebugApi {
             );
         }
 
+        DebugApi::count_transfers(payments.len());
         let _ = self.perform_transfer_execute(
             contract_address,
             num_bigint::BigUint::zero(),

--- a/vm/src/api/storage_api_mock.rs
+++ b/vm/src/api/storage_api_mock.rs
@@ -28,14 +28,17 @@ impl DebugApi {
 
 impl StorageReadApiImpl for DebugApi {
     fn storage_load_len(&self, key: &[u8]) -> usize {
+        DebugApi::count_trie_read();
         self.storage_load_vec_u8(key).len()
     }
 
     fn storage_load_to_heap(&self, key: &[u8]) -> Box<[u8]> {
+        DebugApi::count_trie_read();
         self.storage_load_vec_u8(key).into_boxed_slice()
     }
 
     fn storage_load_big_uint_raw(&self, key: &[u8], dest: Self::ManagedBufferHandle) {
+        DebugApi::count_trie_read();
         let bytes = self.storage_load_vec_u8(key);
         let bi = BigInt::from_bytes_be(Sign::Plus, bytes.as_slice());
         self.bi_overwrite(dest, bi);
@@ -46,6 +49,7 @@ impl StorageReadApiImpl for DebugApi {
         key_handle: Self::ManagedBufferHandle,
         dest: Self::ManagedBufferHandle,
     ) {
+        DebugApi::count_trie_read();
         let key_bytes = self.mb_to_boxed_bytes(key_handle);
         let bytes = self.storage_load_vec_u8(key_bytes.as_slice());
         self.mb_overwrite(dest, bytes.as_slice());
@@ -57,6 +61,7 @@ impl StorageReadApiImpl for DebugApi {
         key_handle: Self::ManagedBufferHandle,
         dest: Self::ManagedBufferHandle,
     ) {
+        DebugApi::count_trie_read();
         let address = multiversx_sc::types::heap::Address::from_slice(
             self.mb_to_boxed_bytes(address_handle).as_slice(),
         );

--- a/vm/src/tx_mock/tx_context.rs
+++ b/vm/src/tx_mock/tx_context.rs
@@ -16,6 +16,24 @@ use super::{
     BlockchainRng, BlockchainUpdate, TxCache, TxInput, TxManagedTypes, TxResult, TxStaticVars,
 };
 
+#[derive(Debug, Clone)]
+pub struct ApiCalls {
+    pub transfers: usize,
+    pub trie_reads: usize,
+    // TODO not yet counted
+    pub built_in_calls: usize,
+}
+
+impl Default for ApiCalls {
+    fn default() -> Self {
+        ApiCalls {
+            transfers: 0,
+            built_in_calls: 0,
+            trie_reads: 0,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct TxContext {
     pub tx_input_box: Box<TxInput>,
@@ -26,6 +44,7 @@ pub struct TxContext {
     pub tx_result_cell: RefCell<TxResult>,
     pub b_rng: RefCell<BlockchainRng>,
     pub printed_messages: RefCell<Vec<String>>,
+    pub api_calls: RefCell<ApiCalls>,
 }
 
 impl TxContext {
@@ -40,6 +59,7 @@ impl TxContext {
             tx_result_cell: RefCell::new(TxResult::empty()),
             b_rng,
             printed_messages: RefCell::new(Vec::new()),
+            api_calls: RefCell::new(ApiCalls::default()),
         }
     }
 
@@ -75,6 +95,7 @@ impl TxContext {
             tx_result_cell: RefCell::new(TxResult::empty()),
             b_rng,
             printed_messages: RefCell::new(Vec::new()),
+            api_calls: RefCell::new(ApiCalls::default()),
         }
     }
 

--- a/vm/src/tx_mock/tx_context_ref.rs
+++ b/vm/src/tx_mock/tx_context_ref.rs
@@ -1,6 +1,6 @@
 use std::{ops::Deref, rc::Rc};
 
-use crate::tx_mock::{TxContext, TxResult};
+use crate::tx_mock::{ApiCalls, TxContext, TxResult};
 
 use super::{BlockchainUpdate, TxContextStack};
 
@@ -66,5 +66,23 @@ impl TxContextRef {
     /// Clears entire print history.
     pub fn printed_messages_clear(&self) {
         self.0.printed_messages.borrow_mut().clear();
+    }
+
+    pub fn count_transfers(num: usize) {
+        let tx_context_rc = TxContextStack::static_peek();
+        tx_context_rc.api_calls.borrow_mut().transfers += num;
+    }
+    pub fn count_trie_read() {
+        let tx_context_rc = TxContextStack::static_peek();
+        tx_context_rc.api_calls.borrow_mut().trie_reads += 1;
+    }
+    pub fn count_built_in_call() {
+        let tx_context_rc = TxContextStack::static_peek();
+        tx_context_rc.api_calls.borrow_mut().built_in_calls += 1;
+    }
+
+    pub fn get_api_calls(&self) -> ApiCalls {
+        let tx_context_rc = TxContextStack::static_peek();
+        let x = (*tx_context_rc.api_calls.borrow()).clone(); x
     }
 }

--- a/vm/src/tx_mock/tx_result.rs
+++ b/vm/src/tx_mock/tx_result.rs
@@ -1,6 +1,7 @@
 use alloc::vec::Vec;
 
 use std::fmt;
+use crate::tx_mock::ApiCalls;
 
 use super::{AsyncCallTxData, TxLog, TxPanic, TxResultCalls};
 
@@ -11,6 +12,8 @@ pub struct TxResult {
     pub result_message: String,
     pub result_values: Vec<Vec<u8>>,
     pub result_logs: Vec<TxLog>,
+
+    pub api_calls: ApiCalls,
 
     /// Calls that need to be executed.
     ///
@@ -32,13 +35,26 @@ impl Default for TxResult {
             result_logs: Vec::new(),
             pending_calls: TxResultCalls::empty(),
             all_calls: Vec::new(),
+            api_calls: ApiCalls::default(),
         }
     }
 }
 
 impl TxResult {
+    // TODO delete?
     pub fn empty() -> TxResult {
         TxResult::default()
+    }
+    pub fn with_api_calls(api_calls: ApiCalls) -> TxResult {
+        TxResult {
+            result_status: 0,
+            result_message: String::new(),
+            result_values: Vec::new(),
+            result_logs: Vec::new(),
+            pending_calls: TxResultCalls::empty(),
+            all_calls: Vec::new(),
+            api_calls,
+        }
     }
 
     pub fn print(&self) {


### PR DESCRIPTION
# Count API Calls

## Problem

The [API Limits](https://docs.multiversx.com/developers/contract-api-limits/) are not testable with pure rust tests.

## Solution

I extended the rust test framework to count the API calls:

- [x] Trie Reads
- [x] Transfers
- [ ] Built-in function calls

This enables to write tests that count these calls and make assert statements like these:

```rust
assert_eq!(tx_result.api_calls.trie_reads, 5);
assert_eq!(tx_result.api_calls.transfers, 2);
```

## TODO

I could not find a clear point where to count built-in function calls (for me, it is also unclear what exactly counts as such). Could you please help me and guide me to a solution?

Please also verify I counted the transfers and trie_reads correctly.

Apart from that, I still would like to extend some tests or write new tests to verify the correct counting.

Summarized:

- [ ] Count built-in function calls
- [ ] Verify correctness of trie read counts
- [ ] Verify correctness of transfer counts
- [ ] Extend/write tests