### PR TITLE
getting smart contract results from logs

### DIFF
--- a/contracts/examples/multisig/interact-rs/src/multisig_interact_nfts.rs
+++ b/contracts/examples/multisig/interact-rs/src/multisig_interact_nfts.rs
@@ -105,7 +105,7 @@ impl MultisigInteract {
             return;
         }
 
-        self.collection_token_identifier = result.unwrap();
+        self.collection_token_identifier = result.unwrap().unwrap();
         println!(
             "collection token identifier: {}",
             self.collection_token_identifier
@@ -180,7 +180,7 @@ impl MultisigInteract {
             return;
         }
 
-        self.collection_token_identifier = result.unwrap();
+        self.collection_token_identifier = result.unwrap().unwrap();
         println!(
             "collection token identifier: {}",
             self.collection_token_identifier

--- a/framework/snippets/src/interactor_sc_call.rs
+++ b/framework/snippets/src/interactor_sc_call.rs
@@ -19,7 +19,7 @@ impl Interactor {
 
         sc_call_step.response = Some(TxResponse::from_network_tx(tx));
 
-        if let Ok(token_identifier) = sc_call_step
+        if let Ok(Some(token_identifier)) = sc_call_step
             .response()
             .issue_non_fungible_new_token_identifier()
         {


### PR DESCRIPTION
Hey!

Sometimes, for a reason I ignore, the smartContractResults field is not present in the proxy's /transactions/:txHash?withResults=true endpoint, despite the transaction actually have results. In this case we can get them from logs.

In order to handle this I changed the way you parse the response.

Just a word the `issue_non_fungible_new_token_identifier` function. The previous signature was `Result<String, TxResponseStatus>`, but the function either finish with `Ok(...)` or never finish (panic via the macro or via forced unwrapping). I might miss something here.
I would have changed the signature to `Option<String>` (and so removing the `Result<...>`), but I saw in the `multisig_interact_nfts.rs` and `interactor_sc_call.rs` files that you are printing the error, so I think you plan to implement it later? So finally I left the `Result` as is and the output is `Result<Option<String>, TxResponseStatus>`