### PR TITLE
meta - replace wasm-objdump with internal impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2137,6 +2137,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml 0.5.11",
+ "wasmparser",
  "zip",
 ]
 
@@ -3804,6 +3805,16 @@ name = "wasm-bindgen-shared"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+
+[[package]]
+name = "wasmparser"
+version = "0.113.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a128cea7b8516703ab41b10a0b1aa9ba18d0454cd3792341489947ddeee268db"
+dependencies = [
+ "indexmap 2.0.0",
+ "semver",
+]
 
 [[package]]
 name = "web-sys"

--- a/framework/meta/Cargo.toml
+++ b/framework/meta/Cargo.toml
@@ -43,6 +43,7 @@ common-path = "1.0.0"
 lazy_static = "1.4.0"
 convert_case = "0.6.0"
 hex = "0.4"
+wasmparser = "0.113.1"
 
 [dependencies.multiversx-sc]
 version = "=0.43.4"

--- a/framework/meta/src/cmd/contract/output_contract/wasm_build.rs
+++ b/framework/meta/src/cmd/contract/output_contract/wasm_build.rs
@@ -7,7 +7,7 @@ use crate::{
     ei::EIVersion,
     mxsc_file_json::{save_mxsc_file_json, MxscFileJson},
     print_util::*,
-    tools::post_build,
+    tools::{self, post_build},
 };
 
 impl OutputContract {
@@ -134,8 +134,9 @@ impl OutputContract {
             self.imports_json_output_name(build_args)
         );
         print_extract_imports(&output_imports_json_path);
-        let result = post_build::run_wasm_objdump(output_wasm_path.as_str());
-        let import_names = post_build::parse_imports(result.as_str());
+        let import_names = tools::extract_wasm_imports(&output_wasm_path)
+            .expect("error occured while extracting imports from .wasm ");
+        println!("{import_names:?}");
         write_imports_output(output_imports_json_path.as_str(), import_names.as_slice());
         validate_ei(&import_names, &self.settings.check_ei);
     }

--- a/framework/meta/src/tools.rs
+++ b/framework/meta/src/tools.rs
@@ -1,4 +1,6 @@
 mod git_describe;
 pub mod post_build;
+mod wasm_imports;
 
 pub use git_describe::git_describe;
+pub use wasm_imports::extract_wasm_imports;

--- a/framework/meta/src/tools/wasm_imports.rs
+++ b/framework/meta/src/tools/wasm_imports.rs
@@ -1,0 +1,20 @@
+use anyhow::Result;
+use std::fs;
+use wasmparser::{Parser, Payload};
+
+/// Parses the WebAssembly code and extracts all the import names.
+pub fn extract_wasm_imports(output_wasm_path: &str) -> Result<Vec<String>> {
+    let wasm_data = fs::read(output_wasm_path)?;
+    let mut import_names = Vec::new();
+
+    let parser = Parser::new(0);
+    for payload in parser.parse_all(&wasm_data) {
+        if let Payload::ImportSection(import_section) = payload? {
+            for import in import_section {
+                import_names.push(import?.name.to_string());
+            }
+        }
+    }
+
+    Ok(import_names)
+}


### PR DESCRIPTION
This simplifies our dependencies, we no longer need the external tool `wasm-objdump` installed to run builds.