### PR TITLE
sc-meta explicit CLI --target-dir-wasm and --target-dir-meta

### DIFF
--- a/framework/meta/src/cli_args/cli_args_build.rs
+++ b/framework/meta/src/cli_args/cli_args_build.rs
@@ -47,10 +47,10 @@ pub struct BuildArgs {
     )]
     pub extract_imports: bool,
 
-    /// Allows specifying the target directory where the Rust compiler will build the intermediary files.
+    /// For the wasm crate, allows specifying the target directory where the Rust compiler will build the intermediary files.
     /// Sharing the same target directory can speed up building multiple contract crates at once.
-    #[arg(long = "target-dir", verbatim_doc_comment)]
-    pub target_dir: Option<String>,
+    #[arg(long = "target-dir-wasm", alias = "target-dir", verbatim_doc_comment)]
+    pub target_dir_wasm: Option<String>,
 
     /// Generate a twiggy top report after building.
     #[arg(long = "twiggy-top", verbatim_doc_comment)]
@@ -97,7 +97,7 @@ impl Default for BuildArgs {
             emit_mir: false,
             emit_llvm_ir: false,
             extract_imports: true,
-            target_dir: None,
+            target_dir_wasm: None,
             twiggy_top: false,
             twiggy_paths: false,
             twiggy_monos: false,
@@ -144,9 +144,9 @@ impl CliArgsToRaw for BuildArgs {
         if !self.extract_imports {
             raw.push("--no-imports".to_string());
         }
-        if let Some(target_dir) = &self.target_dir {
-            raw.push("--target-dir".to_string());
-            raw.push(target_dir.clone());
+        if let Some(target_dir_wasm) = &self.target_dir_wasm {
+            raw.push("--target-dir-wasm".to_string());
+            raw.push(target_dir_wasm.clone());
         }
         if self.twiggy_top {
             raw.push("--twiggy-top".to_string());
@@ -166,10 +166,10 @@ impl CliArgsToRaw for BuildArgs {
 
 #[derive(Clone, PartialEq, Eq, Debug, Args)]
 pub struct BuildDbgArgs {
-    /// Allows specifying the target directory where the Rust compiler will build the intermediary files.
+    /// For the wasm crate, allows specifying the target directory where the Rust compiler will build the intermediary files.
     /// Sharing the same target directory can speed up building multiple contract crates at once.
-    #[arg(long = "target-dir", verbatim_doc_comment)]
-    pub target_dir: Option<String>,
+    #[arg(long = "target-dir-wasm", verbatim_doc_comment)]
+    pub target_dir_wasm: Option<String>,
 
     /// Generate a twiggy top report after building.
     #[arg(long = "twiggy-top", verbatim_doc_comment)]
@@ -198,7 +198,7 @@ impl BuildDbgArgs {
             wasm_opt: false,
             wat: true,
             extract_imports: false,
-            target_dir: self.target_dir,
+            target_dir_wasm: self.target_dir_wasm,
             twiggy_top: self.twiggy_top,
             twiggy_paths: self.twiggy_paths,
             twiggy_monos: self.twiggy_monos,
@@ -211,9 +211,9 @@ impl BuildDbgArgs {
 impl CliArgsToRaw for BuildDbgArgs {
     fn to_raw(&self) -> Vec<String> {
         let mut raw = Vec::new();
-        if let Some(target_dir) = &self.target_dir {
-            raw.push("--target-dir".to_string());
-            raw.push(target_dir.clone());
+        if let Some(target_dir_wasm) = &self.target_dir_wasm {
+            raw.push("--target-dir-wasm".to_string());
+            raw.push(target_dir_wasm.clone());
         }
         if self.twiggy_top {
             raw.push("--twiggy-top".to_string());
@@ -233,16 +233,16 @@ impl CliArgsToRaw for BuildDbgArgs {
 
 #[derive(Clone, PartialEq, Eq, Debug, Args)]
 pub struct TwiggyArgs {
-    /// Allows specifying the target directory where the Rust compiler will build the intermediary files.
+    /// For the wasm crate, allows specifying the target directory where the Rust compiler will build the intermediary files.
     /// Sharing the same target directory can speed up building multiple contract crates at once.
-    #[arg(long = "target-dir", verbatim_doc_comment)]
-    pub target_dir: Option<String>,
+    #[arg(long = "target-dir-wasm", verbatim_doc_comment)]
+    pub target_dir_wasm: Option<String>,
 }
 
 impl TwiggyArgs {
     pub fn into_build_args(self) -> BuildArgs {
         BuildDbgArgs {
-            target_dir: self.target_dir,
+            target_dir_wasm: self.target_dir_wasm,
             twiggy_top: true,
             twiggy_paths: true,
             twiggy_monos: true,
@@ -255,8 +255,8 @@ impl TwiggyArgs {
 impl CliArgsToRaw for TwiggyArgs {
     fn to_raw(&self) -> Vec<String> {
         let mut raw = Vec::new();
-        if let Some(target_dir) = &self.target_dir {
-            raw.push("--target-dir".to_string());
+        if let Some(target_dir) = &self.target_dir_wasm {
+            raw.push("--target-dir-wasm".to_string());
             raw.push(target_dir.clone());
         }
         raw

--- a/framework/meta/src/cli_args/cli_args_build.rs
+++ b/framework/meta/src/cli_args/cli_args_build.rs
@@ -49,6 +49,7 @@ pub struct BuildArgs {
 
     /// For the wasm crate, allows specifying the target directory where the Rust compiler will build the intermediary files.
     /// Sharing the same target directory can speed up building multiple contract crates at once.
+    /// Has alias `target-dir` for backwards compatibility.
     #[arg(long = "target-dir-wasm", alias = "target-dir", verbatim_doc_comment)]
     pub target_dir_wasm: Option<String>,
 
@@ -168,7 +169,8 @@ impl CliArgsToRaw for BuildArgs {
 pub struct BuildDbgArgs {
     /// For the wasm crate, allows specifying the target directory where the Rust compiler will build the intermediary files.
     /// Sharing the same target directory can speed up building multiple contract crates at once.
-    #[arg(long = "target-dir-wasm", verbatim_doc_comment)]
+    /// Has alias `target-dir` for backwards compatibility.
+    #[arg(long = "target-dir-wasm", alias = "target-dir", verbatim_doc_comment)]
     pub target_dir_wasm: Option<String>,
 
     /// Generate a twiggy top report after building.
@@ -235,7 +237,8 @@ impl CliArgsToRaw for BuildDbgArgs {
 pub struct TwiggyArgs {
     /// For the wasm crate, allows specifying the target directory where the Rust compiler will build the intermediary files.
     /// Sharing the same target directory can speed up building multiple contract crates at once.
-    #[arg(long = "target-dir-wasm", verbatim_doc_comment)]
+    /// Has alias `target-dir` for backwards compatibility.
+    #[arg(long = "target-dir-wasm", alias = "target-dir", verbatim_doc_comment)]
     pub target_dir_wasm: Option<String>,
 }
 

--- a/framework/meta/src/cli_args/cli_args_standalone.rs
+++ b/framework/meta/src/cli_args/cli_args_standalone.rs
@@ -102,11 +102,22 @@ pub struct AllArgs {
     )]
     #[clap(global = true)]
     pub load_abi_git_version: bool,
+
+    /// For the meta crates, allows specifying the target directory where the Rust compiler will build the intermediary files.
+    /// Sharing the same target directory can speed up building multiple contract crates at once.
+    #[arg(long = "target-dir-meta", verbatim_doc_comment)]
+    #[clap(global = true)]
+    pub target_dir_meta: Option<String>,
 }
 
-impl CliArgsToRaw for AllArgs {
-    fn to_raw(&self) -> Vec<String> {
-        let mut raw = self.command.to_raw();
+impl AllArgs {
+    pub fn to_cargo_run_args(&self) -> Vec<String> {
+        let mut raw = vec!["run".to_string()];
+        if let Some(target_dir_meta) = &self.target_dir_meta {
+            raw.push("--target-dir".to_string());
+            raw.push(target_dir_meta.clone());
+        }
+        raw.append(&mut self.command.to_raw());
         if !self.load_abi_git_version {
             raw.push("--no-abi-git-version".to_string());
         }

--- a/framework/meta/src/cmd/contract/output_contract/wasm_build.rs
+++ b/framework/meta/src/cmd/contract/output_contract/wasm_build.rs
@@ -35,8 +35,8 @@ impl OutputContract {
         if build_args.locked {
             command.arg("--locked");
         }
-        if let Some(target_dir) = &build_args.target_dir {
-            command.args(["--target-dir", target_dir]);
+        if let Some(target_dir_wasm) = &build_args.target_dir_wasm {
+            command.args(["--target-dir", target_dir_wasm]);
         }
         let rustflags = self.compose_rustflags(build_args);
         if !rustflags.is_empty() {
@@ -77,7 +77,7 @@ impl OutputContract {
     }
 
     fn copy_contracts_to_output(&self, build_args: &BuildArgs, output_path: &str) {
-        let source_wasm_path = self.wasm_compilation_output_path(&build_args.target_dir);
+        let source_wasm_path = self.wasm_compilation_output_path(&build_args.target_dir_wasm);
         let output_wasm_path = format!("{output_path}/{}", self.wasm_output_name(build_args));
         print_copy_contract(source_wasm_path.as_str(), output_wasm_path.as_str());
         fs::copy(source_wasm_path, output_wasm_path)

--- a/framework/meta/src/cmd/standalone/all.rs
+++ b/framework/meta/src/cmd/standalone/all.rs
@@ -1,7 +1,7 @@
 use std::{path::Path, process::Command};
 
 use crate::{
-    cli_args::{AllArgs, CliArgsToRaw},
+    cli_args::AllArgs,
     folder_structure::{dir_pretty_print, RelevantDirectories},
     print_util::{print_all_command, print_all_count, print_all_index},
 };
@@ -13,7 +13,7 @@ pub fn call_all_meta(args: &AllArgs) {
         "./"
     };
 
-    perform_call_all_meta(path, args.ignore.as_slice(), args.to_raw());
+    perform_call_all_meta(path, args.ignore.as_slice(), args.to_cargo_run_args());
 }
 
 fn perform_call_all_meta(path: impl AsRef<Path>, ignore: &[String], raw_args: Vec<String>) {
@@ -45,7 +45,7 @@ pub fn call_contract_meta(contract_crate_path: &Path, cargo_run_args: &[String])
 
     let exit_status = Command::new("cargo")
         .current_dir(&meta_path)
-        .args(std::iter::once(&"run".to_string()).chain(cargo_run_args.iter()))
+        .args(cargo_run_args)
         .spawn()
         .expect("failed to spawn cargo run process in meta crate")
         .wait()

--- a/framework/meta/src/print_util.rs
+++ b/framework/meta/src/print_util.rs
@@ -18,10 +18,11 @@ pub fn print_all_index(contract_crates_index: usize, num_contract_crates: usize)
 
 pub fn print_all_command(meta_path: &Path, cargo_run_args: &[String]) {
     println!(
-        "{} `cargo run {}` in {}",
+        "{} {}\n{} `cargo {}`",
+        "In".green(),
+        meta_path.display(),
         "Calling".green(),
         cargo_run_args.join(" "),
-        meta_path.display(),
     );
 }
 


### PR DESCRIPTION
Requested by the community.

This feature allows us to explicitly set the target dir for both meta and wasm crates, whereas in the past it was just for the wasm crate.