### PR TITLE
FunctionCall object

### DIFF
--- a/contracts/examples/multisig/interact/src/multisig_interact_nfts.rs
+++ b/contracts/examples/multisig/interact/src/multisig_interact_nfts.rs
@@ -1,7 +1,9 @@
 use std::time::Duration;
 
-use multiversx_sc_scenario::multiversx_sc::codec::multi_types::IgnoreValue;
-use multiversx_sc_snippets::multiversx_sc::codec::test_util::top_encode_to_vec_u8_or_panic;
+use multiversx_sc_scenario::multiversx_sc::{
+    codec::{multi_types::IgnoreValue, Empty},
+    types::FunctionCall,
+};
 
 use super::*;
 
@@ -39,17 +41,17 @@ impl MultisigInteract {
             .interactor
             .sc_call_get_result(
                 ScCallStep::new()
-                    .call(self.state.multisig().propose_async_call(
-                        system_sc_address,
-                        ISSUE_COST,
-                        "registerAndSetAllRoles".to_string(),
-                        MultiValueVec::from([
-                            COLLECTION_NAME.as_bytes(),
-                            COLLECTION_TICKER.as_bytes(),
-                            TOKEN_TYPE.as_bytes(),
-                            top_encode_to_vec_u8_or_panic(&0u32).as_slice(),
-                        ]),
-                    ))
+                    .call(
+                        self.state.multisig().propose_async_call(
+                            system_sc_address,
+                            ISSUE_COST,
+                            FunctionCall::new("registerAndSetAllRoles")
+                                .argument(&COLLECTION_NAME)
+                                .argument(&COLLECTION_TICKER)
+                                .argument(&TOKEN_TYPE)
+                                .argument(&0u32),
+                        ),
+                    )
                     .from(&self.wallet_address)
                     .gas_limit("10,000,000")
                     .expect(TxExpect::ok().additional_error_message("failed to issue collection")),
@@ -100,15 +102,15 @@ impl MultisigInteract {
             .interactor
             .sc_call_get_result(
                 ScCallStep::new()
-                    .call(self.state.multisig().propose_async_call(
-                        system_sc_address,
-                        ISSUE_COST,
-                        "issueNonFungible".to_string(),
-                        MultiValueVec::from([
-                            COLLECTION_NAME.to_string(),
-                            COLLECTION_TICKER.to_string(),
-                        ]),
-                    ))
+                    .call(
+                        self.state.multisig().propose_async_call(
+                            system_sc_address,
+                            ISSUE_COST,
+                            FunctionCall::new("issueNonFungible")
+                                .argument(&COLLECTION_NAME)
+                                .argument(&COLLECTION_TICKER),
+                        ),
+                    )
                     .from(&self.wallet_address)
                     .gas_limit("10,000,000"),
             )
@@ -158,16 +160,16 @@ impl MultisigInteract {
             .interactor
             .sc_call_get_result(
                 ScCallStep::new()
-                    .call(self.state.multisig().propose_async_call(
-                        &self.system_sc_address,
-                        0u64,
-                        "setSpecialRole".to_string(),
-                        MultiValueVec::from([
-                            self.collection_token_identifier.as_bytes(),
-                            multisig_address.as_bytes(),
-                            "ESDTRoleNFTCreate".as_bytes(),
-                        ]),
-                    ))
+                    .call(
+                        self.state.multisig().propose_async_call(
+                            &self.system_sc_address,
+                            0u64,
+                            FunctionCall::new("setSpecialRole")
+                                .argument(&self.collection_token_identifier)
+                                .argument(&multisig_address)
+                                .argument(&"ESDTRoleNFTCreate"),
+                        ),
+                    )
                     .from(&self.wallet_address)
                     .gas_limit("10,000,000"),
             )
@@ -200,20 +202,20 @@ impl MultisigInteract {
             );
 
             let typed_sc_call = ScCallStep::new()
-                .call(self.state.multisig().propose_async_call(
-                    &multisig_address,
-                    0u64,
-                    "ESDTNFTCreate".to_string(),
-                    MultiValueVec::from([
-                        self.collection_token_identifier.as_bytes(),
-                        top_encode_to_vec_u8_or_panic(&1u32).as_slice(),
-                        item_name.as_bytes(),
-                        top_encode_to_vec_u8_or_panic(&ROYALTIES).as_slice(),
-                        &[][..],
-                        METADATA.as_bytes(),
-                        image_cid.as_bytes(),
-                    ]),
-                ))
+                .call(
+                    self.state.multisig().propose_async_call(
+                        &multisig_address,
+                        0u64,
+                        FunctionCall::new("ESDTNFTCreate")
+                            .argument(&self.collection_token_identifier)
+                            .argument(&1u32)
+                            .argument(&item_name)
+                            .argument(&ROYALTIES)
+                            .argument(&Empty)
+                            .argument(&METADATA)
+                            .argument(&image_cid),
+                    ),
+                )
                 .from(&self.wallet_address)
                 .gas_limit("10,000,000");
 

--- a/contracts/examples/multisig/interact/src/multisig_interact_wegld.rs
+++ b/contracts/examples/multisig/interact/src/multisig_interact_wegld.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use multiversx_sc_scenario::multiversx_sc::types::FunctionCall;
 #[allow(unused_imports)]
 use multiversx_sc_snippets::multiversx_sc::types::{
     EsdtTokenPayment, MultiValueEncoded, TokenIdentifier,
@@ -66,8 +67,7 @@ impl MultisigInteract {
                     .call(self.state.multisig().propose_async_call(
                         bech32::decode(WEGLD_SWAP_SC_BECH32),
                         WRAP_AMOUNT,
-                        "wrapEgld".to_string(),
-                        MultiValueEncoded::new(),
+                        FunctionCall::new("wrapEgld"),
                     ))
                     .from(&self.wallet_address)
                     .gas_limit("10,000,000"),
@@ -96,18 +96,11 @@ impl MultisigInteract {
             .interactor
             .sc_call_get_result(
                 ScCallStep::new()
-                    .call(
-                        self.state.multisig().propose_async_call(
-                            contract_call.basic.to,
-                            0u64,
-                            contract_call.basic.function_call.function_name,
-                            contract_call
-                                .basic
-                                .function_call
-                                .arg_buffer
-                                .into_multi_value_encoded(),
-                        ),
-                    )
+                    .call(self.state.multisig().propose_async_call(
+                        contract_call.basic.to,
+                        0u64,
+                        contract_call.basic.function_call,
+                    ))
                     .from(&self.wallet_address)
                     .gas_limit("10,000,000"),
             )

--- a/contracts/examples/multisig/interact/src/multisig_interact_wegld.rs
+++ b/contracts/examples/multisig/interact/src/multisig_interact_wegld.rs
@@ -96,12 +96,18 @@ impl MultisigInteract {
             .interactor
             .sc_call_get_result(
                 ScCallStep::new()
-                    .call(self.state.multisig().propose_async_call(
-                        contract_call.basic.to,
-                        0u64,
-                        contract_call.basic.endpoint_name,
-                        contract_call.basic.arg_buffer.into_multi_value_encoded(),
-                    ))
+                    .call(
+                        self.state.multisig().propose_async_call(
+                            contract_call.basic.to,
+                            0u64,
+                            contract_call.basic.function_call.function_name,
+                            contract_call
+                                .basic
+                                .function_call
+                                .arg_buffer
+                                .into_multi_value_encoded(),
+                        ),
+                    )
                     .from(&self.wallet_address)
                     .gas_limit("10,000,000"),
             )

--- a/contracts/examples/multisig/tests/multisig_blackbox_test.rs
+++ b/contracts/examples/multisig/tests/multisig_blackbox_test.rs
@@ -9,7 +9,7 @@ use multiversx_sc::{
         test_util::top_encode_to_vec_u8_or_panic,
     },
     storage::mappers::SingleValue,
-    types::{Address, CodeMetadata, ContractCallNoPayment},
+    types::{Address, CodeMetadata, ContractCallNoPayment, FunctionCall},
 };
 use multiversx_sc_scenario::{
     api::StaticApi,
@@ -155,19 +155,14 @@ impl MultisigTestState {
         egld_amount: u64,
         contract_call: ContractCallNoPayment<StaticApi, ()>,
     ) -> usize {
-        self.world.sc_call_get_result(
-            ScCallStep::new().from(PROPOSER_ADDRESS_EXPR).call(
+        self.world
+            .sc_call_get_result(ScCallStep::new().from(PROPOSER_ADDRESS_EXPR).call(
                 self.multisig_contract.propose_transfer_execute(
                     to,
                     egld_amount,
-                    contract_call.function_call.function_name,
-                    contract_call
-                        .function_call
-                        .arg_buffer
-                        .into_multi_value_encoded(),
+                    contract_call.into_function_call(),
                 ),
-            ),
-        )
+            ))
     }
 
     fn propose_async_call(
@@ -176,19 +171,14 @@ impl MultisigTestState {
         egld_amount: u64,
         contract_call: ContractCallNoPayment<StaticApi, ()>,
     ) -> usize {
-        self.world.sc_call_get_result(
-            ScCallStep::new().from(PROPOSER_ADDRESS_EXPR).call(
+        self.world
+            .sc_call_get_result(ScCallStep::new().from(PROPOSER_ADDRESS_EXPR).call(
                 self.multisig_contract.propose_async_call(
                     to,
                     egld_amount,
-                    contract_call.function_call.function_name,
-                    contract_call
-                        .function_call
-                        .arg_buffer
-                        .into_multi_value_encoded(),
+                    contract_call.into_function_call(),
                 ),
-            ),
-        )
+            ))
     }
 
     fn propose_remove_user(&mut self, user_address: Address) -> usize {
@@ -451,8 +441,7 @@ fn test_transfer_execute_to_user() {
             .call(state.multisig_contract.propose_transfer_execute(
                 new_user_address.clone(),
                 0u64,
-                OptionalValue::<String>::None,
-                MultiValueVec::<Vec<u8>>::new(),
+                FunctionCall::empty(),
             ))
             .expect(TxExpect::user_error("str:proposed action has no effect")),
     );
@@ -465,8 +454,7 @@ fn test_transfer_execute_to_user() {
                 state.multisig_contract.propose_transfer_execute(
                     new_user_address.clone(),
                     AMOUNT.parse::<u64>().unwrap(),
-                    OptionalValue::<String>::None,
-                    MultiValueVec::<Vec<u8>>::new(),
+                    FunctionCall::empty(),
                 ),
             ));
     state.sign(action_id);

--- a/contracts/examples/multisig/tests/multisig_blackbox_test.rs
+++ b/contracts/examples/multisig/tests/multisig_blackbox_test.rs
@@ -155,15 +155,19 @@ impl MultisigTestState {
         egld_amount: u64,
         contract_call: ContractCallNoPayment<StaticApi, ()>,
     ) -> usize {
-        self.world
-            .sc_call_get_result(ScCallStep::new().from(PROPOSER_ADDRESS_EXPR).call(
+        self.world.sc_call_get_result(
+            ScCallStep::new().from(PROPOSER_ADDRESS_EXPR).call(
                 self.multisig_contract.propose_transfer_execute(
                     to,
                     egld_amount,
-                    contract_call.endpoint_name,
-                    contract_call.arg_buffer.into_multi_value_encoded(),
+                    contract_call.function_call.function_name,
+                    contract_call
+                        .function_call
+                        .arg_buffer
+                        .into_multi_value_encoded(),
                 ),
-            ))
+            ),
+        )
     }
 
     fn propose_async_call(
@@ -172,15 +176,19 @@ impl MultisigTestState {
         egld_amount: u64,
         contract_call: ContractCallNoPayment<StaticApi, ()>,
     ) -> usize {
-        self.world
-            .sc_call_get_result(ScCallStep::new().from(PROPOSER_ADDRESS_EXPR).call(
+        self.world.sc_call_get_result(
+            ScCallStep::new().from(PROPOSER_ADDRESS_EXPR).call(
                 self.multisig_contract.propose_async_call(
                     to,
                     egld_amount,
-                    contract_call.endpoint_name,
-                    contract_call.arg_buffer.into_multi_value_encoded(),
+                    contract_call.function_call.function_name,
+                    contract_call
+                        .function_call
+                        .arg_buffer
+                        .into_multi_value_encoded(),
                 ),
-            ))
+            ),
+        )
     }
 
     fn propose_remove_user(&mut self, user_address: Address) -> usize {

--- a/framework/base/src/types/interaction/async_call.rs
+++ b/framework/base/src/types/interaction/async_call.rs
@@ -1,8 +1,10 @@
 use crate::{
     api::{CallTypeApi, StorageWriteApi},
     contract_base::SendRawWrapper,
-    types::{BigUint, CallbackClosure, ManagedAddress, ManagedArgBuffer, ManagedBuffer},
+    types::{BigUint, CallbackClosure, ManagedAddress},
 };
+
+use super::FunctionCall;
 
 #[must_use]
 pub struct AsyncCall<SA>
@@ -11,8 +13,7 @@ where
 {
     pub(crate) to: ManagedAddress<SA>,
     pub(crate) egld_payment: BigUint<SA>,
-    pub(crate) endpoint_name: ManagedBuffer<SA>,
-    pub(crate) arg_buffer: ManagedArgBuffer<SA>,
+    pub(crate) function_call: FunctionCall<SA>,
     pub(crate) callback_call: Option<CallbackClosure<SA>>,
 }
 
@@ -37,8 +38,8 @@ where
         SendRawWrapper::<SA>::new().async_call_raw(
             &self.to,
             &self.egld_payment,
-            &self.endpoint_name,
-            &self.arg_buffer,
+            &self.function_call.function_name,
+            &self.function_call.arg_buffer,
         )
     }
 }

--- a/framework/base/src/types/interaction/async_call_promises.rs
+++ b/framework/base/src/types/interaction/async_call_promises.rs
@@ -1,8 +1,10 @@
 use crate::{
     api::CallTypeApi,
     contract_base::SendRawWrapper,
-    types::{BigUint, CallbackClosure, ManagedAddress, ManagedArgBuffer, ManagedBuffer},
+    types::{BigUint, CallbackClosure, ManagedAddress, ManagedBuffer},
 };
+
+use super::FunctionCall;
 
 /// Will be renamed to `AsyncCall` and `AsyncCall` to `AsyncCallLegacy` when the promises end up on the mainnet.
 #[must_use]
@@ -12,8 +14,7 @@ where
 {
     pub(crate) to: ManagedAddress<SA>,
     pub(crate) egld_payment: BigUint<SA>,
-    pub(crate) endpoint_name: ManagedBuffer<SA>,
-    pub(crate) arg_buffer: ManagedArgBuffer<SA>,
+    pub(crate) function_call: FunctionCall<SA>,
     pub(crate) explicit_gas_limit: u64,
     pub(crate) extra_gas_for_callback: u64,
     pub(crate) callback_call: Option<CallbackClosure<SA>>,
@@ -56,8 +57,8 @@ where
         SendRawWrapper::<SA>::new().create_async_call_raw(
             &self.to,
             &self.egld_payment,
-            &self.endpoint_name,
-            &self.arg_buffer,
+            &self.function_call.function_name,
+            &self.function_call.arg_buffer,
             callback_name,
             callback_name,
             self.explicit_gas_limit,

--- a/framework/base/src/types/interaction/contract_call_convert.rs
+++ b/framework/base/src/types/interaction/contract_call_convert.rs
@@ -10,7 +10,8 @@ use crate::{
 };
 
 use super::{
-    contract_call_no_payment::ContractCallNoPayment, ContractCallWithEgld, ManagedArgBuffer,
+    contract_call_no_payment::ContractCallNoPayment, ContractCallWithEgld, FunctionCall,
+    ManagedArgBuffer,
 };
 
 impl<SA, OriginalResult> ContractCallWithEgld<SA, OriginalResult>
@@ -39,16 +40,18 @@ where
             let mut new_arg_buffer = ManagedArgBuffer::new();
             new_arg_buffer.push_arg(&payment.token_identifier);
             new_arg_buffer.push_arg(&payment.amount);
-            if !self.basic.endpoint_name.is_empty() {
-                new_arg_buffer.push_arg(&self.basic.endpoint_name);
+            if !self.basic.function_call.function_name.is_empty() {
+                new_arg_buffer.push_arg(&self.basic.function_call.function_name);
             }
 
             ContractCallWithEgld {
                 basic: ContractCallNoPayment {
                     _phantom: PhantomData,
                     to: self.basic.to,
-                    endpoint_name: ESDT_TRANSFER_FUNC_NAME.into(),
-                    arg_buffer: new_arg_buffer.concat(self.basic.arg_buffer),
+                    function_call: FunctionCall {
+                        function_name: ESDT_TRANSFER_FUNC_NAME.into(),
+                        arg_buffer: new_arg_buffer.concat(self.basic.function_call.arg_buffer),
+                    },
                     explicit_gas_limit: self.basic.explicit_gas_limit,
                     _return_type: PhantomData,
                 },
@@ -66,8 +69,8 @@ where
             new_arg_buffer.push_arg(payment.token_nonce);
             new_arg_buffer.push_arg(&payment.amount);
             new_arg_buffer.push_arg(&self.basic.to);
-            if !self.basic.endpoint_name.is_empty() {
-                new_arg_buffer.push_arg(&self.basic.endpoint_name);
+            if !self.basic.function_call.function_name.is_empty() {
+                new_arg_buffer.push_arg(&self.basic.function_call.function_name);
             }
 
             // nft transfer is sent to self, sender = receiver
@@ -77,8 +80,10 @@ where
                 basic: ContractCallNoPayment {
                     _phantom: PhantomData,
                     to: recipient_addr,
-                    endpoint_name: ESDT_NFT_TRANSFER_FUNC_NAME.into(),
-                    arg_buffer: new_arg_buffer.concat(self.basic.arg_buffer),
+                    function_call: FunctionCall {
+                        function_name: ESDT_NFT_TRANSFER_FUNC_NAME.into(),
+                        arg_buffer: new_arg_buffer.concat(self.basic.function_call.arg_buffer),
+                    },
                     explicit_gas_limit: self.basic.explicit_gas_limit,
                     _return_type: PhantomData,
                 },
@@ -100,8 +105,8 @@ where
             new_arg_buffer.push_arg(payment.token_nonce);
             new_arg_buffer.push_arg(payment.amount);
         }
-        if !self.basic.endpoint_name.is_empty() {
-            new_arg_buffer.push_arg(self.basic.endpoint_name);
+        if !self.basic.function_call.function_name.is_empty() {
+            new_arg_buffer.push_arg(self.basic.function_call.function_name);
         }
 
         // multi transfer is sent to self, sender = receiver
@@ -111,8 +116,10 @@ where
             basic: ContractCallNoPayment {
                 _phantom: PhantomData,
                 to: recipient_addr,
-                endpoint_name: ESDT_MULTI_TRANSFER_FUNC_NAME.into(),
-                arg_buffer: new_arg_buffer.concat(self.basic.arg_buffer),
+                function_call: FunctionCall {
+                    function_name: ESDT_MULTI_TRANSFER_FUNC_NAME.into(),
+                    arg_buffer: new_arg_buffer.concat(self.basic.function_call.arg_buffer),
+                },
                 explicit_gas_limit: self.basic.explicit_gas_limit,
                 _return_type: PhantomData,
             },

--- a/framework/base/src/types/interaction/contract_call_convert.rs
+++ b/framework/base/src/types/interaction/contract_call_convert.rs
@@ -1,18 +1,12 @@
 use core::marker::PhantomData;
 
 use crate::{
-    api::{
-        CallTypeApi, ESDT_MULTI_TRANSFER_FUNC_NAME, ESDT_NFT_TRANSFER_FUNC_NAME,
-        ESDT_TRANSFER_FUNC_NAME,
-    },
+    api::CallTypeApi,
     contract_base::BlockchainWrapper,
     types::{BigUint, EsdtTokenPayment, ManagedVec},
 };
 
-use super::{
-    contract_call_no_payment::ContractCallNoPayment, ContractCallWithEgld, FunctionCall,
-    ManagedArgBuffer,
-};
+use super::{contract_call_no_payment::ContractCallNoPayment, ContractCallWithEgld};
 
 impl<SA, OriginalResult> ContractCallWithEgld<SA, OriginalResult>
 where
@@ -37,42 +31,20 @@ where
     ) -> Self {
         if payment.token_nonce == 0 {
             // fungible ESDT
-            let mut new_arg_buffer = ManagedArgBuffer::new();
-            new_arg_buffer.push_arg(&payment.token_identifier);
-            new_arg_buffer.push_arg(&payment.amount);
-            if !self.basic.function_call.function_name.is_empty() {
-                new_arg_buffer.push_arg(&self.basic.function_call.function_name);
-            }
-
             ContractCallWithEgld {
                 basic: ContractCallNoPayment {
                     _phantom: PhantomData,
                     to: self.basic.to,
-                    function_call: FunctionCall {
-                        function_name: ESDT_TRANSFER_FUNC_NAME.into(),
-                        arg_buffer: new_arg_buffer.concat(self.basic.function_call.arg_buffer),
-                    },
+                    function_call: self
+                        .basic
+                        .function_call
+                        .convert_to_single_transfer_fungible_call(payment),
                     explicit_gas_limit: self.basic.explicit_gas_limit,
                     _return_type: PhantomData,
                 },
                 egld_payment: BigUint::zero(),
             }
         } else {
-            // NFT
-            // `ESDTNFTTransfer` takes 4 arguments:
-            // arg0 - token identifier
-            // arg1 - nonce
-            // arg2 - quantity to transfer
-            // arg3 - destination address
-            let mut new_arg_buffer = ManagedArgBuffer::new();
-            new_arg_buffer.push_arg(&payment.token_identifier);
-            new_arg_buffer.push_arg(payment.token_nonce);
-            new_arg_buffer.push_arg(&payment.amount);
-            new_arg_buffer.push_arg(&self.basic.to);
-            if !self.basic.function_call.function_name.is_empty() {
-                new_arg_buffer.push_arg(&self.basic.function_call.function_name);
-            }
-
             // nft transfer is sent to self, sender = receiver
             let recipient_addr = BlockchainWrapper::<SA>::new().get_sc_address();
 
@@ -80,10 +52,10 @@ where
                 basic: ContractCallNoPayment {
                     _phantom: PhantomData,
                     to: recipient_addr,
-                    function_call: FunctionCall {
-                        function_name: ESDT_NFT_TRANSFER_FUNC_NAME.into(),
-                        arg_buffer: new_arg_buffer.concat(self.basic.function_call.arg_buffer),
-                    },
+                    function_call: self
+                        .basic
+                        .function_call
+                        .convert_to_single_transfer_nft_call(&self.basic.to, payment),
                     explicit_gas_limit: self.basic.explicit_gas_limit,
                     _return_type: PhantomData,
                 },
@@ -96,19 +68,6 @@ where
         self,
         payments: ManagedVec<SA, EsdtTokenPayment<SA>>,
     ) -> Self {
-        let mut new_arg_buffer = ManagedArgBuffer::new();
-        new_arg_buffer.push_arg(self.basic.to);
-        new_arg_buffer.push_arg(payments.len());
-
-        for payment in payments.into_iter() {
-            new_arg_buffer.push_arg(payment.token_identifier);
-            new_arg_buffer.push_arg(payment.token_nonce);
-            new_arg_buffer.push_arg(payment.amount);
-        }
-        if !self.basic.function_call.function_name.is_empty() {
-            new_arg_buffer.push_arg(self.basic.function_call.function_name);
-        }
-
         // multi transfer is sent to self, sender = receiver
         let recipient_addr = BlockchainWrapper::<SA>::new().get_sc_address();
 
@@ -116,10 +75,10 @@ where
             basic: ContractCallNoPayment {
                 _phantom: PhantomData,
                 to: recipient_addr,
-                function_call: FunctionCall {
-                    function_name: ESDT_MULTI_TRANSFER_FUNC_NAME.into(),
-                    arg_buffer: new_arg_buffer.concat(self.basic.function_call.arg_buffer),
-                },
+                function_call: self
+                    .basic
+                    .function_call
+                    .convert_to_multi_transfer_esdt_call(&self.basic.to, payments),
                 explicit_gas_limit: self.basic.explicit_gas_limit,
                 _return_type: PhantomData,
             },

--- a/framework/base/src/types/interaction/contract_call_exec.rs
+++ b/framework/base/src/types/interaction/contract_call_exec.rs
@@ -32,8 +32,8 @@ where
 
     pub fn to_call_data_string(&self) -> ManagedBuffer<SA> {
         let mut result = ManagedBufferCachedBuilder::default();
-        result.append_managed_buffer(&self.basic.endpoint_name);
-        for arg in self.basic.arg_buffer.raw_arg_iter() {
+        result.append_managed_buffer(&self.basic.function_call.function_name);
+        for arg in self.basic.function_call.arg_buffer.raw_arg_iter() {
             result.append_bytes(b"@");
             SCLowerHex::fmt(&*arg, &mut result);
         }
@@ -44,8 +44,8 @@ where
         AsyncCall {
             to: self.basic.to,
             egld_payment: self.egld_payment,
-            endpoint_name: self.basic.endpoint_name,
-            arg_buffer: self.basic.arg_buffer,
+            endpoint_name: self.basic.function_call.function_name,
+            arg_buffer: self.basic.function_call.arg_buffer,
             callback_call: None,
         }
     }
@@ -55,8 +55,8 @@ where
         super::AsyncCallPromises {
             to: self.basic.to,
             egld_payment: self.egld_payment,
-            endpoint_name: self.basic.endpoint_name,
-            arg_buffer: self.basic.arg_buffer,
+            endpoint_name: self.basic.function_call.function_name,
+            arg_buffer: self.basic.function_call.arg_buffer,
             explicit_gas_limit: self.basic.explicit_gas_limit,
             extra_gas_for_callback: 0,
             callback_call: None,
@@ -73,8 +73,8 @@ where
             self.resolve_gas_limit(),
             &self.basic.to,
             &self.egld_payment,
-            &self.basic.endpoint_name,
-            &self.basic.arg_buffer,
+            &self.basic.function_call.function_name,
+            &self.basic.function_call.arg_buffer,
         );
 
         SendRawWrapper::<SA>::new().clean_return_data();
@@ -89,8 +89,8 @@ where
         let raw_result = SendRawWrapper::<SA>::new().execute_on_dest_context_readonly_raw(
             self.resolve_gas_limit(),
             &self.basic.to,
-            &self.basic.endpoint_name,
-            &self.basic.arg_buffer,
+            &self.basic.function_call.function_name,
+            &self.basic.function_call.arg_buffer,
         );
 
         SendRawWrapper::<SA>::new().clean_return_data();
@@ -106,8 +106,8 @@ where
             self.resolve_gas_limit(),
             &self.basic.to,
             &self.egld_payment,
-            &self.basic.endpoint_name,
-            &self.basic.arg_buffer,
+            &self.basic.function_call.function_name,
+            &self.basic.function_call.arg_buffer,
         );
 
         SendRawWrapper::<SA>::new().clean_return_data();
@@ -139,8 +139,8 @@ where
             &self.to,
             &egld_payment,
             gas_limit,
-            &self.endpoint_name,
-            &self.arg_buffer,
+            &self.function_call.function_name,
+            &self.function_call.arg_buffer,
         );
     }
 
@@ -154,8 +154,8 @@ where
                 &payment.token_identifier,
                 &payment.amount,
                 gas_limit,
-                &self.endpoint_name,
-                &self.arg_buffer,
+                &self.function_call.function_name,
+                &self.function_call.arg_buffer,
             );
         } else {
             // non-fungible/semi-fungible ESDT
@@ -165,8 +165,8 @@ where
                 payment.token_nonce,
                 &payment.amount,
                 gas_limit,
-                &self.endpoint_name,
-                &self.arg_buffer,
+                &self.function_call.function_name,
+                &self.function_call.arg_buffer,
             );
         }
     }
@@ -180,8 +180,8 @@ where
             &self.to,
             &payments,
             gas_limit,
-            &self.endpoint_name,
-            &self.arg_buffer,
+            &self.function_call.function_name,
+            &self.function_call.arg_buffer,
         );
     }
 

--- a/framework/base/src/types/interaction/contract_call_exec.rs
+++ b/framework/base/src/types/interaction/contract_call_exec.rs
@@ -44,8 +44,7 @@ where
         AsyncCall {
             to: self.basic.to,
             egld_payment: self.egld_payment,
-            endpoint_name: self.basic.function_call.function_name,
-            arg_buffer: self.basic.function_call.arg_buffer,
+            function_call: self.basic.function_call,
             callback_call: None,
         }
     }
@@ -55,8 +54,7 @@ where
         super::AsyncCallPromises {
             to: self.basic.to,
             egld_payment: self.egld_payment,
-            endpoint_name: self.basic.function_call.function_name,
-            arg_buffer: self.basic.function_call.arg_buffer,
+            function_call: self.basic.function_call,
             explicit_gas_limit: self.basic.explicit_gas_limit,
             extra_gas_for_callback: 0,
             callback_call: None,

--- a/framework/base/src/types/interaction/contract_call_no_payment.rs
+++ b/framework/base/src/types/interaction/contract_call_no_payment.rs
@@ -162,4 +162,8 @@ where
     ) -> ContractCallWithEgldOrSingleEsdt<SA, OriginalResult> {
         self.with_egld_or_single_esdt_transfer((payment_token, payment_nonce, payment_amount))
     }
+
+    pub fn into_function_call(self) -> FunctionCall<SA> {
+        self.function_call
+    }
 }

--- a/framework/base/src/types/interaction/contract_call_no_payment.rs
+++ b/framework/base/src/types/interaction/contract_call_no_payment.rs
@@ -13,7 +13,7 @@ use crate::{
 use super::{
     contract_call_exec::UNSPECIFIED_GAS_LIMIT, contract_call_with_egld::ContractCallWithEgld,
     contract_call_with_multi_esdt::ContractCallWithMultiEsdt, ContractCall,
-    ContractCallWithAnyPayment, ContractCallWithEgldOrSingleEsdt, ManagedArgBuffer,
+    ContractCallWithAnyPayment, ContractCallWithEgldOrSingleEsdt, FunctionCall, ManagedArgBuffer,
 };
 
 /// Holds metadata for calling another contract, without payments.
@@ -29,8 +29,7 @@ where
 {
     pub(super) _phantom: PhantomData<SA>,
     pub to: ManagedAddress<SA>,
-    pub endpoint_name: ManagedBuffer<SA>,
-    pub arg_buffer: ManagedArgBuffer<SA>,
+    pub function_call: FunctionCall<SA>,
     pub explicit_gas_limit: u64,
     pub(super) _return_type: PhantomData<OriginalResult>,
 }
@@ -68,8 +67,10 @@ where
         ContractCallNoPayment {
             _phantom: PhantomData,
             to,
-            endpoint_name: endpoint_name.into(),
-            arg_buffer: ManagedArgBuffer::new(),
+            function_call: FunctionCall {
+                function_name: endpoint_name.into(),
+                arg_buffer: ManagedArgBuffer::new(),
+            },
             explicit_gas_limit: UNSPECIFIED_GAS_LIMIT,
             _return_type: PhantomData,
         }

--- a/framework/base/src/types/interaction/contract_call_trait.rs
+++ b/framework/base/src/types/interaction/contract_call_trait.rs
@@ -1,8 +1,6 @@
 use crate::codec::{multi_types::IgnoreValue, TopDecodeMulti, TopEncodeMulti};
 
-use crate::{
-    api::CallTypeApi, contract_base::ExitCodecErrorHandler, err_msg, types::ManagedBuffer,
-};
+use crate::{api::CallTypeApi, types::ManagedBuffer};
 
 use super::{AsyncCall, ContractCallNoPayment, ContractCallWithEgld, ManagedArgBuffer};
 
@@ -27,9 +25,10 @@ where
     /// Used by the generated proxies to add arguments to a call.
     #[doc(hidden)]
     fn proxy_arg<T: TopEncodeMulti>(&mut self, endpoint_arg: &T) {
-        let h = ExitCodecErrorHandler::<SA>::from(err_msg::CONTRACT_CALL_ENCODE_ERROR);
-        let Ok(()) =
-            endpoint_arg.multi_encode_or_handle_err(&mut self.get_mut_basic().arg_buffer, h);
+        self.get_mut_basic()
+            .function_call
+            .arg_buffer
+            .push_multi_arg(endpoint_arg);
     }
 
     /// Serializes and pushes a value to the arguments buffer.
@@ -48,12 +47,15 @@ where
     ///
     /// No serialization occurs, just direct conversion to ManagedBuffer.
     fn push_raw_argument<RawArg: Into<ManagedBuffer<SA>>>(&mut self, raw_arg: RawArg) {
-        self.get_mut_basic().arg_buffer.push_arg_raw(raw_arg.into())
+        self.get_mut_basic()
+            .function_call
+            .arg_buffer
+            .push_arg_raw(raw_arg.into())
     }
 
     /// For cases where we build the contract call by hand.
     fn with_raw_arguments(mut self, raw_argument_buffer: ManagedArgBuffer<SA>) -> Self {
-        self.get_mut_basic().arg_buffer = raw_argument_buffer;
+        self.get_mut_basic().function_call.arg_buffer = raw_argument_buffer;
         self
     }
 

--- a/framework/base/src/types/interaction/function_call.rs
+++ b/framework/base/src/types/interaction/function_call.rs
@@ -1,9 +1,13 @@
-use multiversx_sc_codec::TopEncodeMulti;
+use multiversx_sc_codec::{
+    DecodeErrorHandler, EncodeErrorHandler, TopDecodeMulti, TopDecodeMultiInput, TopEncodeMulti,
+    TopEncodeMultiOutput,
+};
 
 use crate::{
+    abi::{TypeAbi, TypeName},
     api::ManagedTypeApi,
     formatter::SCLowerHex,
-    types::{ManagedBuffer, ManagedBufferCachedBuilder},
+    types::{ManagedBuffer, ManagedBufferCachedBuilder, MultiValueEncoded},
 };
 
 use super::ManagedArgBuffer;
@@ -23,6 +27,9 @@ impl<Api> FunctionCall<Api>
 where
     Api: ManagedTypeApi,
 {
+    /// Initializes a new function call with a function call name.
+    ///
+    /// The arguments will need to be added afterwards.
     pub fn new<N: Into<ManagedBuffer<Api>>>(function_name: N) -> Self {
         FunctionCall {
             function_name: function_name.into(),
@@ -30,6 +37,21 @@ where
         }
     }
 
+    /// Initializes a new empty function call, this means no function name and no arguments.
+    pub fn empty() -> Self {
+        FunctionCall::new(ManagedBuffer::new())
+    }
+
+    /// Empty function calls have empty function names.
+    ///
+    /// There should be no function call with empty function call but with arguments.
+    pub fn is_empty(&self) -> bool {
+        self.function_name.is_empty()
+    }
+
+    /// Adds an argument of any serializable type.
+    ///
+    /// Multi-values are accepted. No type checking performed.
     pub fn argument<T: TopEncodeMulti>(mut self, arg: &T) -> Self {
         self.arg_buffer.push_multi_arg(arg);
         self
@@ -43,5 +65,62 @@ where
             SCLowerHex::fmt(&*arg, &mut result);
         }
         result.into_managed_buffer()
+    }
+}
+
+impl<Api> TopEncodeMulti for FunctionCall<Api>
+where
+    Api: ManagedTypeApi,
+{
+    fn multi_encode_or_handle_err<O, H>(&self, output: &mut O, h: H) -> Result<(), H::HandledErr>
+    where
+        O: TopEncodeMultiOutput,
+        H: EncodeErrorHandler,
+    {
+        if self.function_name.is_empty() {
+            return Ok(());
+        }
+        output.push_single_value(&self.function_name, h)?;
+        for arg in self.arg_buffer.raw_arg_iter() {
+            output.push_single_value(&*arg, h)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<Api> TopDecodeMulti for FunctionCall<Api>
+where
+    Api: ManagedTypeApi,
+{
+    fn multi_decode_or_handle_err<I, H>(input: &mut I, h: H) -> Result<Self, H::HandledErr>
+    where
+        I: TopDecodeMultiInput,
+        H: DecodeErrorHandler,
+    {
+        if !input.has_next() {
+            return Ok(FunctionCall::empty());
+        }
+
+        let function_name = ManagedBuffer::<Api>::multi_decode_or_handle_err(input, h)?;
+        let args =
+            MultiValueEncoded::<Api, ManagedBuffer<Api>>::multi_decode_or_handle_err(input, h)?;
+        Ok(FunctionCall {
+            function_name,
+            arg_buffer: args.to_arg_buffer(),
+        })
+    }
+}
+
+impl<Api> TypeAbi for FunctionCall<Api>
+where
+    Api: ManagedTypeApi,
+{
+    fn type_name() -> TypeName {
+        crate::abi::type_name_variadic::<ManagedBuffer<Api>>()
+    }
+
+    fn is_variadic() -> bool {
+        true
     }
 }

--- a/framework/base/src/types/interaction/function_call.rs
+++ b/framework/base/src/types/interaction/function_call.rs
@@ -1,0 +1,47 @@
+use multiversx_sc_codec::TopEncodeMulti;
+
+use crate::{
+    api::ManagedTypeApi,
+    formatter::SCLowerHex,
+    types::{ManagedBuffer, ManagedBufferCachedBuilder},
+};
+
+use super::ManagedArgBuffer;
+
+/// Encodes a function call on the blockchain, composed of a function name and its encoded arguments.
+///
+/// Can be used as a multi-argument, to embed a call within a call.
+pub struct FunctionCall<Api>
+where
+    Api: ManagedTypeApi,
+{
+    pub function_name: ManagedBuffer<Api>,
+    pub arg_buffer: ManagedArgBuffer<Api>,
+}
+
+impl<Api> FunctionCall<Api>
+where
+    Api: ManagedTypeApi,
+{
+    pub fn new<N: Into<ManagedBuffer<Api>>>(function_name: N) -> Self {
+        FunctionCall {
+            function_name: function_name.into(),
+            arg_buffer: ManagedArgBuffer::new(),
+        }
+    }
+
+    pub fn argument<T: TopEncodeMulti>(mut self, arg: &T) -> Self {
+        self.arg_buffer.push_multi_arg(arg);
+        self
+    }
+
+    pub fn to_call_data_string(&self) -> ManagedBuffer<Api> {
+        let mut result = ManagedBufferCachedBuilder::default();
+        result.append_managed_buffer(&self.function_name);
+        for arg in self.arg_buffer.raw_arg_iter() {
+            result.append_bytes(b"@");
+            SCLowerHex::fmt(&*arg, &mut result);
+        }
+        result.into_managed_buffer()
+    }
+}

--- a/framework/base/src/types/interaction/managed_arg_buffer.rs
+++ b/framework/base/src/types/interaction/managed_arg_buffer.rs
@@ -14,6 +14,7 @@ use crate::{
     },
 };
 use alloc::vec::Vec;
+use multiversx_sc_codec::TopEncodeMulti;
 
 #[derive(Debug, Default, Clone)]
 #[repr(transparent)]
@@ -180,6 +181,11 @@ where
             ExitCodecErrorHandler::<M>::from(err_msg::CONTRACT_CALL_ENCODE_ERROR),
         );
         self.push_arg_raw(encoded_buffer);
+    }
+
+    pub fn push_multi_arg<T: TopEncodeMulti>(&mut self, arg: &T) {
+        let h = ExitCodecErrorHandler::<M>::from(err_msg::CONTRACT_CALL_ENCODE_ERROR);
+        let Ok(()) = arg.multi_encode_or_handle_err(self, h);
     }
 }
 

--- a/framework/base/src/types/interaction/managed_arg_buffer.rs
+++ b/framework/base/src/types/interaction/managed_arg_buffer.rs
@@ -168,6 +168,10 @@ where
     pub fn into_multi_value_encoded(self) -> MultiValueEncoded<M, ManagedBuffer<M>> {
         self.data.into()
     }
+
+    pub fn into_vec_of_buffers(self) -> ManagedVec<M, ManagedBuffer<M>> {
+        self.data
+    }
 }
 
 impl<M> ManagedArgBuffer<M>

--- a/framework/base/src/types/interaction/mod.rs
+++ b/framework/base/src/types/interaction/mod.rs
@@ -11,6 +11,7 @@ mod contract_call_with_egld;
 mod contract_call_with_egld_or_single_esdt;
 mod contract_call_with_multi_esdt;
 mod contract_deploy;
+mod function_call;
 mod managed_arg_buffer;
 
 pub use async_call::AsyncCall;
@@ -26,4 +27,5 @@ pub use contract_call_with_egld::ContractCallWithEgld;
 pub use contract_call_with_egld_or_single_esdt::ContractCallWithEgldOrSingleEsdt;
 pub use contract_call_with_multi_esdt::ContractCallWithMultiEsdt;
 pub use contract_deploy::{new_contract_deploy, ContractDeploy};
+pub use function_call::FunctionCall;
 pub use managed_arg_buffer::ManagedArgBuffer;

--- a/framework/base/src/types/managed/wrapped/esdt_token_data.rs
+++ b/framework/base/src/types/managed/wrapped/esdt_token_data.rs
@@ -16,7 +16,9 @@ use crate::derive::TypeAbi;
 
 const DECODE_ATTRIBUTE_ERROR_PREFIX: &[u8] = b"error decoding ESDT attributes: ";
 
-#[derive(Clone, TopDecode, TopEncode, NestedDecode, NestedEncode, TypeAbi, Debug, ManagedVecItem)]
+#[derive(
+    Clone, TopDecode, TopEncode, NestedDecode, NestedEncode, TypeAbi, Debug, ManagedVecItem,
+)]
 pub struct EsdtTokenData<M: ManagedTypeApi> {
     pub token_type: EsdtTokenType,
     pub amount: BigUint<M>,

--- a/framework/derive/src/preprocessing/substitution_list.rs
+++ b/framework/derive/src/preprocessing/substitution_list.rs
@@ -82,6 +82,7 @@ fn add_managed_types(substitutions: &mut SubstitutionsMap) {
     add_managed_type_with_generics(substitutions, &quote!(PreloadedManagedBuffer));
     add_managed_type(substitutions, &quote!(RandomnessSource));
     add_managed_type(substitutions, &quote!(TokenIdentifier));
+    add_managed_type(substitutions, &quote!(FunctionCall));
 }
 
 fn add_storage_mapper_single_generic_arg(

--- a/framework/scenario/src/scenario/model/step/sc_call_step.rs
+++ b/framework/scenario/src/scenario/model/step/sc_call_step.rs
@@ -234,13 +234,14 @@ where
     let function = String::from_utf8(
         normalized_cc
             .basic
-            .endpoint_name
+            .function_call
+            .function_name
             .to_boxed_bytes()
             .into_vec(),
     )
     .unwrap();
     let egld_value_expr = BigUintValue::from(normalized_cc.egld_payment);
-    let scenario_args = convert_call_args(&normalized_cc.basic.arg_buffer);
+    let scenario_args = convert_call_args(&normalized_cc.basic.function_call.arg_buffer);
     (to_str, function, egld_value_expr, scenario_args)
 }
 

--- a/framework/scenario/tests/contract_call_test.rs
+++ b/framework/scenario/tests/contract_call_test.rs
@@ -13,7 +13,7 @@ fn test_contract_call_multi_esdt() {
     let cc = tx.tx.to_contract_call();
 
     assert_eq!(
-        cc.basic.endpoint_name.to_vec(),
+        cc.basic.function_call.function_name.to_vec(),
         ESDT_MULTI_TRANSFER_FUNC_NAME.as_bytes().to_vec(),
     );
     assert_eq!(

--- a/framework/snippets/src/interactor_sc_call.rs
+++ b/framework/snippets/src/interactor_sc_call.rs
@@ -74,12 +74,13 @@ fn contract_call_to_tx_data(contract_call: &ContractCallWithEgld<StaticApi, ()>)
     let mut result = String::from_utf8(
         contract_call
             .basic
-            .endpoint_name
+            .function_call
+            .function_name
             .to_boxed_bytes()
             .into_vec(),
     )
     .unwrap();
-    for argument in contract_call.basic.arg_buffer.raw_arg_iter() {
+    for argument in contract_call.basic.function_call.arg_buffer.raw_arg_iter() {
         result.push('@');
         result.push_str(hex::encode(argument.to_boxed_bytes().as_slice()).as_str());
     }


### PR DESCRIPTION
Refactoring PR.

`FunctionCall` created to be used inside the framework, but also in contracts like the multisig. It can be encoded as a multi-value argument.

Also refactored some of the code formatting ESDT transfer calls.

Changes are also going to be used in the new unified syntax, but are useful enough on their own to deserve their own PR.