### PR TITLE
Switch to the officially recommended (by us) Rust version

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -15,7 +15,7 @@ jobs:
     name: Contracts
     uses: multiversx/mx-sc-actions/.github/workflows/contracts.yml@v2.3.0
     with:
-      rust-toolchain: nightly-2023-08-08
+      rust-toolchain: nightly-2023-05-26
       vmtools-version: v1.4.60
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lldb-formatter-tests.yml
+++ b/.github/workflows/lldb-formatter-tests.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           default: true
-          toolchain: nightly-2023-08-08
+          toolchain: nightly-2023-05-26
 
       - name: Download vscode-lldb
         uses: robinraju/release-downloader@v1.5

--- a/.github/workflows/release-upload.yml
+++ b/.github/workflows/release-upload.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           default: true
-          toolchain: nightly-2023-08-08
+          toolchain: nightly-2023-05-26
           target: wasm32-unknown-unknown
 
       - name: Setup the PATH variable

--- a/.github/workflows/template-test-current.yml
+++ b/.github/workflows/template-test-current.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           default: true
-          toolchain: nightly-2023-08-08
+          toolchain: nightly-2023-05-26
           target: wasm32-unknown-unknown
 
       - name: Setup the PATH variable

--- a/.github/workflows/template-test-released.yml
+++ b/.github/workflows/template-test-released.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           default: true
-          toolchain: nightly-2023-08-08
+          toolchain: nightly-2023-05-26
           target: wasm32-unknown-unknown
 
       - name: Setup the PATH variable

--- a/contracts/benchmarks/large-storage/wasm/Cargo.lock
+++ b/contracts/benchmarks/large-storage/wasm/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/benchmarks/large-storage/wasm/src/lib.rs
+++ b/contracts/benchmarks/large-storage/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   4
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/benchmarks/mappers/linked-list-repeat/wasm/Cargo.lock
+++ b/contracts/benchmarks/mappers/linked-list-repeat/wasm/Cargo.lock
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/benchmarks/mappers/linked-list-repeat/wasm/src/lib.rs
+++ b/contracts/benchmarks/mappers/linked-list-repeat/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:  10
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/benchmarks/mappers/map-repeat/wasm/Cargo.lock
+++ b/contracts/benchmarks/mappers/map-repeat/wasm/Cargo.lock
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/benchmarks/mappers/map-repeat/wasm/src/lib.rs
+++ b/contracts/benchmarks/mappers/map-repeat/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   8
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/benchmarks/mappers/queue-repeat/wasm/Cargo.lock
+++ b/contracts/benchmarks/mappers/queue-repeat/wasm/Cargo.lock
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/benchmarks/mappers/queue-repeat/wasm/src/lib.rs
+++ b/contracts/benchmarks/mappers/queue-repeat/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:  10
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/benchmarks/mappers/set-repeat/wasm/Cargo.lock
+++ b/contracts/benchmarks/mappers/set-repeat/wasm/Cargo.lock
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/benchmarks/mappers/set-repeat/wasm/src/lib.rs
+++ b/contracts/benchmarks/mappers/set-repeat/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:  10
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/benchmarks/mappers/single-value-repeat/wasm/Cargo.lock
+++ b/contracts/benchmarks/mappers/single-value-repeat/wasm/Cargo.lock
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/benchmarks/mappers/single-value-repeat/wasm/src/lib.rs
+++ b/contracts/benchmarks/mappers/single-value-repeat/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   8
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/benchmarks/mappers/vec-repeat/wasm/Cargo.lock
+++ b/contracts/benchmarks/mappers/vec-repeat/wasm/Cargo.lock
@@ -173,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/benchmarks/mappers/vec-repeat/wasm/src/lib.rs
+++ b/contracts/benchmarks/mappers/vec-repeat/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:  10
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/benchmarks/send-tx-repeat/wasm/Cargo.lock
+++ b/contracts/benchmarks/send-tx-repeat/wasm/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/benchmarks/send-tx-repeat/wasm/src/lib.rs
+++ b/contracts/benchmarks/send-tx-repeat/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   3
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/benchmarks/str-repeat/wasm/Cargo.lock
+++ b/contracts/benchmarks/str-repeat/wasm/Cargo.lock
@@ -166,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "str-repeat"

--- a/contracts/benchmarks/str-repeat/wasm/src/lib.rs
+++ b/contracts/benchmarks/str-repeat/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   5
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!(leaking);

--- a/contracts/core/price-aggregator/wasm/Cargo.lock
+++ b/contracts/core/price-aggregator/wasm/Cargo.lock
@@ -190,9 +190,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/core/price-aggregator/wasm/src/lib.rs
+++ b/contracts/core/price-aggregator/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:  21
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/core/wegld-swap/wasm/src/lib.rs
+++ b/contracts/core/wegld-swap/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   9
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/examples/adder/wasm/Cargo.lock
+++ b/contracts/examples/adder/wasm/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/examples/adder/wasm/src/lib.rs
+++ b/contracts/examples/adder/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   4
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/examples/bonding-curve-contract/wasm/Cargo.lock
+++ b/contracts/examples/bonding-curve-contract/wasm/Cargo.lock
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/examples/bonding-curve-contract/wasm/src/lib.rs
+++ b/contracts/examples/bonding-curve-contract/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:  12
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/examples/check-pause/wasm/Cargo.lock
+++ b/contracts/examples/check-pause/wasm/Cargo.lock
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/examples/check-pause/wasm/src/lib.rs
+++ b/contracts/examples/check-pause/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   6
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/examples/crowdfunding-esdt/wasm/Cargo.lock
+++ b/contracts/examples/crowdfunding-esdt/wasm/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/examples/crowdfunding-esdt/wasm/src/lib.rs
+++ b/contracts/examples/crowdfunding-esdt/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:  10
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/examples/crypto-bubbles/wasm/Cargo.lock
+++ b/contracts/examples/crypto-bubbles/wasm/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/examples/crypto-bubbles/wasm/src/lib.rs
+++ b/contracts/examples/crypto-bubbles/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   8
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/examples/crypto-kitties/kitty-auction/wasm/Cargo.lock
+++ b/contracts/examples/crypto-kitties/kitty-auction/wasm/Cargo.lock
@@ -217,9 +217,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/examples/crypto-kitties/kitty-auction/wasm/src/lib.rs
+++ b/contracts/examples/crypto-kitties/kitty-auction/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:  11
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/examples/crypto-kitties/kitty-genetic-alg/wasm/Cargo.lock
+++ b/contracts/examples/crypto-kitties/kitty-genetic-alg/wasm/Cargo.lock
@@ -198,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/examples/crypto-kitties/kitty-genetic-alg/wasm/src/lib.rs
+++ b/contracts/examples/crypto-kitties/kitty-genetic-alg/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   3
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/examples/crypto-kitties/kitty-ownership/wasm/Cargo.lock
+++ b/contracts/examples/crypto-kitties/kitty-ownership/wasm/Cargo.lock
@@ -208,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/examples/crypto-kitties/kitty-ownership/wasm/src/lib.rs
+++ b/contracts/examples/crypto-kitties/kitty-ownership/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:  23
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/examples/crypto-zombies/wasm/Cargo.lock
+++ b/contracts/examples/crypto-zombies/wasm/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/examples/crypto-zombies/wasm/src/lib.rs
+++ b/contracts/examples/crypto-zombies/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:  19
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/examples/digital-cash/wasm/Cargo.lock
+++ b/contracts/examples/digital-cash/wasm/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/examples/digital-cash/wasm/src/lib.rs
+++ b/contracts/examples/digital-cash/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:  10
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/examples/empty/wasm/Cargo.lock
+++ b/contracts/examples/empty/wasm/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/examples/empty/wasm/src/lib.rs
+++ b/contracts/examples/empty/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   2
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/examples/esdt-transfer-with-fee/wasm/Cargo.lock
+++ b/contracts/examples/esdt-transfer-with-fee/wasm/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/examples/esdt-transfer-with-fee/wasm/src/lib.rs
+++ b/contracts/examples/esdt-transfer-with-fee/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   8
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/examples/factorial/wasm/Cargo.lock
+++ b/contracts/examples/factorial/wasm/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/examples/factorial/wasm/src/lib.rs
+++ b/contracts/examples/factorial/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   3
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/examples/fractional-nfts/wasm/Cargo.lock
+++ b/contracts/examples/fractional-nfts/wasm/Cargo.lock
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/examples/fractional-nfts/wasm/src/lib.rs
+++ b/contracts/examples/fractional-nfts/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   6
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/examples/lottery-esdt/wasm/Cargo.lock
+++ b/contracts/examples/lottery-esdt/wasm/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/examples/lottery-esdt/wasm/src/lib.rs
+++ b/contracts/examples/lottery-esdt/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   9
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/examples/multisig/wasm-multisig-full/Cargo.lock
+++ b/contracts/examples/multisig/wasm-multisig-full/Cargo.lock
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/examples/multisig/wasm-multisig-full/src/lib.rs
+++ b/contracts/examples/multisig/wasm-multisig-full/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:  30
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/examples/multisig/wasm-multisig-view/Cargo.lock
+++ b/contracts/examples/multisig/wasm-multisig-view/Cargo.lock
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/examples/multisig/wasm-multisig-view/src/lib.rs
+++ b/contracts/examples/multisig/wasm-multisig-view/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:  10
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/examples/multisig/wasm/Cargo.lock
+++ b/contracts/examples/multisig/wasm/Cargo.lock
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/examples/multisig/wasm/src/lib.rs
+++ b/contracts/examples/multisig/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:  22
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/examples/nft-minter/wasm/Cargo.lock
+++ b/contracts/examples/nft-minter/wasm/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/examples/nft-minter/wasm/src/lib.rs
+++ b/contracts/examples/nft-minter/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   8
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/examples/nft-storage-prepay/wasm/Cargo.lock
+++ b/contracts/examples/nft-storage-prepay/wasm/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/examples/nft-storage-prepay/wasm/src/lib.rs
+++ b/contracts/examples/nft-storage-prepay/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:  10
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/examples/order-book/factory/wasm/Cargo.lock
+++ b/contracts/examples/order-book/factory/wasm/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/examples/order-book/factory/wasm/src/lib.rs
+++ b/contracts/examples/order-book/factory/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   4
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/examples/order-book/pair/wasm/Cargo.lock
+++ b/contracts/examples/order-book/pair/wasm/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/examples/order-book/pair/wasm/src/lib.rs
+++ b/contracts/examples/order-book/pair/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:  15
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/examples/ping-pong-egld/wasm/Cargo.lock
+++ b/contracts/examples/ping-pong-egld/wasm/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/examples/ping-pong-egld/wasm/src/lib.rs
+++ b/contracts/examples/ping-pong-egld/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:  12
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/examples/proxy-pause/wasm/Cargo.lock
+++ b/contracts/examples/proxy-pause/wasm/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/examples/proxy-pause/wasm/src/lib.rs
+++ b/contracts/examples/proxy-pause/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:  10
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/examples/rewards-distribution/wasm/Cargo.lock
+++ b/contracts/examples/rewards-distribution/wasm/Cargo.lock
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/examples/rewards-distribution/wasm/src/lib.rs
+++ b/contracts/examples/rewards-distribution/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:  15
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/examples/seed-nft-minter/wasm/Cargo.lock
+++ b/contracts/examples/seed-nft-minter/wasm/Cargo.lock
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/examples/seed-nft-minter/wasm/src/lib.rs
+++ b/contracts/examples/seed-nft-minter/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:  11
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/examples/token-release/wasm/Cargo.lock
+++ b/contracts/examples/token-release/wasm/Cargo.lock
@@ -166,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/examples/token-release/wasm/src/lib.rs
+++ b/contracts/examples/token-release/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:  15
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/feature-tests/abi-tester/wasm-abi-tester-ev/Cargo.lock
+++ b/contracts/feature-tests/abi-tester/wasm-abi-tester-ev/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/abi-tester/wasm-abi-tester-ev/src/lib.rs
+++ b/contracts/feature-tests/abi-tester/wasm-abi-tester-ev/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   5
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/feature-tests/abi-tester/wasm/Cargo.lock
+++ b/contracts/feature-tests/abi-tester/wasm/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/abi-tester/wasm/src/lib.rs
+++ b/contracts/feature-tests/abi-tester/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:  29
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/feature-tests/alloc-features/wasm/Cargo.lock
+++ b/contracts/feature-tests/alloc-features/wasm/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/alloc-features/wasm/src/lib.rs
+++ b/contracts/feature-tests/alloc-features/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:  66
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!(static64k);

--- a/contracts/feature-tests/basic-features/wasm-basic-features-storage-bytes/Cargo.lock
+++ b/contracts/feature-tests/basic-features/wasm-basic-features-storage-bytes/Cargo.lock
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/basic-features/wasm-basic-features-storage-bytes/src/lib.rs
+++ b/contracts/feature-tests/basic-features/wasm-basic-features-storage-bytes/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   4
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/feature-tests/basic-features/wasm/Cargo.lock
+++ b/contracts/feature-tests/basic-features/wasm/Cargo.lock
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/basic-features/wasm/src/lib.rs
+++ b/contracts/feature-tests/basic-features/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions: 342
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/feature-tests/big-float-features/wasm/Cargo.lock
+++ b/contracts/feature-tests/big-float-features/wasm/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/big-float-features/wasm/src/lib.rs
+++ b/contracts/feature-tests/big-float-features/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:  72
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/feature-tests/composability/builtin-func-features/wasm/Cargo.lock
+++ b/contracts/feature-tests/composability/builtin-func-features/wasm/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/composability/builtin-func-features/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/builtin-func-features/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   4
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/feature-tests/composability/esdt-contract-pair/first-contract/wasm/Cargo.lock
+++ b/contracts/feature-tests/composability/esdt-contract-pair/first-contract/wasm/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/composability/esdt-contract-pair/first-contract/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/esdt-contract-pair/first-contract/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   9
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/feature-tests/composability/esdt-contract-pair/second-contract/wasm/Cargo.lock
+++ b/contracts/feature-tests/composability/esdt-contract-pair/second-contract/wasm/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/composability/esdt-contract-pair/second-contract/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/esdt-contract-pair/second-contract/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   5
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/child/wasm/Cargo.lock
+++ b/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/child/wasm/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/child/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/child/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   4
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/parent/wasm/Cargo.lock
+++ b/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/parent/wasm/Cargo.lock
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/parent/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/parent/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   6
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/feature-tests/composability/forwarder-queue/wasm-forwarder-queue-promises/Cargo.lock
+++ b/contracts/feature-tests/composability/forwarder-queue/wasm-forwarder-queue-promises/Cargo.lock
@@ -182,9 +182,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/composability/forwarder-queue/wasm-forwarder-queue-promises/src/lib.rs
+++ b/contracts/feature-tests/composability/forwarder-queue/wasm-forwarder-queue-promises/src/lib.rs
@@ -11,7 +11,9 @@
 // Total number of exported functions:  13
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/feature-tests/composability/forwarder-queue/wasm/Cargo.lock
+++ b/contracts/feature-tests/composability/forwarder-queue/wasm/Cargo.lock
@@ -182,9 +182,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/composability/forwarder-queue/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/forwarder-queue/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:  12
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/feature-tests/composability/forwarder-raw/wasm-forwarder-raw-init-async-call/Cargo.lock
+++ b/contracts/feature-tests/composability/forwarder-raw/wasm-forwarder-raw-init-async-call/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/composability/forwarder-raw/wasm-forwarder-raw-init-async-call/src/lib.rs
+++ b/contracts/feature-tests/composability/forwarder-raw/wasm-forwarder-raw-init-async-call/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   3
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/feature-tests/composability/forwarder-raw/wasm-forwarder-raw-init-sync-call/Cargo.lock
+++ b/contracts/feature-tests/composability/forwarder-raw/wasm-forwarder-raw-init-sync-call/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/composability/forwarder-raw/wasm-forwarder-raw-init-sync-call/src/lib.rs
+++ b/contracts/feature-tests/composability/forwarder-raw/wasm-forwarder-raw-init-sync-call/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   2
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/feature-tests/composability/forwarder-raw/wasm/Cargo.lock
+++ b/contracts/feature-tests/composability/forwarder-raw/wasm/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/composability/forwarder-raw/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/forwarder-raw/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:  27
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/feature-tests/composability/forwarder/wasm/Cargo.lock
+++ b/contracts/feature-tests/composability/forwarder/wasm/Cargo.lock
@@ -182,9 +182,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/composability/forwarder/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/forwarder/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:  68
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/feature-tests/composability/local-esdt-and-nft/wasm/Cargo.lock
+++ b/contracts/feature-tests/composability/local-esdt-and-nft/wasm/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/composability/local-esdt-and-nft/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/local-esdt-and-nft/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:  20
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/feature-tests/composability/promises-features/wasm/Cargo.lock
+++ b/contracts/feature-tests/composability/promises-features/wasm/Cargo.lock
@@ -182,9 +182,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/composability/promises-features/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/promises-features/wasm/src/lib.rs
@@ -11,7 +11,9 @@
 // Total number of exported functions:  11
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/feature-tests/composability/proxy-test-first/wasm/Cargo.lock
+++ b/contracts/feature-tests/composability/proxy-test-first/wasm/Cargo.lock
@@ -182,9 +182,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/composability/proxy-test-first/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/proxy-test-first/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   8
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!(static64k);

--- a/contracts/feature-tests/composability/proxy-test-second/wasm/Cargo.lock
+++ b/contracts/feature-tests/composability/proxy-test-second/wasm/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/composability/proxy-test-second/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/proxy-test-second/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   5
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!(static64k);

--- a/contracts/feature-tests/composability/recursive-caller/wasm/Cargo.lock
+++ b/contracts/feature-tests/composability/recursive-caller/wasm/Cargo.lock
@@ -182,9 +182,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/composability/recursive-caller/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/recursive-caller/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   3
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/feature-tests/composability/transfer-role-features/wasm/Cargo.lock
+++ b/contracts/feature-tests/composability/transfer-role-features/wasm/Cargo.lock
@@ -173,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/composability/transfer-role-features/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/transfer-role-features/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   3
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/feature-tests/composability/vault/wasm-vault-promises/Cargo.lock
+++ b/contracts/feature-tests/composability/vault/wasm-vault-promises/Cargo.lock
@@ -166,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/composability/vault/wasm-vault-promises/src/lib.rs
+++ b/contracts/feature-tests/composability/vault/wasm-vault-promises/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:  18
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/feature-tests/composability/vault/wasm/Cargo.lock
+++ b/contracts/feature-tests/composability/vault/wasm/Cargo.lock
@@ -166,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/composability/vault/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/vault/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:  17
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/feature-tests/erc-style-contracts/crowdfunding-erc20/wasm/Cargo.lock
+++ b/contracts/feature-tests/erc-style-contracts/crowdfunding-erc20/wasm/Cargo.lock
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/erc-style-contracts/crowdfunding-erc20/wasm/src/lib.rs
+++ b/contracts/feature-tests/erc-style-contracts/crowdfunding-erc20/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:  10
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/feature-tests/erc-style-contracts/erc1155-marketplace/wasm/Cargo.lock
+++ b/contracts/feature-tests/erc-style-contracts/erc1155-marketplace/wasm/Cargo.lock
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/erc-style-contracts/erc1155-marketplace/wasm/src/lib.rs
+++ b/contracts/feature-tests/erc-style-contracts/erc1155-marketplace/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:  14
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!(static64k);

--- a/contracts/feature-tests/erc-style-contracts/erc1155-user-mock/wasm/Cargo.lock
+++ b/contracts/feature-tests/erc-style-contracts/erc1155-user-mock/wasm/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/erc-style-contracts/erc1155-user-mock/wasm/src/lib.rs
+++ b/contracts/feature-tests/erc-style-contracts/erc1155-user-mock/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   4
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/feature-tests/erc-style-contracts/erc1155/wasm/Cargo.lock
+++ b/contracts/feature-tests/erc-style-contracts/erc1155/wasm/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/erc-style-contracts/erc1155/wasm/src/lib.rs
+++ b/contracts/feature-tests/erc-style-contracts/erc1155/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:  15
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!(static64k);

--- a/contracts/feature-tests/erc-style-contracts/erc20/wasm/Cargo.lock
+++ b/contracts/feature-tests/erc-style-contracts/erc20/wasm/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/erc-style-contracts/erc20/wasm/src/lib.rs
+++ b/contracts/feature-tests/erc-style-contracts/erc20/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   8
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/feature-tests/erc-style-contracts/erc721/wasm/Cargo.lock
+++ b/contracts/feature-tests/erc-style-contracts/erc721/wasm/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/erc-style-contracts/erc721/wasm/src/lib.rs
+++ b/contracts/feature-tests/erc-style-contracts/erc721/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:  10
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/feature-tests/erc-style-contracts/lottery-erc20/wasm/Cargo.lock
+++ b/contracts/feature-tests/erc-style-contracts/lottery-erc20/wasm/Cargo.lock
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/erc-style-contracts/lottery-erc20/wasm/src/lib.rs
+++ b/contracts/feature-tests/erc-style-contracts/lottery-erc20/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   9
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!(static64k);

--- a/contracts/feature-tests/esdt-system-sc-mock/wasm/Cargo.lock
+++ b/contracts/feature-tests/esdt-system-sc-mock/wasm/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/esdt-system-sc-mock/wasm/src/lib.rs
+++ b/contracts/feature-tests/esdt-system-sc-mock/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   8
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/feature-tests/formatted-message-features/wasm/Cargo.lock
+++ b/contracts/feature-tests/formatted-message-features/wasm/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/formatted-message-features/wasm/src/lib.rs
+++ b/contracts/feature-tests/formatted-message-features/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:  18
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/feature-tests/managed-map-features/wasm/Cargo.lock
+++ b/contracts/feature-tests/managed-map-features/wasm/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/managed-map-features/wasm/src/lib.rs
+++ b/contracts/feature-tests/managed-map-features/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   5
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/feature-tests/multi-contract-features/wasm-multi-contract-alt-impl/Cargo.lock
+++ b/contracts/feature-tests/multi-contract-features/wasm-multi-contract-alt-impl/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/multi-contract-features/wasm-multi-contract-alt-impl/src/lib.rs
+++ b/contracts/feature-tests/multi-contract-features/wasm-multi-contract-alt-impl/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   3
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/feature-tests/multi-contract-features/wasm-multi-contract-example-feature/Cargo.lock
+++ b/contracts/feature-tests/multi-contract-features/wasm-multi-contract-example-feature/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/multi-contract-features/wasm-multi-contract-example-feature/src/lib.rs
+++ b/contracts/feature-tests/multi-contract-features/wasm-multi-contract-example-feature/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   4
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/feature-tests/multi-contract-features/wasm-multi-contract-features-view/Cargo.lock
+++ b/contracts/feature-tests/multi-contract-features/wasm-multi-contract-features-view/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/multi-contract-features/wasm-multi-contract-features-view/src/lib.rs
+++ b/contracts/feature-tests/multi-contract-features/wasm-multi-contract-features-view/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   5
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/feature-tests/multi-contract-features/wasm/Cargo.lock
+++ b/contracts/feature-tests/multi-contract-features/wasm/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/multi-contract-features/wasm/src/lib.rs
+++ b/contracts/feature-tests/multi-contract-features/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   4
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/feature-tests/panic-message-features/wasm/Cargo.lock
+++ b/contracts/feature-tests/panic-message-features/wasm/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/panic-message-features/wasm/src/lib.rs
+++ b/contracts/feature-tests/panic-message-features/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   4
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/feature-tests/payable-features/wasm/Cargo.lock
+++ b/contracts/feature-tests/payable-features/wasm/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/payable-features/wasm/src/lib.rs
+++ b/contracts/feature-tests/payable-features/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:  17
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/feature-tests/rust-snippets-generator-test/wasm/Cargo.lock
+++ b/contracts/feature-tests/rust-snippets-generator-test/wasm/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/rust-snippets-generator-test/wasm/src/lib.rs
+++ b/contracts/feature-tests/rust-snippets-generator-test/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:  18
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/feature-tests/rust-testing-framework-tester/wasm/Cargo.lock
+++ b/contracts/feature-tests/rust-testing-framework-tester/wasm/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/rust-testing-framework-tester/wasm/src/lib.rs
+++ b/contracts/feature-tests/rust-testing-framework-tester/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:  28
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!(static64k);

--- a/contracts/feature-tests/use-module/wasm-use-module-view/Cargo.lock
+++ b/contracts/feature-tests/use-module/wasm-use-module-view/Cargo.lock
@@ -173,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/use-module/wasm-use-module-view/src/lib.rs
+++ b/contracts/feature-tests/use-module/wasm-use-module-view/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:   4
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();

--- a/contracts/feature-tests/use-module/wasm/Cargo.lock
+++ b/contracts/feature-tests/use-module/wasm/Cargo.lock
@@ -173,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "syn"

--- a/contracts/feature-tests/use-module/wasm/src/lib.rs
+++ b/contracts/feature-tests/use-module/wasm/src/lib.rs
@@ -10,7 +10,9 @@
 // Total number of exported functions:  64
 
 #![no_std]
-#![allow(internal_features)]
+
+// Configuration that works with rustc < 1.73.0.
+// TODO: Recommended rustc version: 1.73.0 or newer.
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();


### PR DESCRIPTION
Currently, `nightly-2023-05-26` is the one we recommend (for consistency across projects, tooling etc.).

 - https://github.com/multiversx/mx-sdk-rust-contract-builder/blob/v5.3.0/Dockerfile#L5
 - https://github.com/multiversx/mx-sdk-py-cli/blob/v8.1.2/multiversx_sdk_cli/config.py#L158
 - https://github.com/multiversx/mx-exchange-sc/blob/main/.github/workflows/actions.yml#L25

Also ran a ` sc-meta update all`.