### PR TITLE
sc-meta feature fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,21 +751,12 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
-dependencies = [
- "signature 1.6.4",
-]
-
-[[package]]
-name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8",
- "signature 2.1.0",
+ "signature",
 ]
 
 [[package]]
@@ -775,7 +766,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7277392b266383ef8396db7fdeb1e77b6c52fed775f5df15bb24f35b72156980"
 dependencies = [
  "curve25519-dalek",
- "ed25519 2.2.3",
+ "ed25519",
  "serde",
  "sha2 0.10.8",
  "zeroize",
@@ -2017,7 +2008,6 @@ dependencies = [
  "base64 0.13.1",
  "bech32",
  "bip39",
- "ed25519 1.5.3",
  "hex",
  "hmac",
  "itertools",
@@ -3019,12 +3009,6 @@ checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "signature"
-version = "1.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
 name = "signature"

--- a/contracts/benchmarks/large-storage/meta/Cargo.toml
+++ b/contracts/benchmarks/large-storage/meta/Cargo.toml
@@ -10,3 +10,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../framework/meta"
+default-features = false

--- a/contracts/benchmarks/mappers/linked-list-repeat/meta/Cargo.toml
+++ b/contracts/benchmarks/mappers/linked-list-repeat/meta/Cargo.toml
@@ -11,3 +11,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../../framework/meta"
+default-features = false

--- a/contracts/benchmarks/mappers/map-repeat/meta/Cargo.toml
+++ b/contracts/benchmarks/mappers/map-repeat/meta/Cargo.toml
@@ -11,3 +11,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../../framework/meta"
+default-features = false

--- a/contracts/benchmarks/mappers/queue-repeat/meta/Cargo.toml
+++ b/contracts/benchmarks/mappers/queue-repeat/meta/Cargo.toml
@@ -11,3 +11,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../../framework/meta"
+default-features = false

--- a/contracts/benchmarks/mappers/set-repeat/meta/Cargo.toml
+++ b/contracts/benchmarks/mappers/set-repeat/meta/Cargo.toml
@@ -11,3 +11,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../../framework/meta"
+default-features = false

--- a/contracts/benchmarks/mappers/single-value-repeat/meta/Cargo.toml
+++ b/contracts/benchmarks/mappers/single-value-repeat/meta/Cargo.toml
@@ -11,3 +11,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../../framework/meta"
+default-features = false

--- a/contracts/benchmarks/mappers/vec-repeat/meta/Cargo.toml
+++ b/contracts/benchmarks/mappers/vec-repeat/meta/Cargo.toml
@@ -10,3 +10,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../../framework/meta"
+default-features = false

--- a/contracts/benchmarks/send-tx-repeat/meta/Cargo.toml
+++ b/contracts/benchmarks/send-tx-repeat/meta/Cargo.toml
@@ -10,3 +10,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../framework/meta"
+default-features = false

--- a/contracts/benchmarks/str-repeat/meta/Cargo.toml
+++ b/contracts/benchmarks/str-repeat/meta/Cargo.toml
@@ -10,3 +10,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../framework/meta"
+default-features = false

--- a/contracts/core/price-aggregator/meta/Cargo.toml
+++ b/contracts/core/price-aggregator/meta/Cargo.toml
@@ -14,3 +14,4 @@ path = "../../../../framework/base"
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../framework/meta"
+default-features = false

--- a/contracts/core/wegld-swap/meta/Cargo.toml
+++ b/contracts/core/wegld-swap/meta/Cargo.toml
@@ -17,3 +17,4 @@ path = "../../../../framework/base"
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../framework/meta"
+default-features = false

--- a/contracts/examples/adder/meta/Cargo.toml
+++ b/contracts/examples/adder/meta/Cargo.toml
@@ -10,3 +10,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../framework/meta"
+default-features = false

--- a/contracts/examples/bonding-curve-contract/meta/Cargo.toml
+++ b/contracts/examples/bonding-curve-contract/meta/Cargo.toml
@@ -11,3 +11,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../framework/meta"
+default-features = false

--- a/contracts/examples/check-pause/meta/Cargo.toml
+++ b/contracts/examples/check-pause/meta/Cargo.toml
@@ -11,3 +11,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../framework/meta"
+default-features = false

--- a/contracts/examples/crowdfunding-esdt/meta/Cargo.toml
+++ b/contracts/examples/crowdfunding-esdt/meta/Cargo.toml
@@ -11,3 +11,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../framework/meta"
+default-features = false

--- a/contracts/examples/crypto-bubbles/meta/Cargo.toml
+++ b/contracts/examples/crypto-bubbles/meta/Cargo.toml
@@ -11,3 +11,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../framework/meta"
+default-features = false

--- a/contracts/examples/crypto-kitties/kitty-auction/meta/Cargo.toml
+++ b/contracts/examples/crypto-kitties/kitty-auction/meta/Cargo.toml
@@ -10,3 +10,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../../framework/meta"
+default-features = false

--- a/contracts/examples/crypto-kitties/kitty-genetic-alg/meta/Cargo.toml
+++ b/contracts/examples/crypto-kitties/kitty-genetic-alg/meta/Cargo.toml
@@ -10,3 +10,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../../framework/meta"
+default-features = false

--- a/contracts/examples/crypto-kitties/kitty-ownership/meta/Cargo.toml
+++ b/contracts/examples/crypto-kitties/kitty-ownership/meta/Cargo.toml
@@ -10,3 +10,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../../framework/meta"
+default-features = false

--- a/contracts/examples/crypto-zombies/meta/Cargo.toml
+++ b/contracts/examples/crypto-zombies/meta/Cargo.toml
@@ -10,3 +10,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../framework/meta"
+default-features = false

--- a/contracts/examples/digital-cash/meta/Cargo.toml
+++ b/contracts/examples/digital-cash/meta/Cargo.toml
@@ -10,3 +10,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../framework/meta"
+default-features = false

--- a/contracts/examples/empty/meta/Cargo.toml
+++ b/contracts/examples/empty/meta/Cargo.toml
@@ -10,3 +10,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../framework/meta"
+default-features = false

--- a/contracts/examples/esdt-transfer-with-fee/meta/Cargo.toml
+++ b/contracts/examples/esdt-transfer-with-fee/meta/Cargo.toml
@@ -10,3 +10,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../framework/meta"
+default-features = false

--- a/contracts/examples/factorial/meta/Cargo.toml
+++ b/contracts/examples/factorial/meta/Cargo.toml
@@ -11,3 +11,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../framework/meta"
+default-features = false

--- a/contracts/examples/fractional-nfts/meta/Cargo.toml
+++ b/contracts/examples/fractional-nfts/meta/Cargo.toml
@@ -11,3 +11,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../framework/meta"
+default-features = false

--- a/contracts/examples/lottery-esdt/meta/Cargo.toml
+++ b/contracts/examples/lottery-esdt/meta/Cargo.toml
@@ -11,3 +11,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../framework/meta"
+default-features = false

--- a/contracts/examples/multisig/meta/Cargo.toml
+++ b/contracts/examples/multisig/meta/Cargo.toml
@@ -11,3 +11,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../framework/meta"
+default-features = false

--- a/contracts/examples/nft-minter/meta/Cargo.toml
+++ b/contracts/examples/nft-minter/meta/Cargo.toml
@@ -11,3 +11,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../framework/meta"
+default-features = false

--- a/contracts/examples/nft-storage-prepay/meta/Cargo.toml
+++ b/contracts/examples/nft-storage-prepay/meta/Cargo.toml
@@ -13,3 +13,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../framework/meta"
+default-features = false

--- a/contracts/examples/nft-subscription/meta/Cargo.toml
+++ b/contracts/examples/nft-subscription/meta/Cargo.toml
@@ -11,3 +11,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../framework/meta"
+default-features = false

--- a/contracts/examples/order-book/factory/meta/Cargo.toml
+++ b/contracts/examples/order-book/factory/meta/Cargo.toml
@@ -11,3 +11,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../../framework/meta"
+default-features = false

--- a/contracts/examples/order-book/pair/meta/Cargo.toml
+++ b/contracts/examples/order-book/pair/meta/Cargo.toml
@@ -11,3 +11,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../../framework/meta"
+default-features = false

--- a/contracts/examples/ping-pong-egld/meta/Cargo.toml
+++ b/contracts/examples/ping-pong-egld/meta/Cargo.toml
@@ -11,3 +11,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../framework/meta"
+default-features = false

--- a/contracts/examples/proxy-pause/meta/Cargo.toml
+++ b/contracts/examples/proxy-pause/meta/Cargo.toml
@@ -13,3 +13,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../framework/meta"
+default-features = false

--- a/contracts/examples/rewards-distribution/meta/Cargo.toml
+++ b/contracts/examples/rewards-distribution/meta/Cargo.toml
@@ -13,3 +13,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../framework/meta"
+default-features = false

--- a/contracts/examples/seed-nft-minter/meta/Cargo.toml
+++ b/contracts/examples/seed-nft-minter/meta/Cargo.toml
@@ -13,3 +13,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../framework/meta"
+default-features = false

--- a/contracts/examples/token-release/meta/Cargo.toml
+++ b/contracts/examples/token-release/meta/Cargo.toml
@@ -12,4 +12,5 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../framework/meta"
+default-features = false
 

--- a/contracts/feature-tests/abi-tester/meta/Cargo.toml
+++ b/contracts/feature-tests/abi-tester/meta/Cargo.toml
@@ -11,3 +11,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../framework/meta"
+default-features = false

--- a/contracts/feature-tests/alloc-features/meta/Cargo.toml
+++ b/contracts/feature-tests/alloc-features/meta/Cargo.toml
@@ -11,3 +11,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../framework/meta"
+default-features = false

--- a/contracts/feature-tests/basic-features/meta/Cargo.toml
+++ b/contracts/feature-tests/basic-features/meta/Cargo.toml
@@ -11,3 +11,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../framework/meta"
+default-features = false

--- a/contracts/feature-tests/big-float-features/meta/Cargo.toml
+++ b/contracts/feature-tests/big-float-features/meta/Cargo.toml
@@ -11,3 +11,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../framework/meta"
+default-features = false

--- a/contracts/feature-tests/composability/builtin-func-features/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/builtin-func-features/meta/Cargo.toml
@@ -10,3 +10,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../../framework/meta"
+default-features = false

--- a/contracts/feature-tests/composability/esdt-contract-pair/first-contract/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/esdt-contract-pair/first-contract/meta/Cargo.toml
@@ -14,3 +14,4 @@ path = "../../../../../../framework/base"
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../../../framework/meta"
+default-features = false

--- a/contracts/feature-tests/composability/esdt-contract-pair/second-contract/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/esdt-contract-pair/second-contract/meta/Cargo.toml
@@ -14,3 +14,4 @@ path = "../../../../../../framework/base"
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../../../framework/meta"
+default-features = false

--- a/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/child/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/child/meta/Cargo.toml
@@ -14,3 +14,4 @@ path = "../../../../../../framework/base"
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../../../framework/meta"
+default-features = false

--- a/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/parent/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/parent/meta/Cargo.toml
@@ -14,3 +14,4 @@ path = "../../../../../../framework/base"
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../../../framework/meta"
+default-features = false

--- a/contracts/feature-tests/composability/forwarder-queue/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/forwarder-queue/meta/Cargo.toml
@@ -10,3 +10,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../../framework/meta"
+default-features = false

--- a/contracts/feature-tests/composability/forwarder-raw/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/forwarder-raw/meta/Cargo.toml
@@ -10,3 +10,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../../framework/meta"
+default-features = false

--- a/contracts/feature-tests/composability/forwarder/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/forwarder/meta/Cargo.toml
@@ -10,3 +10,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../../framework/meta"
+default-features = false

--- a/contracts/feature-tests/composability/local-esdt-and-nft/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/local-esdt-and-nft/meta/Cargo.toml
@@ -10,3 +10,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../../framework/meta"
+default-features = false

--- a/contracts/feature-tests/composability/promises-features/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/promises-features/meta/Cargo.toml
@@ -10,3 +10,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../../framework/meta"
+default-features = false

--- a/contracts/feature-tests/composability/proxy-test-first/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/proxy-test-first/meta/Cargo.toml
@@ -10,3 +10,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../../framework/meta"
+default-features = false

--- a/contracts/feature-tests/composability/proxy-test-second/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/proxy-test-second/meta/Cargo.toml
@@ -10,3 +10,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../../framework/meta"
+default-features = false

--- a/contracts/feature-tests/composability/recursive-caller/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/recursive-caller/meta/Cargo.toml
@@ -10,3 +10,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../../framework/meta"
+default-features = false

--- a/contracts/feature-tests/composability/transfer-role-features/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/transfer-role-features/meta/Cargo.toml
@@ -10,3 +10,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../../framework/meta"
+default-features = false

--- a/contracts/feature-tests/composability/vault/meta/Cargo.toml
+++ b/contracts/feature-tests/composability/vault/meta/Cargo.toml
@@ -10,3 +10,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../../framework/meta"
+default-features = false

--- a/contracts/feature-tests/erc-style-contracts/crowdfunding-erc20/meta/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/crowdfunding-erc20/meta/Cargo.toml
@@ -11,3 +11,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../../framework/meta"
+default-features = false

--- a/contracts/feature-tests/erc-style-contracts/erc1155-marketplace/meta/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/erc1155-marketplace/meta/Cargo.toml
@@ -11,3 +11,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../../framework/meta"
+default-features = false

--- a/contracts/feature-tests/erc-style-contracts/erc1155-user-mock/meta/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/erc1155-user-mock/meta/Cargo.toml
@@ -11,3 +11,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../../framework/meta"
+default-features = false

--- a/contracts/feature-tests/erc-style-contracts/erc1155/meta/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/erc1155/meta/Cargo.toml
@@ -11,3 +11,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../../framework/meta"
+default-features = false

--- a/contracts/feature-tests/erc-style-contracts/erc20/meta/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/erc20/meta/Cargo.toml
@@ -11,3 +11,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../../framework/meta"
+default-features = false

--- a/contracts/feature-tests/erc-style-contracts/erc721/meta/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/erc721/meta/Cargo.toml
@@ -11,3 +11,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../../framework/meta"
+default-features = false

--- a/contracts/feature-tests/erc-style-contracts/lottery-erc20/meta/Cargo.toml
+++ b/contracts/feature-tests/erc-style-contracts/lottery-erc20/meta/Cargo.toml
@@ -11,3 +11,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../../framework/meta"
+default-features = false

--- a/contracts/feature-tests/esdt-system-sc-mock/meta/Cargo.toml
+++ b/contracts/feature-tests/esdt-system-sc-mock/meta/Cargo.toml
@@ -11,3 +11,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../framework/meta"
+default-features = false

--- a/contracts/feature-tests/formatted-message-features/meta/Cargo.toml
+++ b/contracts/feature-tests/formatted-message-features/meta/Cargo.toml
@@ -13,3 +13,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../framework/meta"
+default-features = false

--- a/contracts/feature-tests/managed-map-features/meta/Cargo.toml
+++ b/contracts/feature-tests/managed-map-features/meta/Cargo.toml
@@ -10,3 +10,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../framework/meta"
+default-features = false

--- a/contracts/feature-tests/multi-contract-features/meta/Cargo.toml
+++ b/contracts/feature-tests/multi-contract-features/meta/Cargo.toml
@@ -11,3 +11,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../framework/meta"
+default-features = false

--- a/contracts/feature-tests/panic-message-features/meta/Cargo.toml
+++ b/contracts/feature-tests/panic-message-features/meta/Cargo.toml
@@ -10,3 +10,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../framework/meta"
+default-features = false

--- a/contracts/feature-tests/payable-features/meta/Cargo.toml
+++ b/contracts/feature-tests/payable-features/meta/Cargo.toml
@@ -11,3 +11,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../framework/meta"
+default-features = false

--- a/contracts/feature-tests/rust-snippets-generator-test/meta/Cargo.toml
+++ b/contracts/feature-tests/rust-snippets-generator-test/meta/Cargo.toml
@@ -11,3 +11,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../framework/meta"
+default-features = false

--- a/contracts/feature-tests/rust-testing-framework-tester/meta/Cargo.toml
+++ b/contracts/feature-tests/rust-testing-framework-tester/meta/Cargo.toml
@@ -10,3 +10,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../framework/meta"
+default-features = false

--- a/contracts/feature-tests/use-module/meta/Cargo.toml
+++ b/contracts/feature-tests/use-module/meta/Cargo.toml
@@ -11,3 +11,4 @@ path = ".."
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../framework/meta"
+default-features = false

--- a/contracts/feature-tests/use-module/meta/abi/Cargo.toml
+++ b/contracts/feature-tests/use-module/meta/abi/Cargo.toml
@@ -15,3 +15,4 @@ path = "../../../../framework/base"
 [dependencies.multiversx-sc-meta]
 version = "0.45.0"
 path = "../../../../framework/meta"
+default-features = false

--- a/framework/meta/Cargo.toml
+++ b/framework/meta/Cargo.toml
@@ -26,6 +26,10 @@ standalone = ["ruplacer", "reqwest", "zip", "copy_dir", "pathdiff", "common-path
 template-test-current = []
 template-test-released = []
 
+# no other way to have a default feature in bin at the moment
+# contract meta crates should add `default-features = false`
+default = ["standalone"]
+
 [dependencies]
 clap = { version = "4.4.7", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/framework/meta/src/cmd/standalone/upgrade.rs
+++ b/framework/meta/src/cmd/standalone/upgrade.rs
@@ -1,6 +1,7 @@
 mod upgrade_0_31;
 mod upgrade_0_32;
 mod upgrade_0_39;
+mod upgrade_0_45;
 pub(crate) mod upgrade_common;
 mod upgrade_print;
 mod upgrade_selector;

--- a/framework/meta/src/cmd/standalone/upgrade/upgrade_0_45.rs
+++ b/framework/meta/src/cmd/standalone/upgrade/upgrade_0_45.rs
@@ -1,0 +1,36 @@
+use std::path::Path;
+
+use super::upgrade_common::version_bump_in_cargo_toml;
+use crate::{
+    folder_structure::{DirectoryType, RelevantDirectory},
+    CargoTomlContents,
+};
+use toml::Value;
+
+/// Migrate `0.44.0` to `0.45.0`, including the version bump.
+pub fn upgrade_to_45_0(dir: &RelevantDirectory) {
+    if dir.dir_type == DirectoryType::Contract {
+        v_0_45_prepare_meta(&dir.path);
+    }
+    let (from_version, to_version) = dir.upgrade_in_progress.unwrap();
+    version_bump_in_cargo_toml(&dir.path, from_version, to_version);
+}
+
+fn v_0_45_prepare_meta(sc_crate_path: &Path) {
+    let cargo_toml_path = sc_crate_path.join("meta/Cargo.toml");
+    assert!(
+        cargo_toml_path.exists(),
+        "SC crate Cargo.toml not found: {}",
+        cargo_toml_path.display()
+    );
+    let mut meta_cargo_toml = CargoTomlContents::load_from_file(&cargo_toml_path);
+    let deps = meta_cargo_toml.dependencies_mut();
+    if let Some(meta_dep) = deps.get_mut("multiversx-sc-meta") {
+        let meta_dep_table = meta_dep
+            .as_table_mut()
+            .expect("multiversx-sc-meta dependency expected to be given as a table");
+        meta_dep_table.remove("default-features");
+        meta_dep_table.insert("default-features".to_string(), Value::Boolean(false));
+    }
+    meta_cargo_toml.save_to_file(&cargo_toml_path);
+}

--- a/framework/meta/src/cmd/standalone/upgrade/upgrade_selector.rs
+++ b/framework/meta/src/cmd/standalone/upgrade/upgrade_selector.rs
@@ -8,6 +8,7 @@ use super::{
     upgrade_0_31::upgrade_to_31_0,
     upgrade_0_32::upgrade_to_32_0,
     upgrade_0_39::{postprocessing_after_39_0, upgrade_to_39_0},
+    upgrade_0_45::upgrade_to_45_0,
     upgrade_common::{cargo_check, version_bump_in_cargo_toml},
     upgrade_print::*,
 };
@@ -74,6 +75,9 @@ fn upgrade_function_selector(dir: &RelevantDirectory) {
         },
         Some((_, "0.39.0")) => {
             upgrade_to_39_0(dir);
+        },
+        Some((_, "0.45.0")) => {
+            upgrade_to_45_0(dir);
         },
         Some((from_version, to_version)) => {
             version_bump_in_cargo_toml(&dir.path, from_version, to_version);

--- a/sdk/core/Cargo.toml
+++ b/sdk/core/Cargo.toml
@@ -29,7 +29,6 @@ sha3 = "0.9.1"
 hmac = { version = "0.11.0", features = ["std"] }
 hex = "0.4.3"
 base64 = "0.13.0"
-ed25519 = "1.2.0"
 pbkdf2 = { version = "0.9.0", default-features = false }
 zeroize = "1.4.2"
 bech32 = "0.9"


### PR DESCRIPTION
The "standalone" feature in sc-meta needs to be default, to no interfere with the normal installation process.

To retain the faster builds, contract meta crates will have the default features turned off.