### PR TITLE
send api using only handles

### DIFF
--- a/framework/base/src/api/send_api.rs
+++ b/framework/base/src/api/send_api.rs
@@ -36,9 +36,6 @@ pub trait SendApiImpl: ManagedTypeApiImpl {
     /// Sends an asynchronous call to another contract.
     /// Calling this method immediately terminates tx execution.
     /// Using it directly is generally discouraged.
-    ///
-    /// The data is expected to be of the form `functionName@<arg1-hex>@<arg2-hex>@...`.
-    /// Use a `HexCallDataSerializer` to prepare this field.
     fn async_call_raw(
         &self,
         to_handle: RawHandle,

--- a/framework/base/src/api/send_api.rs
+++ b/framework/base/src/api/send_api.rs
@@ -1,8 +1,4 @@
-use super::{BlockchainApi, HandleTypeInfo, ManagedTypeApi, ManagedTypeApiImpl};
-use crate::types::{
-    BigUint, CodeMetadata, EsdtTokenPayment, ManagedAddress, ManagedArgBuffer, ManagedBuffer,
-    ManagedVec,
-};
+use super::{BlockchainApi, HandleTypeInfo, ManagedTypeApi, ManagedTypeApiImpl, RawHandle};
 
 pub trait SendApi: ManagedTypeApi + BlockchainApi {
     type SendApiImpl: SendApiImpl
@@ -19,22 +15,22 @@ pub trait SendApi: ManagedTypeApi + BlockchainApi {
 /// API that groups methods that either send EGLD or ESDT, or that call other contracts.
 pub trait SendApiImpl: ManagedTypeApiImpl {
     /// Sends EGLD to an address (optionally) and executes like an async call, but without callback.
-    fn transfer_value_execute<M: ManagedTypeApi>(
+    fn transfer_value_execute(
         &self,
-        to: &ManagedAddress<M>,
-        amount: &BigUint<M>,
+        to_handle: RawHandle,
+        egld_value_handle: RawHandle,
         gas_limit: u64,
-        endpoint_name: &ManagedBuffer<M>,
-        arg_buffer: &ManagedArgBuffer<M>,
+        endpoint_name_handle: RawHandle,
+        arg_buffer_handle: RawHandle,
     ) -> Result<(), &'static [u8]>;
 
-    fn multi_transfer_esdt_nft_execute<M: ManagedTypeApi>(
+    fn multi_transfer_esdt_nft_execute(
         &self,
-        to: &ManagedAddress<M>,
-        payments: &ManagedVec<M, EsdtTokenPayment<M>>,
+        to_handle: RawHandle,
+        payments_handle: RawHandle,
         gas_limit: u64,
-        endpoint_name: &ManagedBuffer<M>,
-        arg_buffer: &ManagedArgBuffer<M>,
+        endpoint_name_handle: RawHandle,
+        arg_buffer_handle: RawHandle,
     ) -> Result<(), &'static [u8]>;
 
     /// Sends an asynchronous call to another contract.
@@ -43,102 +39,111 @@ pub trait SendApiImpl: ManagedTypeApiImpl {
     ///
     /// The data is expected to be of the form `functionName@<arg1-hex>@<arg2-hex>@...`.
     /// Use a `HexCallDataSerializer` to prepare this field.
-    fn async_call_raw<M: ManagedTypeApi>(
+    fn async_call_raw(
         &self,
-        to: &ManagedAddress<M>,
-        amount: &BigUint<M>,
-        endpoint_name: &ManagedBuffer<M>,
-        arg_buffer: &ManagedArgBuffer<M>,
+        to_handle: RawHandle,
+        egld_value_handle: RawHandle,
+        endpoint_name_handle: RawHandle,
+        arg_buffer_handle: RawHandle,
     ) -> !;
 
     #[allow(clippy::too_many_arguments)]
     fn create_async_call_raw(
         &self,
-        to: Self::ManagedBufferHandle,
-        amount: Self::BigIntHandle,
-        endpoint_name: Self::ManagedBufferHandle,
-        arg_buffer: Self::ManagedBufferHandle,
+        to_handle: RawHandle,
+        egld_value_handle: RawHandle,
+        endpoint_name_handle: RawHandle,
+        arg_buffer_handle: RawHandle,
         success_callback: &'static str,
         error_callback: &'static str,
         gas: u64,
         extra_gas_for_callback: u64,
-        callback_closure: Self::ManagedBufferHandle,
+        callback_closure: RawHandle,
     );
 
     /// Deploys a new contract in the same shard.
     /// Unlike `async_call_raw`, the deployment is synchronous and tx execution continues afterwards.
     /// Also unlike `async_call_raw`, it uses an argument buffer to pass arguments
     /// If the deployment fails, Option::None is returned
-    fn deploy_contract<M: ManagedTypeApi>(
+    #[allow(clippy::too_many_arguments)]
+    fn deploy_contract(
         &self,
         gas: u64,
-        amount: &BigUint<M>,
-        code: &ManagedBuffer<M>,
-        code_metadata: CodeMetadata,
-        arg_buffer: &ManagedArgBuffer<M>,
-    ) -> (ManagedAddress<M>, ManagedVec<M, ManagedBuffer<M>>);
+        egld_value_handle: RawHandle,
+        code_handle: RawHandle,
+        code_metadata_handle: RawHandle,
+        arg_buffer_handle: RawHandle,
+        new_address_handle: RawHandle,
+        result_handle: RawHandle,
+    );
 
     /// Deploys a new contract in the same shard by re-using the code of an already deployed source contract.
     /// The deployment is done synchronously and the new contract's address is returned.
     /// If the deployment fails, Option::None is returned
-    fn deploy_from_source_contract<M: ManagedTypeApi>(
+    #[allow(clippy::too_many_arguments)]
+    fn deploy_from_source_contract(
         &self,
         gas: u64,
-        amount: &BigUint<M>,
-        source_contract_address: &ManagedAddress<M>,
-        code_metadata: CodeMetadata,
-        arg_buffer: &ManagedArgBuffer<M>,
-    ) -> (ManagedAddress<M>, ManagedVec<M, ManagedBuffer<M>>);
+        egld_value_handle: RawHandle,
+        source_contract_address_handle: RawHandle,
+        code_metadata_handle: RawHandle,
+        arg_buffer_handle: RawHandle,
+        new_address_handle: RawHandle,
+        result_handle: RawHandle,
+    );
 
-    fn upgrade_from_source_contract<M: ManagedTypeApi>(
+    fn upgrade_from_source_contract(
         &self,
-        sc_address: &ManagedAddress<M>,
+        sc_address_handle: RawHandle,
         gas: u64,
-        amount: &BigUint<M>,
-        source_contract_address: &ManagedAddress<M>,
-        code_metadata: CodeMetadata,
-        arg_buffer: &ManagedArgBuffer<M>,
+        egld_value_handle: RawHandle,
+        source_contract_address_handle: RawHandle,
+        code_metadata_handle: RawHandle,
+        arg_buffer_handle: RawHandle,
     );
 
     /// Upgrades a child contract of the currently executing contract.
     /// The upgrade is synchronous, and the current transaction will fail if the upgrade fails.
     /// The child contract's new init function will be called with the provided arguments
-    fn upgrade_contract<M: ManagedTypeApi>(
+    fn upgrade_contract(
         &self,
-        sc_address: &ManagedAddress<M>,
+        sc_address_handle: RawHandle,
         gas: u64,
-        amount: &BigUint<M>,
-        code: &ManagedBuffer<M>,
-        code_metadata: CodeMetadata,
-        arg_buffer: &ManagedArgBuffer<M>,
+        egld_value_handle: RawHandle,
+        code_handle: RawHandle,
+        code_metadata_handle: RawHandle,
+        arg_buffer_handle: RawHandle,
     );
 
     /// Same shard, in-line execution of another contract.
-    fn execute_on_dest_context_raw<M: ManagedTypeApi>(
+    fn execute_on_dest_context_raw(
         &self,
         gas: u64,
-        address: &ManagedAddress<M>,
-        value: &BigUint<M>,
-        endpoint_name: &ManagedBuffer<M>,
-        arg_buffer: &ManagedArgBuffer<M>,
-    ) -> ManagedVec<M, ManagedBuffer<M>>;
+        address_handle: RawHandle,
+        egld_value_handle: RawHandle,
+        endpoint_name_handle: RawHandle,
+        arg_buffer_handle: RawHandle,
+        result_handle: RawHandle,
+    );
 
-    fn execute_on_same_context_raw<M: ManagedTypeApi>(
+    fn execute_on_same_context_raw(
         &self,
         gas: u64,
-        address: &ManagedAddress<M>,
-        value: &BigUint<M>,
-        endpoint_name: &ManagedBuffer<M>,
-        arg_buffer: &ManagedArgBuffer<M>,
-    ) -> ManagedVec<M, ManagedBuffer<M>>;
+        address_handle: RawHandle,
+        egld_value_handle: RawHandle,
+        endpoint_name_handle: RawHandle,
+        arg_buffer_handle: RawHandle,
+        result_handle: RawHandle,
+    );
 
-    fn execute_on_dest_context_readonly_raw<M: ManagedTypeApi>(
+    fn execute_on_dest_context_readonly_raw(
         &self,
         gas: u64,
-        address: &ManagedAddress<M>,
-        endpoint_name: &ManagedBuffer<M>,
-        arg_buffer: &ManagedArgBuffer<M>,
-    ) -> ManagedVec<M, ManagedBuffer<M>>;
+        address_handle: RawHandle,
+        endpoint_name_handle: RawHandle,
+        arg_buffer_handle: RawHandle,
+        result_handle: RawHandle,
+    );
 
     fn clean_return_data(&self);
 

--- a/framework/base/src/api/uncallable/send_api_uncallable.rs
+++ b/framework/base/src/api/uncallable/send_api_uncallable.rs
@@ -1,10 +1,4 @@
-use crate::{
-    api::{ManagedTypeApi, SendApi, SendApiImpl},
-    types::{
-        BigUint, CodeMetadata, EsdtTokenPayment, ManagedAddress, ManagedArgBuffer, ManagedBuffer,
-        ManagedVec,
-    },
-};
+use crate::api::{RawHandle, SendApi, SendApiImpl};
 
 use super::UncallableApi;
 
@@ -17,136 +11,143 @@ impl SendApi for UncallableApi {
 }
 
 impl SendApiImpl for UncallableApi {
-    fn transfer_value_execute<M: ManagedTypeApi>(
+    fn transfer_value_execute(
         &self,
-        _to: &ManagedAddress<M>,
-        _amount: &BigUint<M>,
+        _to_handle: RawHandle,
+        _amount_handle: RawHandle,
         _gas_limit: u64,
-        _endpoint_name: &ManagedBuffer<M>,
-        _arg_buffer: &ManagedArgBuffer<M>,
+        _endpoint_name_handle: RawHandle,
+        _arg_buffer_handle: RawHandle,
     ) -> Result<(), &'static [u8]> {
         unreachable!()
     }
 
-    fn multi_transfer_esdt_nft_execute<M: ManagedTypeApi>(
+    fn multi_transfer_esdt_nft_execute(
         &self,
-        _to: &ManagedAddress<M>,
-        _payments: &ManagedVec<M, EsdtTokenPayment<M>>,
+        _to_handle: RawHandle,
+        _payments_handle: RawHandle,
         _gas_limit: u64,
-        _endpoint_name: &ManagedBuffer<M>,
-        _arg_buffer: &ManagedArgBuffer<M>,
+        _endpoint_name_handle: RawHandle,
+        _arg_buffer_handle: RawHandle,
     ) -> Result<(), &'static [u8]> {
         unreachable!()
     }
 
-    fn async_call_raw<M: ManagedTypeApi>(
+    fn async_call_raw(
         &self,
-        _to: &ManagedAddress<M>,
-        _amount: &BigUint<M>,
-        _endpoint_name: &ManagedBuffer<M>,
-        _arg_buffer: &ManagedArgBuffer<M>,
+        _to_handle: RawHandle,
+        _amount_handle: RawHandle,
+        _endpoint_name_handle: RawHandle,
+        _arg_buffer_handle: RawHandle,
     ) -> ! {
         unreachable!()
     }
 
     fn create_async_call_raw(
         &self,
-        _to: Self::ManagedBufferHandle,
-        _amount: Self::BigIntHandle,
-        _endpoint_name: Self::ManagedBufferHandle,
-        _arg_buffer: Self::ManagedBufferHandle,
+        _to_handle: RawHandle,
+        _amount_handle: RawHandle,
+        _endpoint_name_handle: RawHandle,
+        _arg_buffer_handle: RawHandle,
         _success_callback: &'static str,
         _error_callback: &'static str,
         _gas: u64,
         _extra_gas_for_callback: u64,
-        _callback_closure: Self::ManagedBufferHandle,
+        _callback_closure: RawHandle,
     ) {
         unreachable!()
     }
 
-    fn deploy_contract<M: ManagedTypeApi>(
+    fn deploy_contract(
         &self,
         _gas: u64,
-        _amount: &BigUint<M>,
-        _code: &ManagedBuffer<M>,
-        _code_metadata: CodeMetadata,
-        _arg_buffer: &ManagedArgBuffer<M>,
-    ) -> (ManagedAddress<M>, ManagedVec<M, ManagedBuffer<M>>) {
-        unreachable!()
-    }
-
-    fn deploy_from_source_contract<M: ManagedTypeApi>(
-        &self,
-        _gas: u64,
-        _amount: &BigUint<M>,
-        _source_contract_address: &ManagedAddress<M>,
-        _code_metadata: CodeMetadata,
-        _arg_buffer: &ManagedArgBuffer<M>,
-    ) -> (ManagedAddress<M>, ManagedVec<M, ManagedBuffer<M>>) {
-        unreachable!()
-    }
-
-    fn upgrade_from_source_contract<M: ManagedTypeApi>(
-        &self,
-        _sc_address: &ManagedAddress<M>,
-        _gas: u64,
-        _amount: &BigUint<M>,
-        _source_contract_address: &ManagedAddress<M>,
-        _code_metadata: CodeMetadata,
-        _arg_buffer: &ManagedArgBuffer<M>,
+        _amount_handle: RawHandle,
+        _code_handle: RawHandle,
+        _code_metadata_handle: RawHandle,
+        _arg_buffer_handle: RawHandle,
+        _new_address_handle: RawHandle,
+        _result_handle: RawHandle,
     ) {
         unreachable!()
     }
 
-    fn upgrade_contract<M: ManagedTypeApi>(
+    fn deploy_from_source_contract(
         &self,
-        _sc_address: &ManagedAddress<M>,
         _gas: u64,
-        _amount: &BigUint<M>,
-        _code: &ManagedBuffer<M>,
-        _code_metadata: CodeMetadata,
-        _arg_buffer: &ManagedArgBuffer<M>,
+        _amount_handle: RawHandle,
+        _source_contract_address_handle: RawHandle,
+        _code_metadata_handle: RawHandle,
+        _arg_buffer_handle: RawHandle,
+        _new_address_handle: RawHandle,
+        _result_handle: RawHandle,
     ) {
         unreachable!()
     }
 
-    fn execute_on_dest_context_raw<M: ManagedTypeApi>(
+    fn upgrade_from_source_contract(
         &self,
+        _sc_address: RawHandle,
         _gas: u64,
-        _to: &ManagedAddress<M>,
-        _value: &BigUint<M>,
-        _endpoint_name: &ManagedBuffer<M>,
-        _arg_buffer: &ManagedArgBuffer<M>,
-    ) -> ManagedVec<M, ManagedBuffer<M>> {
+        _amount_handle: RawHandle,
+        _source_contract_address_handle: RawHandle,
+        _code_metadata_handle: RawHandle,
+        _arg_buffer_handle: RawHandle,
+    ) {
         unreachable!()
     }
 
-    fn execute_on_same_context_raw<M: ManagedTypeApi>(
+    fn upgrade_contract(
         &self,
+        _sc_address: RawHandle,
         _gas: u64,
-        _to: &ManagedAddress<M>,
-        _value: &BigUint<M>,
-        _endpoint_name: &ManagedBuffer<M>,
-        _arg_buffer: &ManagedArgBuffer<M>,
-    ) -> ManagedVec<M, ManagedBuffer<M>> {
+        _amount_handle: RawHandle,
+        _code_handle: RawHandle,
+        _code_metadata_handle: RawHandle,
+        _arg_buffer_handle: RawHandle,
+    ) {
         unreachable!()
     }
 
-    fn execute_on_dest_context_readonly_raw<M: ManagedTypeApi>(
+    fn execute_on_dest_context_raw(
         &self,
         _gas: u64,
-        _address: &ManagedAddress<M>,
-        _endpoint_name: &ManagedBuffer<M>,
-        _arg_buffer: &ManagedArgBuffer<M>,
-    ) -> ManagedVec<M, ManagedBuffer<M>> {
+        _address: RawHandle,
+        _value: RawHandle,
+        _endpoint_name_handle: RawHandle,
+        _arg_buffer_handle: RawHandle,
+        _result_handle: RawHandle,
+    ) {
+        unreachable!()
+    }
+
+    fn execute_on_same_context_raw(
+        &self,
+        _gas: u64,
+        _address: RawHandle,
+        _value: RawHandle,
+        _endpoint_name_handle: RawHandle,
+        _arg_buffer_handle: RawHandle,
+        _result_handle: RawHandle,
+    ) {
+        unreachable!()
+    }
+
+    fn execute_on_dest_context_readonly_raw(
+        &self,
+        _gas: u64,
+        _address: RawHandle,
+        _endpoint_name_handle: RawHandle,
+        _arg_buffer_handle: RawHandle,
+        _result_handle: RawHandle,
+    ) {
         unreachable!()
     }
 
     fn clean_return_data(&self) {
-        unreachable!();
+        unreachable!()
     }
 
     fn delete_from_return_data(&self, _index: usize) {
-        unreachable!();
+        unreachable!()
     }
 }

--- a/framework/base/src/contract_base/wrappers/send_raw_wrapper.rs
+++ b/framework/base/src/contract_base/wrappers/send_raw_wrapper.rs
@@ -1,7 +1,10 @@
 use core::marker::PhantomData;
 
 use crate::{
-    api::{const_handles, use_raw_handle, BlockchainApiImpl, CallTypeApi, SendApiImpl},
+    api::{
+        const_handles, use_raw_handle, BigIntApiImpl, BlockchainApiImpl, CallTypeApi,
+        HandleConstraints, ManagedBufferApiImpl, RawHandle, SendApiImpl, StaticVarApiImpl,
+    },
     types::{
         BigUint, CodeMetadata, EsdtTokenPayment, ManagedAddress, ManagedArgBuffer, ManagedBuffer,
         ManagedType, ManagedVec, TokenIdentifier,
@@ -26,40 +29,70 @@ where
         }
     }
 
-    pub fn direct_egld<D>(&self, to: &ManagedAddress<A>, amount: &BigUint<A>, data: D)
+    fn load_code_metadata_to_mb(
+        &self,
+        code_metadata: CodeMetadata,
+        code_metadata_handle: RawHandle,
+    ) {
+        let code_metadata_bytes = code_metadata.to_byte_array();
+        A::managed_type_impl().mb_overwrite(
+            use_raw_handle(code_metadata_handle),
+            &code_metadata_bytes[..],
+        );
+    }
+
+    pub fn direct_egld<D>(&self, to: &ManagedAddress<A>, egld_value: &BigUint<A>, data: D)
     where
         D: Into<ManagedBuffer<A>>,
     {
+        let empty_mb_handle: A::ManagedBufferHandle =
+            use_raw_handle(const_handles::MBUF_TEMPORARY_1);
+        A::managed_type_impl().mb_overwrite(empty_mb_handle.clone(), &[]);
+
         let _ = A::send_api_impl().transfer_value_execute(
-            to,
-            amount,
+            to.get_handle().get_raw_handle(),
+            egld_value.get_handle().get_raw_handle(),
             0,
-            &data.into(),
-            &ManagedArgBuffer::new(),
+            data.into().get_handle().get_raw_handle(),
+            empty_mb_handle.get_raw_handle(),
         );
     }
 
     pub fn direct_egld_execute(
         &self,
         to: &ManagedAddress<A>,
-        amount: &BigUint<A>,
+        egld_value: &BigUint<A>,
         gas_limit: u64,
         endpoint_name: &ManagedBuffer<A>,
         arg_buffer: &ManagedArgBuffer<A>,
     ) -> Result<(), &'static [u8]> {
-        A::send_api_impl().transfer_value_execute(to, amount, gas_limit, endpoint_name, arg_buffer)
+        A::send_api_impl().transfer_value_execute(
+            to.get_handle().get_raw_handle(),
+            egld_value.get_handle().get_raw_handle(),
+            gas_limit,
+            endpoint_name.get_handle().get_raw_handle(),
+            arg_buffer.get_handle().get_raw_handle(),
+        )
     }
 
     pub fn transfer_esdt_execute(
         &self,
         to: &ManagedAddress<A>,
         token: &TokenIdentifier<A>,
-        amount: &BigUint<A>,
+        egld_value: &BigUint<A>,
         gas_limit: u64,
         endpoint_name: &ManagedBuffer<A>,
         arg_buffer: &ManagedArgBuffer<A>,
     ) -> Result<(), &'static [u8]> {
-        self.transfer_esdt_nft_execute(to, token, 0, amount, gas_limit, endpoint_name, arg_buffer)
+        self.transfer_esdt_nft_execute(
+            to,
+            token,
+            0,
+            egld_value,
+            gas_limit,
+            endpoint_name,
+            arg_buffer,
+        )
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -68,13 +101,17 @@ where
         to: &ManagedAddress<A>,
         token: &TokenIdentifier<A>,
         nonce: u64,
-        amount: &BigUint<A>,
+        egld_value: &BigUint<A>,
         gas_limit: u64,
         endpoint_name: &ManagedBuffer<A>,
         arg_buffer: &ManagedArgBuffer<A>,
     ) -> Result<(), &'static [u8]> {
         let mut payments: ManagedVec<A, EsdtTokenPayment<A>> = ManagedVec::new();
-        payments.push(EsdtTokenPayment::new(token.clone(), nonce, amount.clone()));
+        payments.push(EsdtTokenPayment::new(
+            token.clone(),
+            nonce,
+            egld_value.clone(),
+        ));
         self.multi_esdt_transfer_execute(to, &payments, gas_limit, endpoint_name, arg_buffer)
     }
 
@@ -87,29 +124,34 @@ where
         arg_buffer: &ManagedArgBuffer<A>,
     ) -> Result<(), &'static [u8]> {
         A::send_api_impl().multi_transfer_esdt_nft_execute(
-            to,
-            payments,
+            to.get_handle().get_raw_handle(),
+            payments.get_handle().get_raw_handle(),
             gas_limit,
-            endpoint_name,
-            arg_buffer,
+            endpoint_name.get_handle().get_raw_handle(),
+            arg_buffer.get_handle().get_raw_handle(),
         )
     }
 
     pub fn async_call_raw(
         &self,
         to: &ManagedAddress<A>,
-        amount: &BigUint<A>,
+        egld_value: &BigUint<A>,
         endpoint_name: &ManagedBuffer<A>,
         arg_buffer: &ManagedArgBuffer<A>,
     ) -> ! {
-        A::send_api_impl().async_call_raw(to, amount, endpoint_name, arg_buffer)
+        A::send_api_impl().async_call_raw(
+            to.get_handle().get_raw_handle(),
+            egld_value.get_handle().get_raw_handle(),
+            endpoint_name.get_handle().get_raw_handle(),
+            arg_buffer.get_handle().get_raw_handle(),
+        )
     }
 
     #[allow(clippy::too_many_arguments)]
     pub fn create_async_call_raw(
         &self,
         to: &ManagedAddress<A>,
-        amount: &BigUint<A>,
+        egld_value: &BigUint<A>,
         endpoint_name: &ManagedBuffer<A>,
         arg_buffer: &ManagedArgBuffer<A>,
         success_callback: &'static str,
@@ -119,15 +161,17 @@ where
         serialized_callback_closure_args: &ManagedBuffer<A>,
     ) {
         A::send_api_impl().create_async_call_raw(
-            to.get_handle(),
-            amount.get_handle(),
-            endpoint_name.get_handle(),
-            arg_buffer.get_handle(),
+            to.get_handle().get_raw_handle(),
+            egld_value.get_handle().get_raw_handle(),
+            endpoint_name.get_handle().get_raw_handle(),
+            arg_buffer.get_handle().get_raw_handle(),
             success_callback,
             error_callback,
             gas,
             extra_gas_for_callback,
-            serialized_callback_closure_args.get_handle(),
+            serialized_callback_closure_args
+                .get_handle()
+                .get_raw_handle(),
         )
     }
 
@@ -138,12 +182,28 @@ where
     pub fn deploy_contract(
         &self,
         gas: u64,
-        amount: &BigUint<A>,
+        egld_value: &BigUint<A>,
         code: &ManagedBuffer<A>,
         code_metadata: CodeMetadata,
         arg_buffer: &ManagedArgBuffer<A>,
     ) -> (ManagedAddress<A>, ManagedVec<A, ManagedBuffer<A>>) {
-        A::send_api_impl().deploy_contract(gas, amount, code, code_metadata, arg_buffer)
+        let code_metadata_handle = const_handles::MBUF_TEMPORARY_1;
+        self.load_code_metadata_to_mb(code_metadata, code_metadata_handle);
+        let new_address_handle = A::static_var_api_impl().next_handle();
+        let result_handle = A::static_var_api_impl().next_handle();
+        A::send_api_impl().deploy_contract(
+            gas,
+            egld_value.get_handle().get_raw_handle(),
+            code.get_handle().get_raw_handle(),
+            code_metadata_handle,
+            arg_buffer.get_handle().get_raw_handle(),
+            new_address_handle,
+            result_handle,
+        );
+        (
+            ManagedAddress::from_raw_handle(new_address_handle),
+            ManagedVec::from_raw_handle(result_handle),
+        )
     }
 
     /// Deploys a new contract in the same shard by re-using the code of an already deployed source contract.
@@ -152,17 +212,27 @@ where
     pub fn deploy_from_source_contract(
         &self,
         gas: u64,
-        amount: &BigUint<A>,
+        egld_value: &BigUint<A>,
         source_contract_address: &ManagedAddress<A>,
         code_metadata: CodeMetadata,
         arg_buffer: &ManagedArgBuffer<A>,
     ) -> (ManagedAddress<A>, ManagedVec<A, ManagedBuffer<A>>) {
+        let code_metadata_handle = const_handles::MBUF_TEMPORARY_1;
+        self.load_code_metadata_to_mb(code_metadata, code_metadata_handle);
+        let new_address_handle = A::static_var_api_impl().next_handle();
+        let result_handle = A::static_var_api_impl().next_handle();
         A::send_api_impl().deploy_from_source_contract(
             gas,
-            amount,
-            source_contract_address,
-            code_metadata,
-            arg_buffer,
+            egld_value.get_handle().get_raw_handle(),
+            source_contract_address.get_handle().get_raw_handle(),
+            code_metadata_handle,
+            arg_buffer.get_handle().get_raw_handle(),
+            new_address_handle,
+            result_handle,
+        );
+        (
+            ManagedAddress::from_raw_handle(new_address_handle),
+            ManagedVec::from_raw_handle(result_handle),
         )
     }
 
@@ -170,18 +240,20 @@ where
         &self,
         sc_address: &ManagedAddress<A>,
         gas: u64,
-        amount: &BigUint<A>,
+        egld_value: &BigUint<A>,
         source_contract_address: &ManagedAddress<A>,
         code_metadata: CodeMetadata,
         arg_buffer: &ManagedArgBuffer<A>,
     ) {
+        let code_metadata_handle = const_handles::MBUF_TEMPORARY_1;
+        self.load_code_metadata_to_mb(code_metadata, code_metadata_handle);
         A::send_api_impl().upgrade_from_source_contract(
-            sc_address,
+            sc_address.get_handle().get_raw_handle(),
             gas,
-            amount,
-            source_contract_address,
-            code_metadata,
-            arg_buffer,
+            egld_value.get_handle().get_raw_handle(),
+            source_contract_address.get_handle().get_raw_handle(),
+            code_metadata_handle,
+            arg_buffer.get_handle().get_raw_handle(),
         )
     }
 
@@ -192,18 +264,20 @@ where
         &self,
         sc_address: &ManagedAddress<A>,
         gas: u64,
-        amount: &BigUint<A>,
+        egld_value: &BigUint<A>,
         code: &ManagedBuffer<A>,
         code_metadata: CodeMetadata,
         arg_buffer: &ManagedArgBuffer<A>,
     ) {
+        let code_metadata_handle = const_handles::MBUF_TEMPORARY_1;
+        self.load_code_metadata_to_mb(code_metadata, code_metadata_handle);
         A::send_api_impl().upgrade_contract(
-            sc_address,
+            sc_address.get_handle().get_raw_handle(),
             gas,
-            amount,
-            code,
-            code_metadata,
-            arg_buffer,
+            egld_value.get_handle().get_raw_handle(),
+            code.get_handle().get_raw_handle(),
+            code_metadata_handle,
+            arg_buffer.get_handle().get_raw_handle(),
         )
     }
 
@@ -216,13 +290,16 @@ where
         endpoint_name: &ManagedBuffer<A>,
         arg_buffer: &ManagedArgBuffer<A>,
     ) -> ManagedVec<A, ManagedBuffer<A>> {
+        let result_handle = A::static_var_api_impl().next_handle();
         A::send_api_impl().execute_on_dest_context_raw(
             gas,
-            address,
-            value,
-            endpoint_name,
-            arg_buffer,
-        )
+            address.get_handle().get_raw_handle(),
+            value.get_handle().get_raw_handle(),
+            endpoint_name.get_handle().get_raw_handle(),
+            arg_buffer.get_handle().get_raw_handle(),
+            result_handle,
+        );
+        ManagedVec::from_raw_handle(result_handle)
     }
 
     pub fn execute_on_same_context_raw(
@@ -233,13 +310,16 @@ where
         endpoint_name: &ManagedBuffer<A>,
         arg_buffer: &ManagedArgBuffer<A>,
     ) -> ManagedVec<A, ManagedBuffer<A>> {
+        let result_handle = A::static_var_api_impl().next_handle();
         A::send_api_impl().execute_on_same_context_raw(
             gas,
-            address,
-            value,
-            endpoint_name,
-            arg_buffer,
-        )
+            address.get_handle().get_raw_handle(),
+            value.get_handle().get_raw_handle(),
+            endpoint_name.get_handle().get_raw_handle(),
+            arg_buffer.get_handle().get_raw_handle(),
+            result_handle,
+        );
+        ManagedVec::from_raw_handle(result_handle)
     }
 
     /// Same shard, in-line execution of another contract.
@@ -250,12 +330,15 @@ where
         endpoint_name: &ManagedBuffer<A>,
         arg_buffer: &ManagedArgBuffer<A>,
     ) -> ManagedVec<A, ManagedBuffer<A>> {
+        let result_handle = A::static_var_api_impl().next_handle();
         A::send_api_impl().execute_on_dest_context_readonly_raw(
             gas,
-            address,
-            endpoint_name,
-            arg_buffer,
-        )
+            address.get_handle().get_raw_handle(),
+            endpoint_name.get_handle().get_raw_handle(),
+            arg_buffer.get_handle().get_raw_handle(),
+            result_handle,
+        );
+        ManagedVec::from_raw_handle(result_handle)
     }
 
     /// Allows synchronously calling a local function by name. Execution is resumed afterwards.
@@ -269,18 +352,21 @@ where
         let own_address_handle: A::ManagedBufferHandle =
             use_raw_handle(const_handles::MBUF_TEMPORARY_1);
         A::blockchain_api_impl().load_sc_address_managed(own_address_handle.clone());
+        let egld_value_handle = A::managed_type_impl().bi_new_zero();
 
-        let results = A::send_api_impl().execute_on_dest_context_raw(
+        let result_handle = A::static_var_api_impl().next_handle();
+        A::send_api_impl().execute_on_dest_context_raw(
             gas,
-            &ManagedAddress::from_handle(own_address_handle),
-            &BigUint::zero(),
-            function_name,
-            arg_buffer,
+            own_address_handle.get_raw_handle(),
+            egld_value_handle.get_raw_handle(),
+            function_name.get_handle().get_raw_handle(),
+            arg_buffer.get_handle().get_raw_handle(),
+            result_handle,
         );
 
         self.clean_return_data();
 
-        results
+        ManagedVec::from_raw_handle(result_handle)
     }
 
     pub fn clean_return_data(&self) {

--- a/vm/src/api/blockchain_api_mock.rs
+++ b/vm/src/api/blockchain_api_mock.rs
@@ -326,7 +326,7 @@ impl DebugApi {
             royalties_handle,
             num_bigint::BigInt::from(instance.metadata.royalties),
         );
-        m_types.mb_set_vec(uris_handle, instance.metadata.uri.clone());
+        m_types.mb_set_vec_of_bytes(uris_handle, instance.metadata.uri.clone());
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/vm/src/api/call_value_api_mock.rs
+++ b/vm/src/api/call_value_api_mock.rs
@@ -36,10 +36,7 @@ impl CallValueApiImpl for DebugApi {
     fn load_all_esdt_transfers(&self, dest_handle: Self::ManagedBufferHandle) {
         let transfers = self.input_ref().received_esdt();
         self.m_types_borrow_mut()
-            .write_all_esdt_transfers_to_managed_vec(
-                dest_handle.get_raw_handle_unchecked(),
-                transfers,
-            );
+            .mb_set_vec_of_esdt_payments(dest_handle.get_raw_handle_unchecked(), transfers);
     }
 
     fn esdt_num_transfers(&self) -> usize {

--- a/vm/src/tx_mock/tx_input.rs
+++ b/vm/src/tx_mock/tx_input.rs
@@ -66,7 +66,7 @@ impl TxInput {
 }
 
 /// Models ESDT transfers between accounts.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TxTokenTransfer {
     pub token_identifier: Vec<u8>,
     pub nonce: u64,

--- a/vm/src/tx_mock/tx_input_function.rs
+++ b/vm/src/tx_mock/tx_input_function.rs
@@ -64,6 +64,10 @@ impl TxFunctionName {
         self.0.into_owned()
     }
 
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.into_string().into_bytes()
+    }
+
     pub fn as_str(&self) -> &str {
         &self.0
     }

--- a/vm/src/tx_mock/tx_managed_types/tx_big_int.rs
+++ b/vm/src/tx_mock/tx_managed_types/tx_big_int.rs
@@ -19,6 +19,12 @@ impl TxManagedTypes {
         self.big_int_map.get(handle).clone()
     }
 
+    pub fn bu_get(&self, handle: RawHandle) -> num_bigint::BigUint {
+        self.bi_get(handle)
+            .try_into()
+            .expect("number cannot be negative")
+    }
+
     pub fn bi_to_i64(&self, handle: RawHandle) -> Option<i64> {
         let bi = self.bi_get(handle);
         big_int_to_i64(&bi)

--- a/vm/src/vm_hooks/vh_handler/vh_blockchain.rs
+++ b/vm/src/vm_hooks/vh_handler/vh_blockchain.rs
@@ -264,7 +264,7 @@ pub trait VMHooksBlockchain: VMHooksHandlerSource {
             royalties_handle,
             num_bigint::BigInt::from(instance.metadata.royalties),
         );
-        m_types.mb_set_vec(uris_handle, instance.metadata.uri.clone());
+        m_types.mb_set_vec_of_bytes(uris_handle, instance.metadata.uri.clone());
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/vm/src/vm_hooks/vh_handler/vh_call_value.rs
+++ b/vm/src/vm_hooks/vh_handler/vh_call_value.rs
@@ -28,7 +28,7 @@ pub trait VMHooksCallValue: VMHooksHandlerSource + VMHooksManagedTypes {
     fn load_all_esdt_transfers(&self, dest_handle: RawHandle) {
         let transfers = self.input_ref().received_esdt();
         self.m_types_borrow_mut()
-            .write_all_esdt_transfers_to_managed_vec(dest_handle, transfers);
+            .mb_set_vec_of_esdt_payments(dest_handle, transfers);
     }
 
     fn esdt_num_transfers(&self) -> usize {

--- a/vm/src/vm_hooks/vh_handler/vh_log.rs
+++ b/vm/src/vm_hooks/vh_handler/vh_log.rs
@@ -4,7 +4,7 @@ use crate::{tx_mock::TxLog, vm_hooks::VMHooksHandlerSource};
 
 pub trait VMHooksLog: VMHooksHandlerSource {
     fn managed_write_log(&self, topics_handle: RawHandle, data_handle: RawHandle) {
-        let topics = self.m_types_borrow().mb_get_vec(topics_handle);
+        let topics = self.m_types_borrow().mb_get_vec_of_bytes(topics_handle);
         let data = self.m_types_borrow().mb_get(data_handle).to_vec();
         self.push_tx_log(TxLog {
             address: self.input_ref().to.clone(),


### PR DESCRIPTION
SendApi was the last unreformed API. It was still using high-level objects.

This long technical debt is finally fixed. It is now a very thin layer over the EI.