### PR TITLE
forwarder-raw upgrade_async_call endpoint

### DIFF
--- a/contracts/feature-tests/composability/forwarder-raw/src/forwarder_raw_alt_init.rs
+++ b/contracts/feature-tests/composability/forwarder-raw/src/forwarder_raw_alt_init.rs
@@ -24,6 +24,22 @@ pub trait ForwarderRawAlterativeInit: super::forwarder_raw_common::ForwarderRawC
             .call_and_exit();
     }
 
+    /// Will not work, only written for VM testing.
+    ///
+    /// Async calls are explicitly forbidden in upgrade constructors.
+    /// 
+    /// TODO: write test once scenario tests support upgrades directly.
+    #[endpoint(upgrade)]
+    #[label("init-async-call")]
+    fn upgrade_async_call(
+        &self,
+        to: ManagedAddress,
+        endpoint_name: ManagedBuffer,
+        args: MultiValueEncoded<ManagedBuffer>,
+    ) {
+        self.init_async_call(to, endpoint_name, args)
+    }
+
     /// Works, but without forwarding EGLD.
     ///
     /// Forwarding EGLD only shows up in a VM test.

--- a/contracts/feature-tests/composability/forwarder-raw/wasm-forwarder-raw-init-async-call/src/lib.rs
+++ b/contracts/feature-tests/composability/forwarder-raw/wasm-forwarder-raw-init-async-call/src/lib.rs
@@ -5,9 +5,9 @@
 ////////////////////////////////////////////////////
 
 // Init:                                 1
-// Endpoints:                            0
+// Endpoints:                            1
 // Async Callback:                       1
-// Total number of exported functions:   2
+// Total number of exported functions:   3
 
 #![no_std]
 #![feature(lang_items)]
@@ -19,6 +19,7 @@ multiversx_sc_wasm_adapter::endpoints! {
     forwarder_raw
     (
         init => init_async_call
+        upgrade => upgrade_async_call
     )
 }
 


### PR DESCRIPTION
Some leftover code. We don't have a test for it yet, but didn't want it to get lost either.