### PR TITLE
renamed specific managed type APIs, improved hygiene

### DIFF
--- a/framework/base/src/api/endpoint_arg_api.rs
+++ b/framework/base/src/api/endpoint_arg_api.rs
@@ -1,8 +1,8 @@
 use crate::{err_msg, types::heap::BoxedBytes};
 
 use super::{
-    const_handles, use_raw_handle, BigIntApi, ErrorApi, ErrorApiImpl, HandleTypeInfo,
-    ManagedBufferApi, ManagedTypeApi, ManagedTypeApiImpl,
+    const_handles, use_raw_handle, BigIntApiImpl, ErrorApi, ErrorApiImpl, HandleTypeInfo,
+    ManagedBufferApiImpl, ManagedTypeApi, ManagedTypeApiImpl,
 };
 
 pub trait EndpointArgumentApi: HandleTypeInfo {

--- a/framework/base/src/api/external_view/ev_storage_api.rs
+++ b/framework/base/src/api/external_view/ev_storage_api.rs
@@ -1,5 +1,5 @@
 use crate::api::{
-    const_handles, use_raw_handle, ManagedBufferApi, ManagedTypeApiImpl, StaticVarApiImpl,
+    const_handles, use_raw_handle, ManagedBufferApiImpl, ManagedTypeApiImpl, StaticVarApiImpl,
     StorageReadApi, StorageReadApiImpl, VMApi,
 };
 

--- a/framework/base/src/api/managed_types/big_float_api.rs
+++ b/framework/base/src/api/managed_types/big_float_api.rs
@@ -3,7 +3,7 @@ use core::cmp::Ordering;
 use super::{HandleTypeInfo, Sign};
 
 /// Definition of the BigFloat type required by the API.
-pub trait BigFloatApi: HandleTypeInfo {
+pub trait BigFloatApiImpl: HandleTypeInfo {
     fn bf_from_parts(
         &self,
         integral_part: i32,

--- a/framework/base/src/api/managed_types/big_int_api.rs
+++ b/framework/base/src/api/managed_types/big_int_api.rs
@@ -12,7 +12,7 @@ pub enum Sign {
 }
 
 /// Definition of the BigInt type required by the API.
-pub trait BigIntApi: HandleTypeInfo {
+pub trait BigIntApiImpl: HandleTypeInfo {
     fn bi_new(&self, value: i64) -> Self::BigIntHandle;
 
     fn bi_new_zero(&self) -> Self::BigIntHandle {

--- a/framework/base/src/api/managed_types/elliptic_curve_api.rs
+++ b/framework/base/src/api/managed_types/elliptic_curve_api.rs
@@ -3,7 +3,7 @@ use crate::types::heap::BoxedBytes;
 use super::HandleTypeInfo;
 
 /// Wrapper around the EllipticCurve functionality provided by Arwen.
-pub trait EllipticCurveApi: HandleTypeInfo {
+pub trait EllipticCurveApiImpl: HandleTypeInfo {
     fn ec_create_from_name_bytes(&self, name: &[u8]) -> Self::EllipticCurveHandle;
 
     fn ec_create_from_name_mb(

--- a/framework/base/src/api/managed_types/managed_buffer_api.rs
+++ b/framework/base/src/api/managed_types/managed_buffer_api.rs
@@ -8,7 +8,7 @@ use super::HandleTypeInfo;
 pub struct InvalidSliceError;
 
 /// A raw bytes buffer managed by Arwen.
-pub trait ManagedBufferApi: HandleTypeInfo {
+pub trait ManagedBufferApiImpl: HandleTypeInfo {
     /// Requests a new handle from the VM. No longer used extensively.
     fn mb_new_empty(&self) -> Self::ManagedBufferHandle;
 

--- a/framework/base/src/api/managed_types/managed_map_api.rs
+++ b/framework/base/src/api/managed_types/managed_map_api.rs
@@ -1,7 +1,7 @@
 use super::HandleTypeInfo;
 
 /// A raw bytes buffer managed by Arwen.
-pub trait ManagedMapApi: HandleTypeInfo {
+pub trait ManagedMapApiImpl: HandleTypeInfo {
     /// Requests a new handle from the VM.
     fn mm_new(&self) -> Self::ManagedMapHandle;
 

--- a/framework/base/src/api/managed_types/managed_type_api_impl.rs
+++ b/framework/base/src/api/managed_types/managed_type_api_impl.rs
@@ -1,12 +1,17 @@
 use crate::api::ErrorApi;
 
 use super::{
-    token_identifier_util::IDENTIFIER_MAX_LENGTH, BigFloatApi, BigIntApi, EllipticCurveApi,
-    ManagedBufferApi, ManagedMapApi,
+    token_identifier_util::IDENTIFIER_MAX_LENGTH, BigFloatApiImpl, BigIntApiImpl,
+    EllipticCurveApiImpl, ManagedBufferApiImpl, ManagedMapApiImpl,
 };
 
 pub trait ManagedTypeApiImpl:
-    BigIntApi + BigFloatApi + EllipticCurveApi + ManagedBufferApi + ManagedMapApi + ErrorApi
+    BigIntApiImpl
+    + BigFloatApiImpl
+    + EllipticCurveApiImpl
+    + ManagedBufferApiImpl
+    + ManagedMapApiImpl
+    + ErrorApi
 {
     fn mb_to_big_int_unsigned(
         &self,

--- a/framework/base/src/api/uncallable/big_float_api_uncallable.rs
+++ b/framework/base/src/api/uncallable/big_float_api_uncallable.rs
@@ -1,8 +1,8 @@
 use core::cmp::Ordering;
 
-use crate::api::{BigFloatApi, Sign};
+use crate::api::{BigFloatApiImpl, Sign};
 
-impl BigFloatApi for super::UncallableApi {
+impl BigFloatApiImpl for super::UncallableApi {
     fn bf_from_parts(
         &self,
         _integral_part: i32,

--- a/framework/base/src/api/uncallable/big_int_api_uncallable.rs
+++ b/framework/base/src/api/uncallable/big_int_api_uncallable.rs
@@ -1,11 +1,11 @@
 use core::cmp::Ordering;
 
 use crate::{
-    api::{BigIntApi, Sign},
+    api::{BigIntApiImpl, Sign},
     types::heap::BoxedBytes,
 };
 
-impl BigIntApi for super::UncallableApi {
+impl BigIntApiImpl for super::UncallableApi {
     fn bi_new(&self, _value: i64) -> Self::BigIntHandle {
         unreachable!()
     }

--- a/framework/base/src/api/uncallable/elliptic_curve_api_uncallable.rs
+++ b/framework/base/src/api/uncallable/elliptic_curve_api_uncallable.rs
@@ -1,6 +1,6 @@
-use crate::{api::EllipticCurveApi, types::heap::BoxedBytes};
+use crate::{api::EllipticCurveApiImpl, types::heap::BoxedBytes};
 
-impl EllipticCurveApi for super::UncallableApi {
+impl EllipticCurveApiImpl for super::UncallableApi {
     fn ec_create_from_name_bytes(&self, _name: &[u8]) -> Self::ManagedBufferHandle {
         unreachable!()
     }

--- a/framework/base/src/api/uncallable/managed_buffer_api_uncallable.rs
+++ b/framework/base/src/api/uncallable/managed_buffer_api_uncallable.rs
@@ -1,9 +1,9 @@
 use crate::{
-    api::{InvalidSliceError, ManagedBufferApi},
+    api::{InvalidSliceError, ManagedBufferApiImpl},
     types::heap::BoxedBytes,
 };
 
-impl ManagedBufferApi for super::UncallableApi {
+impl ManagedBufferApiImpl for super::UncallableApi {
     fn mb_new_empty(&self) -> Self::ManagedBufferHandle {
         unreachable!()
     }

--- a/framework/base/src/api/uncallable/managed_map_api_uncallable.rs
+++ b/framework/base/src/api/uncallable/managed_map_api_uncallable.rs
@@ -1,6 +1,6 @@
-use crate::api::ManagedMapApi;
+use crate::api::ManagedMapApiImpl;
 
-impl ManagedMapApi for super::UncallableApi {
+impl ManagedMapApiImpl for super::UncallableApi {
     fn mm_new(&self) -> Self::ManagedBufferHandle {
         unreachable!()
     }

--- a/framework/base/src/contract_base/wrappers/callback_args_wrapper.rs
+++ b/framework/base/src/contract_base/wrappers/callback_args_wrapper.rs
@@ -3,7 +3,7 @@ use core::marker::PhantomData;
 use crate::{
     api::{
         const_handles, use_raw_handle, EndpointArgumentApi, EndpointArgumentApiImpl, ErrorApi,
-        HandleTypeInfo, ManagedBufferApi, ManagedTypeApi, StaticVarApi, VMApi,
+        HandleTypeInfo, ManagedBufferApiImpl, ManagedTypeApi, StaticVarApi, VMApi,
     },
     types::{ManagedArgBuffer, ManagedBuffer, ManagedType},
 };

--- a/framework/base/src/external_view_contract.rs
+++ b/framework/base/src/external_view_contract.rs
@@ -1,7 +1,7 @@
 use crate::{
     abi::{EndpointAbi, EndpointMutabilityAbi, EndpointTypeAbi, InputAbi, OutputAbis, TypeAbi},
     api::{
-        const_handles, use_raw_handle, CallValueApiImpl, ManagedBufferApi, StorageWriteApiImpl,
+        const_handles, use_raw_handle, CallValueApiImpl, ManagedBufferApiImpl, StorageWriteApiImpl,
         VMApi, EXTERNAL_VIEW_TARGET_ADRESS_KEY,
     },
     io::load_endpoint_args,

--- a/framework/base/src/io/call_value_init.rs
+++ b/framework/base/src/io/call_value_init.rs
@@ -1,7 +1,7 @@
 use crate::{
     api::{
         const_handles, use_raw_handle, CallValueApi, CallValueApiImpl, ErrorApi, ErrorApiImpl,
-        ManagedBufferApi, ManagedTypeApi,
+        ManagedBufferApiImpl, ManagedTypeApi,
     },
     contract_base::CallValueWrapper,
     err_msg,

--- a/framework/base/src/macros.rs
+++ b/framework/base/src/macros.rs
@@ -12,12 +12,7 @@ macro_rules! imports {
         };
         use multiversx_sc::{
             abi::TypeAbi,
-            api::{
-                BigFloatApi, BigIntApi, BlockchainApi, BlockchainApiImpl, CallValueApi,
-                CallValueApiImpl, CryptoApi, CryptoApiImpl, EllipticCurveApi, ErrorApi,
-                ErrorApiImpl, LogApi, LogApiImpl, ManagedTypeApi, PrintApi, PrintApiImpl, SendApi,
-                SendApiImpl,
-            },
+            api::{ErrorApiImpl, ManagedTypeApi},
             arrayvec::ArrayVec,
             codec::{
                 multi_types::*, DecodeError, IntoMultiValue, NestedDecode, NestedEncode, TopDecode,

--- a/framework/base/src/storage/storage_get.rs
+++ b/framework/base/src/storage/storage_get.rs
@@ -2,8 +2,8 @@ use core::marker::PhantomData;
 
 use crate::{
     api::{
-        const_handles, use_raw_handle, ErrorApi, ErrorApiImpl, ManagedBufferApi, ManagedTypeApi,
-        StaticVarApiImpl, StorageReadApi, StorageReadApiImpl,
+        const_handles, use_raw_handle, ErrorApi, ErrorApiImpl, ManagedBufferApiImpl,
+        ManagedTypeApi, StaticVarApiImpl, StorageReadApi, StorageReadApiImpl,
     },
     codec::*,
     err_msg,

--- a/framework/base/src/storage/storage_get_from_address.rs
+++ b/framework/base/src/storage/storage_get_from_address.rs
@@ -1,6 +1,6 @@
 use crate::{
     api::{
-        const_handles, use_raw_handle, ErrorApi, ManagedBufferApi, ManagedTypeApi,
+        const_handles, use_raw_handle, ErrorApi, ManagedBufferApiImpl, ManagedTypeApi,
         StaticVarApiImpl, StorageReadApi, StorageReadApiImpl,
     },
     codec::*,

--- a/framework/base/src/types/managed/basic/big_float.rs
+++ b/framework/base/src/types/managed/basic/big_float.rs
@@ -1,7 +1,7 @@
 use super::ManagedBuffer;
 
 use crate::{
-    api::{BigFloatApi, ManagedTypeApi, ManagedTypeApiImpl, Sign, StaticVarApiImpl},
+    api::{BigFloatApiImpl, ManagedTypeApi, ManagedTypeApiImpl, Sign, StaticVarApiImpl},
     types::{BigInt, BigUint, ManagedType},
 };
 use alloc::string::String;

--- a/framework/base/src/types/managed/basic/big_float_cmp.rs
+++ b/framework/base/src/types/managed/basic/big_float_cmp.rs
@@ -1,6 +1,6 @@
 use core::cmp::Ordering;
 
-use crate::api::{BigFloatApi, ManagedTypeApi, StaticVarApiImpl};
+use crate::api::{BigFloatApiImpl, ManagedTypeApi, StaticVarApiImpl};
 
 use super::{BigFloat, BigInt};
 

--- a/framework/base/src/types/managed/basic/big_float_operators.rs
+++ b/framework/base/src/types/managed/basic/big_float_operators.rs
@@ -1,6 +1,6 @@
 use super::BigFloat;
 use crate::{
-    api::{BigFloatApi, ManagedTypeApi, StaticVarApiImpl},
+    api::{BigFloatApiImpl, ManagedTypeApi, StaticVarApiImpl},
     types::managed::managed_type_trait::ManagedType,
 };
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};

--- a/framework/base/src/types/managed/basic/big_int.rs
+++ b/framework/base/src/types/managed/basic/big_int.rs
@@ -3,7 +3,7 @@ use core::{convert::TryInto, marker::PhantomData};
 use crate::{
     abi::TypeName,
     api::{
-        const_handles, use_raw_handle, BigIntApi, HandleConstraints, ManagedBufferApi,
+        const_handles, use_raw_handle, BigIntApiImpl, HandleConstraints, ManagedBufferApiImpl,
         ManagedTypeApi, ManagedTypeApiImpl, RawHandle, StaticVarApiImpl,
     },
     codec::{

--- a/framework/base/src/types/managed/basic/big_int_cmp.rs
+++ b/framework/base/src/types/managed/basic/big_int_cmp.rs
@@ -1,6 +1,6 @@
 use core::cmp::Ordering;
 
-use crate::api::{BigIntApi, ManagedTypeApi};
+use crate::api::{BigIntApiImpl, ManagedTypeApi};
 
 use super::{big_num_cmp::cmp_i64, BigInt};
 

--- a/framework/base/src/types/managed/basic/big_int_operators.rs
+++ b/framework/base/src/types/managed/basic/big_int_operators.rs
@@ -3,7 +3,7 @@ use core::ops::{
 };
 
 use crate::{
-    api::{BigIntApi, ManagedTypeApi, StaticVarApiImpl},
+    api::{BigIntApiImpl, ManagedTypeApi, StaticVarApiImpl},
     types::{BigInt, BigUint, ManagedType, Sign},
 };
 

--- a/framework/base/src/types/managed/basic/big_num_cmp.rs
+++ b/framework/base/src/types/managed/basic/big_num_cmp.rs
@@ -1,7 +1,7 @@
 use core::{cmp::Ordering, convert::TryInto};
 
 use crate::{
-    api::{const_handles, BigIntApi, ManagedTypeApi},
+    api::{const_handles, BigIntApiImpl, ManagedTypeApi},
     types::ManagedType,
 };
 

--- a/framework/base/src/types/managed/basic/big_uint.rs
+++ b/framework/base/src/types/managed/basic/big_uint.rs
@@ -3,7 +3,7 @@ use core::convert::TryInto;
 use crate::{
     abi::TypeName,
     api::{
-        const_handles, use_raw_handle, BigIntApi, HandleConstraints, ManagedBufferApi,
+        const_handles, use_raw_handle, BigIntApiImpl, HandleConstraints, ManagedBufferApiImpl,
         ManagedTypeApi, ManagedTypeApiImpl, RawHandle, StaticVarApiImpl,
     },
     codec::{

--- a/framework/base/src/types/managed/basic/big_uint_cmp.rs
+++ b/framework/base/src/types/managed/basic/big_uint_cmp.rs
@@ -1,7 +1,7 @@
 use crate::types::managed::basic::big_num_cmp::cmp_conv_i64;
 use core::cmp::Ordering;
 
-use crate::api::{BigIntApi, ManagedTypeApi};
+use crate::api::{BigIntApiImpl, ManagedTypeApi};
 
 use super::BigUint;
 

--- a/framework/base/src/types/managed/basic/big_uint_operators.rs
+++ b/framework/base/src/types/managed/basic/big_uint_operators.rs
@@ -1,5 +1,5 @@
 use crate::{
-    api::{const_handles, BigIntApi, ManagedTypeApi, StaticVarApiImpl},
+    api::{const_handles, BigIntApiImpl, ManagedTypeApi, StaticVarApiImpl},
     types::{BigUint, ManagedType},
 };
 use core::ops::{

--- a/framework/base/src/types/managed/basic/elliptic_curve.rs
+++ b/framework/base/src/types/managed/basic/elliptic_curve.rs
@@ -1,6 +1,6 @@
 use crate::{
     abi::{TypeAbi, TypeName},
-    api::{BigIntApi, EllipticCurveApi, ManagedTypeApi},
+    api::{BigIntApiImpl, EllipticCurveApiImpl, ManagedTypeApi},
     types::{BigUint, ManagedType},
 };
 

--- a/framework/base/src/types/managed/basic/managed_buffer.rs
+++ b/framework/base/src/types/managed/basic/managed_buffer.rs
@@ -1,7 +1,7 @@
 use crate::{
     abi::TypeName,
     api::{
-        use_raw_handle, ErrorApiImpl, HandleConstraints, InvalidSliceError, ManagedBufferApi,
+        use_raw_handle, ErrorApiImpl, HandleConstraints, InvalidSliceError, ManagedBufferApiImpl,
         ManagedTypeApi, StaticVarApiImpl,
     },
     codec::{

--- a/framework/base/src/types/managed/basic/managed_map.rs
+++ b/framework/base/src/types/managed/basic/managed_map.rs
@@ -1,5 +1,5 @@
 use crate::{
-    api::{ManagedMapApi, ManagedTypeApi, StaticVarApiImpl},
+    api::{ManagedMapApiImpl, ManagedTypeApi, StaticVarApiImpl},
     types::ManagedType,
 };
 

--- a/framework/derive/src/generate/auto_impl_event.rs
+++ b/framework/derive/src/generate/auto_impl_event.rs
@@ -113,7 +113,7 @@ pub fn generate_legacy_event_impl(m: &Method, event_id_bytes: &[u8]) -> proc_mac
                     let data_vec = match multiversx_sc::codec::top_encode_to_vec_u8(&#pat) {
                         Result::Ok(data_vec) => data_vec,
                         Result::Err(encode_err) => multiversx_sc::api::ErrorApiImpl::signal_error(
-                            &Self::Api::error_api_impl(),
+                            &<Self::Api as multiversx_sc::api::ErrorApi>::error_api_impl(),
                             encode_err.message_bytes()
                         ),
                     };
@@ -131,7 +131,7 @@ pub fn generate_legacy_event_impl(m: &Method, event_id_bytes: &[u8]) -> proc_mac
             topics[0] = #event_id_literal;
             #(#topic_conv_snippets)*
             multiversx_sc::api::LogApiImpl::write_legacy_log(
-                &Self::Api::log_api_impl(),
+                &<Self::Api as multiversx_sc::api::LogApi>::log_api_impl(),
                 &topics[..],
                 &data_vec.as_slice()
             );

--- a/framework/derive/src/generate/callback_gen.rs
+++ b/framework/derive/src/generate/callback_gen.rs
@@ -50,7 +50,7 @@ pub fn generate_callback_selector_and_main(
                     if let multiversx_sc::types::CallbackSelectorResult::NotProcessed(_) =
                         self::EndpointWrappers::callback_selector(self, ___cb_closure___)	{
                         multiversx_sc::api::ErrorApiImpl::signal_error(
-                            &Self::Api::error_api_impl(),
+                            &<Self::Api as multiversx_sc::api::ErrorApi>::error_api_impl(),
                             err_msg::CALLBACK_BAD_FUNC,
                         );
                     }

--- a/framework/scenario/src/api/managed_type_api_vh/big_float_api_vh.rs
+++ b/framework/scenario/src/api/managed_type_api_vh/big_float_api_vh.rs
@@ -1,10 +1,10 @@
 use core::cmp::Ordering;
 
-use multiversx_sc::api::{BigFloatApi, Sign};
+use multiversx_sc::api::{BigFloatApiImpl, Sign};
 
 use crate::api::VMHooksApiImpl;
 
-impl BigFloatApi for VMHooksApiImpl {
+impl BigFloatApiImpl for VMHooksApiImpl {
     fn bf_from_parts(
         &self,
         _integral_part: i32,

--- a/framework/scenario/src/api/managed_type_api_vh/big_int_api_vh.rs
+++ b/framework/scenario/src/api/managed_type_api_vh/big_int_api_vh.rs
@@ -2,7 +2,7 @@ use core::cmp::Ordering;
 
 use multiversx_chain_vm::mem_conv;
 use multiversx_sc::{
-    api::{BigIntApi, HandleConstraints, Sign},
+    api::{BigIntApiImpl, HandleConstraints, Sign},
     types::BoxedBytes,
 };
 
@@ -35,7 +35,7 @@ macro_rules! unary_op_method {
     };
 }
 
-impl BigIntApi for VMHooksApiImpl {
+impl BigIntApiImpl for VMHooksApiImpl {
     fn bi_new(&self, _value: i64) -> Self::BigIntHandle {
         todo!()
     }

--- a/framework/scenario/src/api/managed_type_api_vh/elliptic_curve_api_vh.rs
+++ b/framework/scenario/src/api/managed_type_api_vh/elliptic_curve_api_vh.rs
@@ -1,8 +1,8 @@
-use multiversx_sc::{api::EllipticCurveApi, types::BoxedBytes};
+use multiversx_sc::{api::EllipticCurveApiImpl, types::BoxedBytes};
 
 use crate::api::VMHooksApiImpl;
 
-impl EllipticCurveApi for VMHooksApiImpl {
+impl EllipticCurveApiImpl for VMHooksApiImpl {
     fn ec_create_from_name_bytes(&self, _name: &[u8]) -> Self::ManagedBufferHandle {
         todo!()
     }

--- a/framework/scenario/src/api/managed_type_api_vh/managed_buffer_api_vh.rs
+++ b/framework/scenario/src/api/managed_type_api_vh/managed_buffer_api_vh.rs
@@ -1,12 +1,12 @@
 use multiversx_chain_vm::{executor::MemPtr, mem_conv};
 use multiversx_sc::{
-    api::{InvalidSliceError, ManagedBufferApi},
+    api::{InvalidSliceError, ManagedBufferApiImpl},
     types::BoxedBytes,
 };
 
 use crate::api::VMHooksApiImpl;
 
-impl ManagedBufferApi for VMHooksApiImpl {
+impl ManagedBufferApiImpl for VMHooksApiImpl {
     fn mb_new_empty(&self) -> Self::ManagedBufferHandle {
         self.with_vm_hooks(|vh| vh.mbuffer_new())
     }

--- a/framework/scenario/src/api/managed_type_api_vh/managed_map_api_vh.rs
+++ b/framework/scenario/src/api/managed_type_api_vh/managed_map_api_vh.rs
@@ -1,8 +1,8 @@
-use multiversx_sc::api::ManagedMapApi;
+use multiversx_sc::api::ManagedMapApiImpl;
 
 use crate::api::VMHooksApiImpl;
 
-impl ManagedMapApi for VMHooksApiImpl {
+impl ManagedMapApiImpl for VMHooksApiImpl {
     fn mm_new(&self) -> Self::ManagedBufferHandle {
         todo!()
     }

--- a/framework/scenario/tests/contract_without_macros.rs
+++ b/framework/scenario/tests/contract_without_macros.rs
@@ -57,9 +57,7 @@ mod module_1 {
     pub trait EndpointWrappers: VersionModule + multiversx_sc::contract_base::ContractBase {
         #[inline]
         fn call_version(&self) {
-            multiversx_sc::api::CallValueApiImpl::check_not_payable(
-                &Self::Api::call_value_api_impl(),
-            );
+            multiversx_sc::io::call_value_init::not_payable::<Self::Api>();
             let result = self.version();
             multiversx_sc::io::finish_multi::<Self::Api, _>(&result)
         }
@@ -175,9 +173,7 @@ mod sample_adder {
         #[inline]
         fn call_get_sum(&self) {
             <Self::Api as multiversx_sc::api::VMApi>::init_static();
-            multiversx_sc::api::CallValueApiImpl::check_not_payable(
-                &Self::Api::call_value_api_impl(),
-            );
+            multiversx_sc::io::call_value_init::not_payable::<Self::Api>();
             let () = multiversx_sc::io::load_endpoint_args::<Self::Api, ()>(());
             let result = self.get_sum();
             multiversx_sc::io::finish_multi::<Self::Api, _>(&result);
@@ -185,9 +181,7 @@ mod sample_adder {
         #[inline]
         fn call_init(&self) {
             <Self::Api as multiversx_sc::api::VMApi>::init_static();
-            multiversx_sc::api::CallValueApiImpl::check_not_payable(
-                &Self::Api::call_value_api_impl(),
-            );
+            multiversx_sc::io::call_value_init::not_payable::<Self::Api>();
             let (initial_value, ()) = multiversx_sc::io::load_endpoint_args::<
                 Self::Api,
                 (multiversx_sc::types::BigInt<Self::Api>, ()),
@@ -197,9 +191,7 @@ mod sample_adder {
         #[inline]
         fn call_add(&self) {
             <Self::Api as multiversx_sc::api::VMApi>::init_static();
-            multiversx_sc::api::CallValueApiImpl::check_not_payable(
-                &Self::Api::call_value_api_impl(),
-            );
+            multiversx_sc::io::call_value_init::not_payable::<Self::Api>();
             let (value, ()) = multiversx_sc::io::load_endpoint_args::<
                 Self::Api,
                 (multiversx_sc::types::BigInt<Self::Api>, ()),

--- a/framework/wasm-adapter/src/api/blockchain_api_node.rs
+++ b/framework/wasm-adapter/src/api/blockchain_api_node.rs
@@ -5,7 +5,7 @@ use crate::api::{
     VmApiImpl,
 };
 use multiversx_sc::{
-    api::{BlockchainApi, BlockchainApiImpl, ManagedBufferApi, ManagedTypeApi},
+    api::{BlockchainApi, BlockchainApiImpl, ManagedBufferApiImpl, ManagedTypeApi},
     types::{
         heap::{Address, Box, H256},
         BigUint, EsdtTokenData, EsdtTokenType, ManagedAddress, ManagedBuffer, ManagedType,
@@ -366,7 +366,7 @@ impl BlockchainApiImpl for VmApiImpl {
         token: &TokenIdentifier<M>,
         nonce: u64,
     ) -> EsdtTokenData<M> {
-        use multiversx_sc::{api::BigIntApi, types::heap::BoxedBytes};
+        use multiversx_sc::{api::BigIntApiImpl, types::heap::BoxedBytes};
 
         let address = m_address.to_address();
         let token_bytes = token.to_boxed_bytes();
@@ -457,7 +457,7 @@ impl BlockchainApiImpl for VmApiImpl {
         token: &TokenIdentifier<M>,
         nonce: u64,
     ) -> EsdtTokenData<M> {
-        use multiversx_sc::api::BigIntApi;
+        use multiversx_sc::api::BigIntApiImpl;
 
         let managed_token_id = token.as_managed_buffer();
 

--- a/framework/wasm-adapter/src/api/managed_types/big_float_api_node.rs
+++ b/framework/wasm-adapter/src/api/managed_types/big_float_api_node.rs
@@ -1,6 +1,6 @@
 use core::cmp::Ordering;
 
-use multiversx_sc::api::{BigFloatApi, Sign};
+use multiversx_sc::api::{BigFloatApiImpl, Sign};
 
 extern "C" {
     fn bigFloatNewFromParts(integralPart: i32, fractionalPart: i32, exponent: i32) -> i32;
@@ -67,7 +67,7 @@ macro_rules! unary_op_method_big_int_handle {
     };
 }
 
-impl BigFloatApi for crate::api::VmApiImpl {
+impl BigFloatApiImpl for crate::api::VmApiImpl {
     #[inline]
     fn bf_from_parts(
         &self,

--- a/framework/wasm-adapter/src/api/managed_types/big_int_api_node.rs
+++ b/framework/wasm-adapter/src/api/managed_types/big_int_api_node.rs
@@ -3,7 +3,7 @@ use core::cmp::Ordering;
 use crate::{api::unsafe_buffer, error_hook};
 
 use multiversx_sc::{
-    api::{BigIntApi, Sign},
+    api::{BigIntApiImpl, Sign},
     err_msg,
     types::heap::BoxedBytes,
 };
@@ -72,7 +72,7 @@ macro_rules! unary_op_wrapper {
     };
 }
 
-impl BigIntApi for crate::api::VmApiImpl {
+impl BigIntApiImpl for crate::api::VmApiImpl {
     #[inline]
     fn bi_new(&self, value: i64) -> Self::BigIntHandle {
         unsafe { bigIntNew(value) }

--- a/framework/wasm-adapter/src/api/managed_types/elliptic_curve_api_node.rs
+++ b/framework/wasm-adapter/src/api/managed_types/elliptic_curve_api_node.rs
@@ -1,4 +1,4 @@
-use multiversx_sc::{api::EllipticCurveApi, types::heap::BoxedBytes};
+use multiversx_sc::{api::EllipticCurveApiImpl, types::heap::BoxedBytes};
 
 extern "C" {
     fn createEC(dataOffset: i32, dataLength: i32) -> i32;
@@ -141,7 +141,7 @@ extern "C" {
 
 }
 
-impl EllipticCurveApi for crate::api::VmApiImpl {
+impl EllipticCurveApiImpl for crate::api::VmApiImpl {
     fn ec_create_from_name_bytes(&self, name: &[u8]) -> Self::ManagedBufferHandle {
         unsafe { createEC(name.as_ptr() as i32, name.len() as i32) }
     }

--- a/framework/wasm-adapter/src/api/managed_types/managed_buffer_api_node.rs
+++ b/framework/wasm-adapter/src/api/managed_types/managed_buffer_api_node.rs
@@ -1,6 +1,6 @@
 use crate::{api::unsafe_buffer, error_hook};
 use multiversx_sc::{
-    api::{InvalidSliceError, ManagedBufferApi},
+    api::{InvalidSliceError, ManagedBufferApiImpl},
     err_msg,
     types::heap::BoxedBytes,
 };
@@ -40,7 +40,7 @@ extern "C" {
     fn managedBufferToHex(sourceHandle: i32, destinationHandle: i32);
 }
 
-impl ManagedBufferApi for crate::api::VmApiImpl {
+impl ManagedBufferApiImpl for crate::api::VmApiImpl {
     #[inline]
     fn mb_new_empty(&self) -> Self::ManagedBufferHandle {
         unsafe { mBufferNew() }

--- a/framework/wasm-adapter/src/api/managed_types/managed_map_api_node.rs
+++ b/framework/wasm-adapter/src/api/managed_types/managed_map_api_node.rs
@@ -1,4 +1,4 @@
-use multiversx_sc::api::ManagedMapApi;
+use multiversx_sc::api::ManagedMapApiImpl;
 
 #[allow(dead_code)]
 extern "C" {
@@ -9,7 +9,7 @@ extern "C" {
     fn managedMapContains(map_handle: i32, key_handle: i32) -> i32;
 }
 
-impl ManagedMapApi for crate::api::VmApiImpl {
+impl ManagedMapApiImpl for crate::api::VmApiImpl {
     fn mm_new(&self) -> Self::ManagedBufferHandle {
         unsafe { managedMapNew() }
     }

--- a/vm/src/api/blockchain_api_mock.rs
+++ b/vm/src/api/blockchain_api_mock.rs
@@ -4,7 +4,9 @@ use crate::{
     DebugApi,
 };
 use multiversx_sc::{
-    api::{BlockchainApi, BlockchainApiImpl, HandleConstraints, ManagedBufferApi, ManagedTypeApi},
+    api::{
+        BlockchainApi, BlockchainApiImpl, HandleConstraints, ManagedBufferApiImpl, ManagedTypeApi,
+    },
     types::{
         heap::{Address, H256},
         BigUint, EsdtLocalRole, EsdtLocalRoleFlags, EsdtTokenData, EsdtTokenType, ManagedAddress,

--- a/vm/src/api/call_value_api_mock.rs
+++ b/vm/src/api/call_value_api_mock.rs
@@ -1,6 +1,6 @@
 use crate::{num_bigint, tx_mock::TxPanic, DebugApi};
 use multiversx_sc::{
-    api::{handle_to_be_bytes, CallValueApi, CallValueApiImpl, ManagedBufferApi},
+    api::{handle_to_be_bytes, CallValueApi, CallValueApiImpl, ManagedBufferApiImpl},
     err_msg,
 };
 use num_traits::Zero;

--- a/vm/src/api/crypto_api_mock.rs
+++ b/vm/src/api/crypto_api_mock.rs
@@ -2,7 +2,7 @@ use crate::DebugApi;
 use ed25519_dalek::*;
 use multiversx_sc::{
     api::{
-        CryptoApi, CryptoApiImpl, ManagedBufferApi, KECCAK256_RESULT_LEN, RIPEMD_RESULT_LEN,
+        CryptoApi, CryptoApiImpl, ManagedBufferApiImpl, KECCAK256_RESULT_LEN, RIPEMD_RESULT_LEN,
         SHA256_RESULT_LEN,
     },
     types::{heap::BoxedBytes, MessageHashType},

--- a/vm/src/api/endpoint_arg_api_mock.rs
+++ b/vm/src/api/endpoint_arg_api_mock.rs
@@ -4,7 +4,7 @@ use crate::{
     DebugApi,
 };
 use alloc::vec::Vec;
-use multiversx_sc::api::{EndpointArgumentApi, EndpointArgumentApiImpl, ManagedBufferApi};
+use multiversx_sc::api::{EndpointArgumentApi, EndpointArgumentApiImpl, ManagedBufferApiImpl};
 use num_traits::cast::ToPrimitive;
 
 impl EndpointArgumentApi for DebugApi {

--- a/vm/src/api/endpoint_finish_api_mock.rs
+++ b/vm/src/api/endpoint_finish_api_mock.rs
@@ -2,7 +2,9 @@ use crate::{
     num_bigint::{BigInt, BigUint},
     DebugApi,
 };
-use multiversx_sc::api::{BigIntApi, EndpointFinishApi, EndpointFinishApiImpl, ManagedBufferApi};
+use multiversx_sc::api::{
+    BigIntApiImpl, EndpointFinishApi, EndpointFinishApiImpl, ManagedBufferApiImpl,
+};
 
 impl EndpointFinishApi for DebugApi {
     type EndpointFinishApiImpl = DebugApi;

--- a/vm/src/api/error_api_mock.rs
+++ b/vm/src/api/error_api_mock.rs
@@ -1,5 +1,5 @@
 use crate::{tx_mock::TxPanic, DebugApi};
-use multiversx_sc::api::{ErrorApi, ErrorApiImpl, ManagedBufferApi};
+use multiversx_sc::api::{ErrorApi, ErrorApiImpl, ManagedBufferApiImpl};
 
 impl ErrorApi for DebugApi {
     type ErrorApiImpl = DebugApi;

--- a/vm/src/api/managed_types/big_float_api_mock.rs
+++ b/vm/src/api/managed_types/big_float_api_mock.rs
@@ -6,7 +6,7 @@ use core::{
 use std::convert::TryInto;
 
 use multiversx_sc::{
-    api::{BigFloatApi, BigIntApi, ErrorApiImpl, HandleTypeInfo, Sign},
+    api::{BigFloatApiImpl, BigIntApiImpl, ErrorApiImpl, HandleTypeInfo, Sign},
     codec::num_bigint::BigInt,
     err_msg,
 };
@@ -67,7 +67,7 @@ macro_rules! unary_op_method_big_int_handle {
     };
 }
 
-impl BigFloatApi for DebugApi {
+impl BigFloatApiImpl for DebugApi {
     fn bf_from_parts(
         &self,
         integral_part: i32,

--- a/vm/src/api/managed_types/big_int_api_mock.rs
+++ b/vm/src/api/managed_types/big_int_api_mock.rs
@@ -4,7 +4,7 @@ use core::{
     ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Neg, Rem, Shl, Shr, Sub},
 };
 use multiversx_sc::{
-    api::{BigIntApi, ErrorApiImpl, HandleTypeInfo, ManagedBufferApi},
+    api::{BigIntApiImpl, ErrorApiImpl, HandleTypeInfo, ManagedBufferApiImpl},
     err_msg,
     types::heap::BoxedBytes,
 };
@@ -87,7 +87,7 @@ impl DebugApi {
     }
 }
 
-impl BigIntApi for DebugApi {
+impl BigIntApiImpl for DebugApi {
     #[allow(dead_code)]
     fn bi_new(&self, value: i64) -> Self::BigIntHandle {
         self.bi_new_from_big_int(num_bigint::BigInt::from(value))

--- a/vm/src/api/managed_types/elliptic_curve_api_mock.rs
+++ b/vm/src/api/managed_types/elliptic_curve_api_mock.rs
@@ -1,8 +1,8 @@
-use multiversx_sc::{api::EllipticCurveApi, types::heap::BoxedBytes};
+use multiversx_sc::{api::EllipticCurveApiImpl, types::heap::BoxedBytes};
 
 use crate::DebugApi;
 
-impl EllipticCurveApi for DebugApi {
+impl EllipticCurveApiImpl for DebugApi {
     fn ec_create_from_name_bytes(&self, _name: &[u8]) -> Self::ManagedBufferHandle {
         panic!("ec_create not implemented")
     }

--- a/vm/src/api/managed_types/managed_buffer_api_mock.rs
+++ b/vm/src/api/managed_types/managed_buffer_api_mock.rs
@@ -1,6 +1,6 @@
 use crate::DebugApi;
 use multiversx_sc::{
-    api::{use_raw_handle, HandleTypeInfo, InvalidSliceError, ManagedBufferApi},
+    api::{use_raw_handle, HandleTypeInfo, InvalidSliceError, ManagedBufferApiImpl},
     types::heap::BoxedBytes,
 };
 
@@ -25,7 +25,7 @@ impl DebugApi {
     }
 }
 
-impl ManagedBufferApi for DebugApi {
+impl ManagedBufferApiImpl for DebugApi {
     fn mb_new_empty(&self) -> Self::ManagedBufferHandle {
         use_raw_handle(self.m_types_borrow_mut().mb_new(Vec::new()))
     }

--- a/vm/src/api/managed_types/managed_map_api_mock.rs
+++ b/vm/src/api/managed_types/managed_map_api_mock.rs
@@ -1,5 +1,5 @@
 use crate::{tx_mock::ManagedMapImpl, DebugApi};
-use multiversx_sc::api::{HandleTypeInfo, ManagedMapApi};
+use multiversx_sc::api::{HandleTypeInfo, ManagedMapApiImpl};
 
 impl DebugApi {
     fn mm_values_insert(
@@ -40,7 +40,7 @@ impl DebugApi {
     }
 }
 
-impl ManagedMapApi for DebugApi {
+impl ManagedMapApiImpl for DebugApi {
     fn mm_new(&self) -> Self::ManagedMapHandle {
         let mut managed_types = self.m_types_borrow_mut();
         managed_types

--- a/vm/src/api/managed_types/managed_type_api_mock.rs
+++ b/vm/src/api/managed_types/managed_type_api_mock.rs
@@ -1,6 +1,6 @@
 use std::convert::TryInto;
 
-use multiversx_sc::api::{BigIntApi, ManagedBufferApi, ManagedTypeApi, ManagedTypeApiImpl};
+use multiversx_sc::api::{BigIntApiImpl, ManagedBufferApiImpl, ManagedTypeApi, ManagedTypeApiImpl};
 
 use crate::DebugApi;
 

--- a/vm/src/api/managed_types/managed_type_util.rs
+++ b/vm/src/api/managed_types/managed_type_util.rs
@@ -1,5 +1,5 @@
 use multiversx_sc::{
-    api::{HandleTypeInfo, ManagedBufferApi},
+    api::{HandleTypeInfo, ManagedBufferApiImpl},
     types::{heap::Address, ManagedBuffer, ManagedType},
 };
 use num_traits::Zero;

--- a/vm/src/api/storage_api_mock.rs
+++ b/vm/src/api/storage_api_mock.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use alloc::vec::Vec;
 use multiversx_sc::api::{
-    BigIntApi, ManagedBufferApi, StorageReadApi, StorageReadApiImpl, StorageWriteApi,
+    BigIntApiImpl, ManagedBufferApiImpl, StorageReadApi, StorageReadApiImpl, StorageWriteApi,
     StorageWriteApiImpl,
 };
 


### PR DESCRIPTION
The ManagedTypeApiImpl is composed of:
    BigIntApiImpl
    + BigFloatApiImpl
    + EllipticCurveApiImpl
    + ManagedBufferApiImpl
    + ManagedMapApiImpl

They were (incorrectly) named without the `Impl` suffix in the past.

Also removed most of the APIs from the `imports!()` macro, they shouldn't be accessible so easily.