### PR TITLE
DebuggerApi - handle safety & context

### DIFF
--- a/contracts/feature-tests/rust-testing-framework-tester/tests/rust_mandos_v1_test.rs
+++ b/contracts/feature-tests/rust-testing-framework-tester/tests/rust_mandos_v1_test.rs
@@ -8,8 +8,8 @@ use multiversx_sc::{
     types::{Address, BigUint, EsdtLocalRole, EsdtTokenPayment, ManagedVec, TokenIdentifier},
 };
 use multiversx_sc_scenario::{
-    assert_values_eq, managed_address, managed_biguint, managed_buffer, managed_token_id,
-    rust_biguint, testing_framework::*, DebugApi,
+    api::DebuggerApi as DebugApi, assert_values_eq, managed_address, managed_biguint,
+    managed_buffer, managed_token_id, rust_biguint, testing_framework::*,
 };
 use rust_testing_framework_tester::{dummy_module::DummyModule, *};
 
@@ -1187,6 +1187,7 @@ fn managed_environment_test() {
 }
 
 #[test]
+#[should_panic] // VMHooksApi misuse: operation called with handles from 2 different contexts
 fn managed_environment_consistency_test() {
     let mut wrapper = BlockchainStateWrapper::new();
     let adder_wrapper = wrapper.create_sc_account(
@@ -1208,6 +1209,7 @@ fn managed_environment_consistency_test() {
 }
 
 #[test]
+#[should_panic] // VMHooksApi misuse: operation called with handles from 2 different contexts
 fn test_managed_values_standalone_consistency() {
     let _ = DebugApi::dummy();
 

--- a/framework/scenario/src/api/core_api_vh/call_value_api_vh.rs
+++ b/framework/scenario/src/api/core_api_vh/call_value_api_vh.rs
@@ -16,11 +16,15 @@ impl<VHB: VMHooksApiBackend> CallValueApiImpl for VMHooksApi<VHB> {
     }
 
     fn load_egld_value(&self, dest: Self::BigIntHandle) {
+        self.assert_live_handle(&dest);
         self.with_vm_hooks(|vh| vh.big_int_get_call_value(dest.get_raw_handle_unchecked()));
     }
 
     fn load_all_esdt_transfers(&self, dest_handle: Self::ManagedBufferHandle) {
-        self.with_vm_hooks(|vh| vh.managed_get_multi_esdt_call_value(dest_handle.get_raw_handle_unchecked()));
+        self.assert_live_handle(&dest_handle);
+        self.with_vm_hooks(|vh| {
+            vh.managed_get_multi_esdt_call_value(dest_handle.get_raw_handle_unchecked())
+        });
     }
 
     fn esdt_num_transfers(&self) -> usize {

--- a/framework/scenario/src/api/core_api_vh/crypto_api_vh.rs
+++ b/framework/scenario/src/api/core_api_vh/crypto_api_vh.rs
@@ -19,8 +19,11 @@ impl<VHB: VMHooksApiBackend> CryptoApiImpl for VMHooksApi<VHB> {
         result_handle: Self::ManagedBufferHandle,
         data_handle: Self::ManagedBufferHandle,
     ) {
-        self.with_vm_hooks(|vh| {
-            vh.managed_sha256(data_handle.get_raw_handle_unchecked(), result_handle.get_raw_handle_unchecked())
+        self.with_vm_hooks_ctx_2(&result_handle, &data_handle, |vh| {
+            vh.managed_sha256(
+                data_handle.get_raw_handle_unchecked(),
+                result_handle.get_raw_handle_unchecked(),
+            )
         });
     }
 
@@ -29,8 +32,11 @@ impl<VHB: VMHooksApiBackend> CryptoApiImpl for VMHooksApi<VHB> {
         result_handle: Self::ManagedBufferHandle,
         data_handle: Self::ManagedBufferHandle,
     ) {
-        self.with_vm_hooks(|vh| {
-            vh.managed_keccak256(data_handle.get_raw_handle_unchecked(), result_handle.get_raw_handle_unchecked())
+        self.with_vm_hooks_ctx_2(&result_handle, &data_handle, |vh| {
+            vh.managed_keccak256(
+                data_handle.get_raw_handle_unchecked(),
+                result_handle.get_raw_handle_unchecked(),
+            )
         });
     }
 
@@ -57,7 +63,7 @@ impl<VHB: VMHooksApiBackend> CryptoApiImpl for VMHooksApi<VHB> {
         message: Self::ManagedBufferHandle,
         signature: Self::ManagedBufferHandle,
     ) {
-        self.with_vm_hooks(|vh| {
+        self.with_vm_hooks_ctx_3(&key, &message, &signature, |vh| {
             vh.managed_verify_ed25519(
                 key.get_raw_handle_unchecked(),
                 message.get_raw_handle_unchecked(),

--- a/framework/scenario/src/api/core_api_vh/endpoint_arg_api_vh.rs
+++ b/framework/scenario/src/api/core_api_vh/endpoint_arg_api_vh.rs
@@ -16,10 +16,12 @@ impl<VHB: VMHooksApiBackend> EndpointArgumentApiImpl for VMHooksApi<VHB> {
     }
 
     fn load_argument_managed_buffer(&self, arg_id: i32, dest: Self::ManagedBufferHandle) {
+        self.assert_live_handle(&dest);
         self.with_vm_hooks(|vh| vh.mbuffer_get_argument(arg_id, dest.get_raw_handle_unchecked()));
     }
 
     fn load_callback_closure_buffer(&self, dest: Self::ManagedBufferHandle) {
+        self.assert_live_handle(&dest);
         self.with_vm_hooks(|vh| vh.managed_get_callback_closure(dest.get_raw_handle_unchecked()));
     }
 

--- a/framework/scenario/src/api/core_api_vh/endpoint_finish_api_vh.rs
+++ b/framework/scenario/src/api/core_api_vh/endpoint_finish_api_vh.rs
@@ -21,14 +21,17 @@ impl<VHB: VMHooksApiBackend> EndpointFinishApiImpl for VMHooksApi<VHB> {
     }
 
     fn finish_big_int_raw(&self, handle: Self::BigIntHandle) {
+        self.assert_live_handle(&handle);
         self.with_vm_hooks(|vh| vh.big_int_finish_signed(handle.get_raw_handle_unchecked()));
     }
 
     fn finish_big_uint_raw(&self, handle: Self::BigIntHandle) {
+        self.assert_live_handle(&handle);
         self.with_vm_hooks(|vh| vh.big_int_finish_unsigned(handle.get_raw_handle_unchecked()));
     }
 
     fn finish_managed_buffer_raw(&self, handle: Self::ManagedBufferHandle) {
+        self.assert_live_handle(&handle);
         self.with_vm_hooks(|vh| vh.mbuffer_finish(handle.get_raw_handle_unchecked()));
     }
 

--- a/framework/scenario/src/api/core_api_vh/error_api_vh.rs
+++ b/framework/scenario/src/api/core_api_vh/error_api_vh.rs
@@ -25,7 +25,8 @@ impl<VHB: VMHooksApiBackend> ErrorApiImpl for VMHooksApi<VHB> {
     }
 
     fn signal_error_from_buffer(&self, message_handle: Self::ManagedBufferHandle) -> ! {
-        self.with_vm_hooks(|vh| vh.managed_signal_error(message_handle.get_raw_handle_unchecked()));
+        self.assert_live_handle(&message_handle);
+        self.with_vm_hooks(|vh| vh.managed_signal_error(message_handle.get_raw_handle()));
 
         // even though not explicitly stated in the VM hooks definition,
         // `managed_signal_error` is expected to terminate execution

--- a/framework/scenario/src/api/core_api_vh/log_api_vh.rs
+++ b/framework/scenario/src/api/core_api_vh/log_api_vh.rs
@@ -17,7 +17,10 @@ impl<VHB: VMHooksApiBackend> LogApiImpl for VMHooksApi<VHB> {
         data_handle: Self::ManagedBufferHandle,
     ) {
         self.with_vm_hooks(|vh| {
-            vh.managed_write_log(topics_handle.get_raw_handle_unchecked(), data_handle.get_raw_handle_unchecked())
+            vh.managed_write_log(
+                topics_handle.get_raw_handle_unchecked(),
+                data_handle.get_raw_handle_unchecked(),
+            )
         });
     }
 }

--- a/framework/scenario/src/api/core_api_vh/storage_api_vh.rs
+++ b/framework/scenario/src/api/core_api_vh/storage_api_vh.rs
@@ -18,8 +18,13 @@ impl<VHB: VMHooksApiBackend> StorageReadApiImpl for VMHooksApi<VHB> {
         key_handle: Self::ManagedBufferHandle,
         dest: Self::ManagedBufferHandle,
     ) {
+        self.assert_live_handle(&key_handle);
+        self.assert_live_handle(&dest);
         self.with_vm_hooks(|vh| {
-            vh.mbuffer_storage_load(key_handle.get_raw_handle_unchecked(), dest.get_raw_handle_unchecked())
+            vh.mbuffer_storage_load(
+                key_handle.get_raw_handle_unchecked(),
+                dest.get_raw_handle_unchecked(),
+            )
         });
     }
 
@@ -29,6 +34,9 @@ impl<VHB: VMHooksApiBackend> StorageReadApiImpl for VMHooksApi<VHB> {
         key_handle: Self::ManagedBufferHandle,
         dest: Self::ManagedBufferHandle,
     ) {
+        self.assert_live_handle(&address_handle);
+        self.assert_live_handle(&key_handle);
+        self.assert_live_handle(&dest);
         self.with_vm_hooks(|vh| {
             vh.mbuffer_storage_load_from_address(
                 address_handle.get_raw_handle_unchecked(),
@@ -53,8 +61,13 @@ impl<VHB: VMHooksApiBackend> StorageWriteApiImpl for VMHooksApi<VHB> {
         key_handle: Self::ManagedBufferHandle,
         value_handle: Self::ManagedBufferHandle,
     ) {
+        self.assert_live_handle(&key_handle);
+        self.assert_live_handle(&value_handle);
         self.with_vm_hooks(|vh| {
-            vh.mbuffer_storage_store(key_handle.get_raw_handle_unchecked(), value_handle.get_raw_handle_unchecked());
+            vh.mbuffer_storage_store(
+                key_handle.get_raw_handle_unchecked(),
+                value_handle.get_raw_handle_unchecked(),
+            );
         });
     }
 }

--- a/framework/scenario/src/api/impl_vh/debug_handle_vh.rs
+++ b/framework/scenario/src/api/impl_vh/debug_handle_vh.rs
@@ -13,7 +13,7 @@ pub struct DebugHandle {
 }
 
 impl DebugHandle {
-    fn assert_current_context(&self) {
+    pub fn assert_current_context(&self) {
         assert!(
             Rc::ptr_eq(&self.context, &TxContextStack::static_peek()),
             "Managed value not used in original context"

--- a/framework/scenario/src/api/impl_vh/vm_hooks_api.rs
+++ b/framework/scenario/src/api/impl_vh/vm_hooks_api.rs
@@ -28,6 +28,48 @@ impl<VHB: VMHooksApiBackend> VMHooksApi<VHB> {
         VHB::with_vm_hooks(f)
     }
 
+    /// Works with the VM hooks given by the context of 1 handle.
+    pub fn with_vm_hooks_ctx_1<R, F>(&self, handle: &VHB::HandleType, f: F) -> R
+    where
+        F: FnOnce(&dyn VMHooks) -> R,
+    {
+        VHB::with_vm_hooks_ctx_1(handle.clone(), f)
+    }
+
+    /// Works with the VM hooks given by the context of 2 handles.
+    pub fn with_vm_hooks_ctx_2<R, F>(
+        &self,
+        handle1: &VHB::HandleType,
+        handle2: &VHB::HandleType,
+        f: F,
+    ) -> R
+    where
+        F: FnOnce(&dyn VMHooks) -> R,
+    {
+        VHB::with_vm_hooks_ctx_2(handle1.clone(), handle2.clone(), f)
+    }
+
+    /// Works with the VM hooks given by the context of 3 handles.
+    pub fn with_vm_hooks_ctx_3<R, F>(
+        &self,
+        handle1: &VHB::HandleType,
+        handle2: &VHB::HandleType,
+        handle3: &VHB::HandleType,
+        f: F,
+    ) -> R
+    where
+        F: FnOnce(&dyn VMHooks) -> R,
+    {
+        VHB::with_vm_hooks_ctx_3(handle1.clone(), handle2.clone(), handle3.clone(), f)
+    }
+
+    /// Checks that the handle refers to the current active context (if possible).
+    ///
+    /// This is to prevent working with handles pointing to the wrong context, when debugging.
+    pub fn assert_live_handle(&self, handle: &VHB::HandleType) {
+        VHB::assert_live_handle(handle);
+    }
+
     /// Static data does not belong to the VM, or to the VM hooks. It belongs to the contract only.
     pub fn with_static_data<R, F>(&self, f: F) -> R
     where

--- a/framework/scenario/src/api/impl_vh/vm_hooks_backend.rs
+++ b/framework/scenario/src/api/impl_vh/vm_hooks_backend.rs
@@ -10,6 +10,36 @@ pub trait VMHooksApiBackend: Clone + 'static {
     where
         F: FnOnce(&dyn VMHooks) -> R;
 
+    fn with_vm_hooks_ctx_1<R, F>(_handle: Self::HandleType, f: F) -> R
+    where
+        F: FnOnce(&dyn VMHooks) -> R,
+    {
+        Self::with_vm_hooks(f)
+    }
+
+    fn with_vm_hooks_ctx_2<R, F>(_handle1: Self::HandleType, _handle2: Self::HandleType, f: F) -> R
+    where
+        F: FnOnce(&dyn VMHooks) -> R,
+    {
+        Self::with_vm_hooks(f)
+    }
+
+    fn with_vm_hooks_ctx_3<R, F>(
+        _handle1: Self::HandleType,
+        _handle2: Self::HandleType,
+        _handle3: Self::HandleType,
+        f: F,
+    ) -> R
+    where
+        F: FnOnce(&dyn VMHooks) -> R,
+    {
+        Self::with_vm_hooks(f)
+    }
+
+    fn assert_live_handle(_handle: &Self::HandleType) {
+        // by default, no check
+    }
+
     /// Static data does not belong to the VM, or to the VM hooks. It belongs to the contract only.
     fn with_static_data<R, F>(f: F) -> R
     where

--- a/framework/scenario/src/api/managed_type_api_vh.rs
+++ b/framework/scenario/src/api/managed_type_api_vh.rs
@@ -22,10 +22,10 @@ impl<VHB: VMHooksApiBackend> ManagedTypeApiImpl for VMHooksApi<VHB> {
         buffer_handle: Self::ManagedBufferHandle,
         big_int_handle: Self::BigIntHandle,
     ) {
-        self.with_vm_hooks(|vh| {
+        self.with_vm_hooks_ctx_2(&buffer_handle, &big_int_handle, |vh| {
             vh.mbuffer_to_big_int_unsigned(
-                buffer_handle.get_raw_handle(),
-                big_int_handle.get_raw_handle(),
+                buffer_handle.get_raw_handle_unchecked(),
+                big_int_handle.get_raw_handle_unchecked(),
             )
         });
     }
@@ -35,10 +35,10 @@ impl<VHB: VMHooksApiBackend> ManagedTypeApiImpl for VMHooksApi<VHB> {
         buffer_handle: Self::ManagedBufferHandle,
         big_int_handle: Self::BigIntHandle,
     ) {
-        self.with_vm_hooks(|vh| {
+        self.with_vm_hooks_ctx_2(&buffer_handle, &big_int_handle, |vh| {
             vh.mbuffer_to_big_int_signed(
-                buffer_handle.get_raw_handle(),
-                big_int_handle.get_raw_handle(),
+                buffer_handle.get_raw_handle_unchecked(),
+                big_int_handle.get_raw_handle_unchecked(),
             )
         });
     }
@@ -48,10 +48,10 @@ impl<VHB: VMHooksApiBackend> ManagedTypeApiImpl for VMHooksApi<VHB> {
         big_int_handle: Self::BigIntHandle,
         buffer_handle: Self::ManagedBufferHandle,
     ) {
-        self.with_vm_hooks(|vh| {
+        self.with_vm_hooks_ctx_2(&buffer_handle, &big_int_handle, |vh| {
             vh.mbuffer_from_big_int_unsigned(
-                buffer_handle.get_raw_handle(),
-                big_int_handle.get_raw_handle(),
+                buffer_handle.get_raw_handle_unchecked(),
+                big_int_handle.get_raw_handle_unchecked(),
             )
         });
     }
@@ -61,10 +61,10 @@ impl<VHB: VMHooksApiBackend> ManagedTypeApiImpl for VMHooksApi<VHB> {
         big_int_handle: Self::BigIntHandle,
         buffer_handle: Self::ManagedBufferHandle,
     ) {
-        self.with_vm_hooks(|vh| {
+        self.with_vm_hooks_ctx_2(&buffer_handle, &big_int_handle, |vh| {
             vh.mbuffer_from_big_int_signed(
-                buffer_handle.get_raw_handle(),
-                big_int_handle.get_raw_handle(),
+                buffer_handle.get_raw_handle_unchecked(),
+                big_int_handle.get_raw_handle_unchecked(),
             )
         });
     }
@@ -74,10 +74,10 @@ impl<VHB: VMHooksApiBackend> ManagedTypeApiImpl for VMHooksApi<VHB> {
         buffer_handle: Self::ManagedBufferHandle,
         big_float_handle: Self::BigFloatHandle,
     ) {
-        self.with_vm_hooks(|vh| {
+        self.with_vm_hooks_ctx_2(&buffer_handle, &big_float_handle, |vh| {
             vh.mbuffer_to_big_float(
-                buffer_handle.get_raw_handle(),
-                big_float_handle.get_raw_handle(),
+                buffer_handle.get_raw_handle_unchecked(),
+                big_float_handle.get_raw_handle_unchecked(),
             )
         });
     }
@@ -87,10 +87,10 @@ impl<VHB: VMHooksApiBackend> ManagedTypeApiImpl for VMHooksApi<VHB> {
         big_float_handle: Self::BigFloatHandle,
         buffer_handle: Self::ManagedBufferHandle,
     ) {
-        self.with_vm_hooks(|vh| {
+        self.with_vm_hooks_ctx_2(&buffer_handle, &big_float_handle, |vh| {
             vh.mbuffer_from_big_float(
-                buffer_handle.get_raw_handle(),
-                big_float_handle.get_raw_handle(),
+                buffer_handle.get_raw_handle_unchecked(),
+                big_float_handle.get_raw_handle_unchecked(),
             )
         });
     }

--- a/framework/scenario/src/api/managed_type_api_vh/big_int_api_vh.rs
+++ b/framework/scenario/src/api/managed_type_api_vh/big_int_api_vh.rs
@@ -5,15 +5,15 @@ use multiversx_sc::api::{use_raw_handle, BigIntApiImpl, HandleConstraints, Sign}
 use crate::api::{i32_to_bool, VMHooksApi, VMHooksApiBackend};
 
 macro_rules! binary_op_method {
-    ($api_method_name:ident, $vh_method_name:ident) => {
+    ($api_method_name:ident, $hook_name:ident) => {
         fn $api_method_name(
             &self,
             dest: Self::BigIntHandle,
             x: Self::BigIntHandle,
             y: Self::BigIntHandle,
         ) {
-            self.with_vm_hooks(|vh| {
-                vh.$vh_method_name(
+            self.with_vm_hooks_ctx_3(&dest, &x, &y, |vh| {
+                vh.$hook_name(
                     dest.get_raw_handle_unchecked(),
                     x.get_raw_handle_unchecked(),
                     y.get_raw_handle_unchecked(),
@@ -24,9 +24,14 @@ macro_rules! binary_op_method {
 }
 
 macro_rules! unary_op_method {
-    ($api_method_name:ident, $vh_method_name:ident) => {
+    ($api_method_name:ident, $hook_name:ident) => {
         fn $api_method_name(&self, dest: Self::BigIntHandle, x: Self::BigIntHandle) {
-            self.with_vm_hooks(|vh| vh.$vh_method_name(dest.get_raw_handle_unchecked(), x.get_raw_handle_unchecked()));
+            self.with_vm_hooks_ctx_2(&dest, &x, |vh| {
+                vh.$hook_name(
+                    dest.get_raw_handle_unchecked(),
+                    x.get_raw_handle_unchecked(),
+                )
+            });
         }
     };
 }
@@ -38,11 +43,13 @@ impl<VHB: VMHooksApiBackend> BigIntApiImpl for VMHooksApi<VHB> {
     }
 
     fn bi_set_int64(&self, destination: Self::BigIntHandle, value: i64) {
-        self.with_vm_hooks(|vh| vh.big_int_set_int64(destination.get_raw_handle_unchecked(), value));
+        self.with_vm_hooks_ctx_1(&destination, |vh| {
+            vh.big_int_set_int64(destination.get_raw_handle_unchecked(), value)
+        });
     }
 
     fn bi_to_i64(&self, reference: Self::BigIntHandle) -> Option<i64> {
-        self.with_vm_hooks(|vh| {
+        self.with_vm_hooks_ctx_1(&reference, |vh| {
             let is_i64_result = vh.big_int_is_int64(reference.get_raw_handle_unchecked());
             if i32_to_bool(is_i64_result) {
                 Some(vh.big_int_get_int64(reference.get_raw_handle_unchecked()))
@@ -62,7 +69,8 @@ impl<VHB: VMHooksApiBackend> BigIntApiImpl for VMHooksApi<VHB> {
     unary_op_method! {bi_neg, big_int_neg}
 
     fn bi_sign(&self, x: Self::BigIntHandle) -> Sign {
-        let sign_raw = self.with_vm_hooks(|vh| vh.big_int_sign(x.get_raw_handle_unchecked()));
+        let sign_raw =
+            self.with_vm_hooks_ctx_1(&x, |vh| vh.big_int_sign(x.get_raw_handle_unchecked()));
         match sign_raw.cmp(&0) {
             Ordering::Greater => Sign::Plus,
             Ordering::Equal => Sign::NoSign,
@@ -71,8 +79,9 @@ impl<VHB: VMHooksApiBackend> BigIntApiImpl for VMHooksApi<VHB> {
     }
 
     fn bi_cmp(&self, x: Self::BigIntHandle, y: Self::BigIntHandle) -> Ordering {
-        let ordering_raw =
-            self.with_vm_hooks(|vh| vh.big_int_cmp(x.get_raw_handle_unchecked(), y.get_raw_handle_unchecked()));
+        let ordering_raw = self.with_vm_hooks_ctx_2(&x, &y, |vh| {
+            vh.big_int_cmp(x.get_raw_handle_unchecked(), y.get_raw_handle_unchecked())
+        });
         ordering_raw.cmp(&0)
     }
 
@@ -80,7 +89,7 @@ impl<VHB: VMHooksApiBackend> BigIntApiImpl for VMHooksApi<VHB> {
     binary_op_method! {bi_pow, big_int_pow}
 
     fn bi_log2(&self, x: Self::BigIntHandle) -> u32 {
-        self.with_vm_hooks(|vh| vh.big_int_log2(x.get_raw_handle_unchecked())) as u32
+        self.with_vm_hooks_ctx_1(&x, |vh| vh.big_int_log2(x.get_raw_handle_unchecked())) as u32
     }
 
     binary_op_method! {bi_and, big_int_and}
@@ -88,20 +97,31 @@ impl<VHB: VMHooksApiBackend> BigIntApiImpl for VMHooksApi<VHB> {
     binary_op_method! {bi_xor, big_int_xor}
 
     fn bi_shr(&self, dest: Self::BigIntHandle, x: Self::BigIntHandle, bits: usize) {
-        self.with_vm_hooks(|vh| {
-            vh.big_int_shr(dest.get_raw_handle_unchecked(), x.get_raw_handle_unchecked(), bits as i32)
+        self.with_vm_hooks_ctx_2(&dest, &x, |vh| {
+            vh.big_int_shr(
+                dest.get_raw_handle_unchecked(),
+                x.get_raw_handle_unchecked(),
+                bits as i32,
+            )
         });
     }
 
     fn bi_shl(&self, dest: Self::BigIntHandle, x: Self::BigIntHandle, bits: usize) {
-        self.with_vm_hooks(|vh| {
-            vh.big_int_shl(dest.get_raw_handle_unchecked(), x.get_raw_handle_unchecked(), bits as i32)
+        self.with_vm_hooks_ctx_2(&dest, &x, |vh| {
+            vh.big_int_shl(
+                dest.get_raw_handle_unchecked(),
+                x.get_raw_handle_unchecked(),
+                bits as i32,
+            )
         });
     }
 
     fn bi_to_string(&self, bi_handle: Self::BigIntHandle, str_handle: Self::ManagedBufferHandle) {
-        self.with_vm_hooks(|vh| {
-            vh.big_int_to_string(bi_handle.get_raw_handle_unchecked(), str_handle.get_raw_handle_unchecked())
+        self.with_vm_hooks_ctx_2(&bi_handle, &str_handle, |vh| {
+            vh.big_int_to_string(
+                bi_handle.get_raw_handle_unchecked(),
+                str_handle.get_raw_handle_unchecked(),
+            )
         });
     }
 }

--- a/framework/scenario/src/api/managed_type_api_vh/managed_buffer_api_vh.rs
+++ b/framework/scenario/src/api/managed_type_api_vh/managed_buffer_api_vh.rs
@@ -1,10 +1,9 @@
+use crate::api::{i32_to_bool, VMHooksApi, VMHooksApiBackend};
 use multiversx_chain_vm::{executor::MemPtr, mem_conv};
 use multiversx_sc::{
     api::{use_raw_handle, HandleConstraints, InvalidSliceError, ManagedBufferApiImpl},
     types::BoxedBytes,
 };
-
-use crate::api::{i32_to_bool, VMHooksApi, VMHooksApiBackend};
 
 impl<VHB: VMHooksApiBackend> ManagedBufferApiImpl for VMHooksApi<VHB> {
     fn mb_new_empty(&self) -> Self::ManagedBufferHandle {
@@ -22,17 +21,21 @@ impl<VHB: VMHooksApiBackend> ManagedBufferApiImpl for VMHooksApi<VHB> {
     }
 
     fn mb_len(&self, handle: Self::ManagedBufferHandle) -> usize {
-        self.with_vm_hooks(|vh| vh.mbuffer_get_length(handle.get_raw_handle_unchecked()) as usize)
+        self.with_vm_hooks_ctx_1(&handle, |vh| {
+            vh.mbuffer_get_length(handle.get_raw_handle_unchecked()) as usize
+        })
     }
 
     fn mb_to_boxed_bytes(&self, handle: Self::ManagedBufferHandle) -> BoxedBytes {
-        self.with_vm_hooks(|vh| {
+        self.with_vm_hooks_ctx_1(&handle, |vh| {
             let len = vh.mbuffer_get_length(handle.get_raw_handle_unchecked()) as usize;
             unsafe {
                 let mut res = BoxedBytes::allocate(len);
                 if len > 0 {
-                    let _ =
-                        vh.mbuffer_get_bytes(handle.get_raw_handle_unchecked(), res.as_mut_ptr() as MemPtr);
+                    let _ = vh.mbuffer_get_bytes(
+                        handle.get_raw_handle_unchecked(),
+                        res.as_mut_ptr() as MemPtr,
+                    );
                 }
                 res
             }
@@ -45,7 +48,7 @@ impl<VHB: VMHooksApiBackend> ManagedBufferApiImpl for VMHooksApi<VHB> {
         starting_position: usize,
         dest_slice: &mut [u8],
     ) -> Result<(), InvalidSliceError> {
-        let err = self.with_vm_hooks(|vh| {
+        let err = self.with_vm_hooks_ctx_1(&source_handle, |vh| {
             mem_conv::with_mem_ptr_mut(dest_slice, |offset, length| {
                 vh.mbuffer_get_byte_slice(
                     source_handle.get_raw_handle_unchecked(),
@@ -69,7 +72,7 @@ impl<VHB: VMHooksApiBackend> ManagedBufferApiImpl for VMHooksApi<VHB> {
         slice_len: usize,
         dest_handle: Self::ManagedBufferHandle,
     ) -> Result<(), InvalidSliceError> {
-        let err = self.with_vm_hooks(|vh| {
+        let err = self.with_vm_hooks_ctx_2(&source_handle, &dest_handle, |vh| {
             vh.mbuffer_copy_byte_slice(
                 source_handle.get_raw_handle_unchecked(),
                 starting_pos as i32,
@@ -85,7 +88,7 @@ impl<VHB: VMHooksApiBackend> ManagedBufferApiImpl for VMHooksApi<VHB> {
     }
 
     fn mb_overwrite(&self, handle: Self::ManagedBufferHandle, value: &[u8]) {
-        self.with_vm_hooks(|vh| {
+        self.with_vm_hooks_ctx_1(&handle, |vh| {
             mem_conv::with_mem_ptr(value, |offset, length| {
                 vh.mbuffer_set_bytes(handle.get_raw_handle_unchecked(), offset, length);
             })
@@ -98,7 +101,7 @@ impl<VHB: VMHooksApiBackend> ManagedBufferApiImpl for VMHooksApi<VHB> {
         starting_position: usize,
         source_slice: &[u8],
     ) -> Result<(), InvalidSliceError> {
-        let err = self.with_vm_hooks(|vh| {
+        let err = self.with_vm_hooks_ctx_1(&dest_handle, |vh| {
             mem_conv::with_mem_ptr(source_slice, |offset, length| {
                 vh.mbuffer_set_byte_slice(
                     dest_handle.get_raw_handle_unchecked(),
@@ -116,7 +119,9 @@ impl<VHB: VMHooksApiBackend> ManagedBufferApiImpl for VMHooksApi<VHB> {
     }
 
     fn mb_set_random(&self, dest_handle: Self::ManagedBufferHandle, length: usize) {
-        self.with_vm_hooks(|vh| vh.mbuffer_set_random(dest_handle.get_raw_handle_unchecked(), length as i32));
+        self.with_vm_hooks_ctx_1(&dest_handle, |vh| {
+            vh.mbuffer_set_random(dest_handle.get_raw_handle_unchecked(), length as i32)
+        });
     }
 
     fn mb_append(
@@ -124,7 +129,7 @@ impl<VHB: VMHooksApiBackend> ManagedBufferApiImpl for VMHooksApi<VHB> {
         accumulator_handle: Self::ManagedBufferHandle,
         data_handle: Self::ManagedBufferHandle,
     ) {
-        self.with_vm_hooks(|vh| {
+        self.with_vm_hooks_ctx_2(&accumulator_handle, &data_handle, |vh| {
             vh.mbuffer_append(
                 accumulator_handle.get_raw_handle_unchecked(),
                 data_handle.get_raw_handle_unchecked(),
@@ -133,10 +138,13 @@ impl<VHB: VMHooksApiBackend> ManagedBufferApiImpl for VMHooksApi<VHB> {
     }
 
     fn mb_append_bytes(&self, accumulator_handle: Self::ManagedBufferHandle, bytes: &[u8]) {
-        self.with_vm_hooks(|vh| {
+        self.with_vm_hooks_ctx_1(&accumulator_handle, |vh| {
             mem_conv::with_mem_ptr(bytes, |offset, length| {
-                let _ =
-                    vh.mbuffer_append_bytes(accumulator_handle.get_raw_handle_unchecked(), offset, length);
+                let _ = vh.mbuffer_append_bytes(
+                    accumulator_handle.get_raw_handle_unchecked(),
+                    offset,
+                    length,
+                );
             })
         });
     }
@@ -146,11 +154,12 @@ impl<VHB: VMHooksApiBackend> ManagedBufferApiImpl for VMHooksApi<VHB> {
         handle1: Self::ManagedBufferHandle,
         handle2: Self::ManagedBufferHandle,
     ) -> bool {
-        i32_to_bool(
-            self.with_vm_hooks(|vh| {
-                vh.mbuffer_eq(handle1.get_raw_handle_unchecked(), handle2.get_raw_handle_unchecked())
-            }),
-        )
+        i32_to_bool(self.with_vm_hooks_ctx_2(&handle1, &handle2, |vh| {
+            vh.mbuffer_eq(
+                handle1.get_raw_handle_unchecked(),
+                handle2.get_raw_handle_unchecked(),
+            )
+        }))
     }
 
     fn mb_to_hex(
@@ -158,8 +167,11 @@ impl<VHB: VMHooksApiBackend> ManagedBufferApiImpl for VMHooksApi<VHB> {
         source_handle: Self::ManagedBufferHandle,
         dest_handle: Self::ManagedBufferHandle,
     ) {
-        self.with_vm_hooks(|vh| {
-            vh.managed_buffer_to_hex(source_handle.get_raw_handle_unchecked(), dest_handle.get_raw_handle_unchecked())
+        self.with_vm_hooks_ctx_2(&source_handle, &dest_handle, |vh| {
+            vh.managed_buffer_to_hex(
+                source_handle.get_raw_handle_unchecked(),
+                dest_handle.get_raw_handle_unchecked(),
+            )
         })
     }
 }

--- a/framework/scenario/src/api/managed_type_api_vh/managed_map_api_vh.rs
+++ b/framework/scenario/src/api/managed_type_api_vh/managed_map_api_vh.rs
@@ -14,7 +14,7 @@ impl<VHB: VMHooksApiBackend> ManagedMapApiImpl for VMHooksApi<VHB> {
         key_handle: Self::ManagedBufferHandle,
         out_value_handle: Self::ManagedBufferHandle,
     ) {
-        self.with_vm_hooks(|vh| {
+        self.with_vm_hooks_ctx_3(&map_handle, &key_handle, &out_value_handle, |vh| {
             vh.managed_map_get(
                 map_handle.get_raw_handle_unchecked(),
                 key_handle.get_raw_handle_unchecked(),
@@ -27,13 +27,13 @@ impl<VHB: VMHooksApiBackend> ManagedMapApiImpl for VMHooksApi<VHB> {
         &self,
         map_handle: Self::ManagedMapHandle,
         key_handle: Self::ManagedBufferHandle,
-        out_value_handle: Self::ManagedBufferHandle,
+        value_handle: Self::ManagedBufferHandle,
     ) {
-        self.with_vm_hooks(|vh| {
+        self.with_vm_hooks_ctx_3(&map_handle, &key_handle, &value_handle, |vh| {
             vh.managed_map_put(
                 map_handle.get_raw_handle_unchecked(),
                 key_handle.get_raw_handle_unchecked(),
-                out_value_handle.get_raw_handle_unchecked(),
+                value_handle.get_raw_handle_unchecked(),
             )
         });
     }
@@ -44,7 +44,7 @@ impl<VHB: VMHooksApiBackend> ManagedMapApiImpl for VMHooksApi<VHB> {
         key_handle: Self::ManagedBufferHandle,
         out_value_handle: Self::ManagedBufferHandle,
     ) {
-        self.with_vm_hooks(|vh| {
+        self.with_vm_hooks_ctx_3(&map_handle, &key_handle, &out_value_handle, |vh| {
             vh.managed_map_remove(
                 map_handle.get_raw_handle_unchecked(),
                 key_handle.get_raw_handle_unchecked(),
@@ -58,8 +58,11 @@ impl<VHB: VMHooksApiBackend> ManagedMapApiImpl for VMHooksApi<VHB> {
         map_handle: Self::ManagedMapHandle,
         key_handle: Self::ManagedBufferHandle,
     ) -> bool {
-        i32_to_bool(self.with_vm_hooks(|vh| {
-            vh.managed_map_contains(map_handle.get_raw_handle_unchecked(), key_handle.get_raw_handle_unchecked())
+        i32_to_bool(self.with_vm_hooks_ctx_2(&map_handle, &key_handle, |vh| {
+            vh.managed_map_contains(
+                map_handle.get_raw_handle_unchecked(),
+                key_handle.get_raw_handle_unchecked(),
+            )
         }))
     }
 }

--- a/framework/scenario/src/whitebox/contract_obj_wrapper.rs
+++ b/framework/scenario/src/whitebox/contract_obj_wrapper.rs
@@ -778,6 +778,7 @@ impl BlockchainStateWrapper {
         let _ = DebugApi::dummy();
         let result = f();
         let _ = TxContextStack::static_pop();
+        let _ = StaticVarStack::static_pop();
 
         result
     }

--- a/vm/src/api/managed_types/managed_buffer_api_mock.rs
+++ b/vm/src/api/managed_types/managed_buffer_api_mock.rs
@@ -1,6 +1,8 @@
 use crate::DebugApi;
 use multiversx_sc::{
-    api::{use_raw_handle, HandleTypeInfo, InvalidSliceError, ManagedBufferApiImpl, HandleConstraints},
+    api::{
+        use_raw_handle, HandleConstraints, HandleTypeInfo, InvalidSliceError, ManagedBufferApiImpl,
+    },
     types::heap::BoxedBytes,
 };
 

--- a/vm/src/api/managed_types/managed_map_api_mock.rs
+++ b/vm/src/api/managed_types/managed_map_api_mock.rs
@@ -1,5 +1,5 @@
 use crate::{tx_mock::ManagedMapImpl, DebugApi};
-use multiversx_sc::api::{ManagedMapApiImpl, HandleConstraints};
+use multiversx_sc::api::{HandleConstraints, ManagedMapApiImpl};
 
 impl ManagedMapApiImpl for DebugApi {
     fn mm_new(&self) -> Self::ManagedMapHandle {

--- a/vm/src/api/managed_types/managed_type_api_mock.rs
+++ b/vm/src/api/managed_types/managed_type_api_mock.rs
@@ -1,6 +1,8 @@
 use std::convert::TryInto;
 
-use multiversx_sc::api::{ManagedBufferApiImpl, ManagedTypeApi, ManagedTypeApiImpl, HandleConstraints};
+use multiversx_sc::api::{
+    HandleConstraints, ManagedBufferApiImpl, ManagedTypeApi, ManagedTypeApiImpl,
+};
 
 use crate::DebugApi;
 

--- a/vm/src/tx_mock/tx_context_ref.rs
+++ b/vm/src/tx_mock/tx_context_ref.rs
@@ -2,7 +2,7 @@ use std::{ops::Deref, rc::Rc};
 
 use crate::tx_mock::{TxContext, TxResult};
 
-use super::{BlockchainUpdate, TxContextStack};
+use super::{BlockchainUpdate, StaticVarStack, TxContextStack};
 
 /// The VM API implementation based on a blockchain mock written in Rust.
 /// Implemented as a smart pointer to a TxContext structure, which tracks a blockchain transaction.
@@ -39,6 +39,7 @@ impl TxContextRef {
         let tx_context_rc = Rc::new(tx_context);
         // TODO: WARNING: this does not clean up after itself, must fix!!!
         TxContextStack::static_push(tx_context_rc.clone());
+        StaticVarStack::static_push();
         Self(tx_context_rc)
     }
 


### PR DESCRIPTION
Managed type APIs work on the context of the respective handles.

Unlike with the old API, all handles always need to be in the same context.

General APIs require that the handles are live, i.e. they refer to the current active context.