### PR TITLE
using multiversx-chain-vm-executor v0.1.0

### DIFF
--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -33,6 +33,5 @@ version = "=0.41.0"
 path = "../framework/base"
 features = ["alloc", "num-bigint", "promises", "big-float"]
 
-[dependencies.multiversx-vm-executor]
-git = "https://github.com/multiversx/mx-vm-executor-rs" # TODO: release, replace with version
-branch = "master"
+[dependencies.multiversx-chain-vm-executor]
+version = "0.1.0"

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -18,7 +18,7 @@ pub use world_mock::BlockchainMock;
 pub use multiversx_sc::codec::num_bigint;
 
 // Re-exporting the executor, for convenience.
-pub use multiversx_vm_executor as executor;
+pub use multiversx_chain_vm_executor as executor;
 
 #[macro_use]
 extern crate alloc;

--- a/vm/src/mem_conv.rs
+++ b/vm/src/mem_conv.rs
@@ -1,4 +1,4 @@
-use multiversx_vm_executor::{MemLength, MemPtr};
+use multiversx_chain_vm_executor::{MemLength, MemPtr};
 
 pub fn with_mem_ptr<F, R>(bytes: &[u8], f: F) -> R
 where

--- a/vm/src/vm_hooks/vh_dispatcher.rs
+++ b/vm/src/vm_hooks/vh_dispatcher.rs
@@ -1,6 +1,6 @@
 use std::ffi::c_void;
 
-use multiversx_vm_executor::{MemLength, MemPtr, VMHooks};
+use multiversx_chain_vm_executor::{MemLength, MemPtr, VMHooks};
 
 use crate::mem_conv;
 
@@ -810,6 +810,14 @@ impl VMHooks for VMHooksDispatcher {
 
     fn managed_buffer_to_hex(&self, source_handle: i32, dest_handle: i32) {
         self.handler.mb_to_hex(source_handle, dest_handle);
+    }
+
+    fn managed_get_code_metadata(&self, address_handle: i32, response_handle: i32) {
+        panic!("Unavailable: managed_get_code_metadata")
+    }
+
+    fn managed_is_builtin_function(&self, function_name_handle: i32) -> i32 {
+        panic!("Unavailable: managed_is_builtin_function")
     }
 
     fn big_float_new_from_parts(


### PR DESCRIPTION
Finally the VM has a proper reference to the executor interface.