### PR TITLE
codec derive hygiene

### DIFF
--- a/data/codec-derive/src/nested_de_derive.rs
+++ b/data/codec-derive/src/nested_de_derive.rs
@@ -11,11 +11,11 @@ pub fn dep_decode_snippet(
     let ty = &field.ty;
     if let Some(ident) = &field.ident {
         quote! {
-            #ident: <#ty as codec::NestedDecode>::dep_decode_or_handle_err(#input_value, h)?
+            #ident: <#ty as codec::NestedDecode>::dep_decode_or_handle_err(#input_value, __h__)?
         }
     } else {
         quote! {
-            <#ty as codec::NestedDecode>::dep_decode_or_handle_err(#input_value, h)?
+            <#ty as codec::NestedDecode>::dep_decode_or_handle_err(#input_value, __h__)?
         }
     }
 }
@@ -53,7 +53,7 @@ pub fn nested_decode_impl(ast: &syn::DeriveInput) -> TokenStream {
                 });
             quote! {
                 impl #impl_generics codec::NestedDecode for #name #ty_generics #where_clause {
-                    fn dep_decode_or_handle_err<I, H>(input: &mut I, h: H) -> core::result::Result<Self, H::HandledErr>
+                    fn dep_decode_or_handle_err<I, H>(input: &mut I, __h__: H) -> core::result::Result<Self, H::HandledErr>
                     where
                         I: codec::NestedDecodeInput,
                         H: codec::DecodeErrorHandler,
@@ -75,14 +75,14 @@ pub fn nested_decode_impl(ast: &syn::DeriveInput) -> TokenStream {
 
             quote! {
                 impl #impl_generics codec::NestedDecode for #name #ty_generics #where_clause {
-                    fn dep_decode_or_handle_err<I, H>(input: &mut I, h: H) -> core::result::Result<Self, H::HandledErr>
+                    fn dep_decode_or_handle_err<I, H>(input: &mut I, __h__: H) -> core::result::Result<Self, H::HandledErr>
                     where
                         I: codec::NestedDecodeInput,
                         H: codec::DecodeErrorHandler,
                     {
-                        match <u8 as codec::NestedDecode>::dep_decode_or_handle_err(input, h)? {
+                        match <u8 as codec::NestedDecode>::dep_decode_or_handle_err(input, __h__)? {
                             #(#variant_dep_decode_snippets)*
-                            _ => core::result::Result::Err(h.handle_error(codec::DecodeError::INVALID_VALUE)),
+                            _ => core::result::Result::Err(__h__.handle_error(codec::DecodeError::INVALID_VALUE)),
                         }
                     }
                 }

--- a/data/codec-derive/src/nested_en_derive.rs
+++ b/data/codec-derive/src/nested_en_derive.rs
@@ -4,7 +4,7 @@ use quote::quote;
 
 pub fn dep_encode_snippet(value: &proc_macro2::TokenStream) -> proc_macro2::TokenStream {
     quote! {
-        codec::NestedEncode::dep_encode_or_handle_err(&#value, dest, h)?;
+        codec::NestedEncode::dep_encode_or_handle_err(&#value, __dest__, __h__)?;
     }
 }
 
@@ -26,7 +26,7 @@ fn variant_dep_encode_snippets(
             });
             quote! {
                 #name::#variant_ident #local_var_declarations => {
-                    codec::NestedEncode::dep_encode_or_handle_err(&#variant_index_u8, dest, h)?;
+                    codec::NestedEncode::dep_encode_or_handle_err(&#variant_index_u8, __dest__, __h__)?;
                     #(#variant_field_snippets)*
                 },
             }
@@ -44,7 +44,7 @@ pub fn nested_encode_impl(ast: &syn::DeriveInput) -> TokenStream {
             });
             quote! {
                 impl #impl_generics codec::NestedEncode for #name #ty_generics #where_clause {
-                    fn dep_encode_or_handle_err<O, H>(&self, dest: &mut O, h: H) -> core::result::Result<(), H::HandledErr>
+                    fn dep_encode_or_handle_err<O, H>(&self, __dest__: &mut O, __h__: H) -> core::result::Result<(), H::HandledErr>
                     where
                         O: codec::NestedEncodeOutput,
                         H: codec::EncodeErrorHandler,
@@ -64,7 +64,7 @@ pub fn nested_encode_impl(ast: &syn::DeriveInput) -> TokenStream {
 
             quote! {
                 impl #impl_generics codec::NestedEncode for #name #ty_generics #where_clause {
-                    fn dep_encode_or_handle_err<O, H>(&self, dest: &mut O, h: H) -> core::result::Result<(), H::HandledErr>
+                    fn dep_encode_or_handle_err<O, H>(&self, __dest__: &mut O, __h__: H) -> core::result::Result<(), H::HandledErr>
                     where
                         O: codec::NestedEncodeOutput,
                         H: codec::EncodeErrorHandler,

--- a/data/codec-derive/src/top_de_derive.rs
+++ b/data/codec-derive/src/top_de_derive.rs
@@ -61,7 +61,7 @@ fn top_decode_method_body(ast: &syn::DeriveInput) -> proc_macro2::TokenStream {
                 let mut nested_buffer = top_input.into_nested_buffer();
                 let result = #name #field_dep_decode_snippets ;
                 if !codec::NestedDecodeInput::is_depleted(&nested_buffer) {
-                    return core::result::Result::Err(h.handle_error(codec::DecodeError::INPUT_TOO_LONG));
+                    return core::result::Result::Err(__h__.handle_error(codec::DecodeError::INPUT_TOO_LONG));
                 }
                 core::result::Result::Ok(result)
             }
@@ -75,9 +75,9 @@ fn top_decode_method_body(ast: &syn::DeriveInput) -> proc_macro2::TokenStream {
                 // fieldless enums are special, they can be top-decoded as u8 directly
                 let top_decode_arms = fieldless_enum_match_arm_result_ok(name, data_enum);
                 quote! {
-                    match <u8 as codec::TopDecode>::top_decode_or_handle_err(top_input, h)? {
+                    match <u8 as codec::TopDecode>::top_decode_or_handle_err(top_input, __h__)? {
                         #(#top_decode_arms)*
-                        _ => core::result::Result::Err(h.handle_error(codec::DecodeError::INVALID_VALUE)),
+                        _ => core::result::Result::Err(__h__.handle_error(codec::DecodeError::INVALID_VALUE)),
                     }
                 }
             } else {
@@ -86,15 +86,15 @@ fn top_decode_method_body(ast: &syn::DeriveInput) -> proc_macro2::TokenStream {
 
                 quote! {
                     let mut nested_buffer = top_input.into_nested_buffer();
-                    let result = match <u8 as codec::NestedDecode>::dep_decode_or_handle_err(&mut nested_buffer, h)? {
+                    let result = match <u8 as codec::NestedDecode>::dep_decode_or_handle_err(&mut nested_buffer, __h__)? {
                         #(#variant_dep_decode_snippets)*
                         _ => core::result::Result::Err(
-                            h.handle_error(codec::DecodeError::INVALID_VALUE),
+                            __h__.handle_error(codec::DecodeError::INVALID_VALUE),
                         ),
                     };
                     if !codec::NestedDecodeInput::is_depleted(&nested_buffer) {
                         return core::result::Result::Err(
-                            h.handle_error(codec::DecodeError::INPUT_TOO_LONG),
+                            __h__.handle_error(codec::DecodeError::INPUT_TOO_LONG),
                         );
                     }
                     result
@@ -113,7 +113,7 @@ pub fn top_decode_impl(ast: &syn::DeriveInput) -> TokenStream {
 
     let gen = quote! {
         impl #impl_generics codec::TopDecode for #name #ty_generics #where_clause {
-            fn top_decode_or_handle_err<I, H>(top_input: I, h: H) -> core::result::Result<Self, H::HandledErr>
+            fn top_decode_or_handle_err<I, H>(top_input: I, __h__: H) -> core::result::Result<Self, H::HandledErr>
             where
                 I: codec::TopDecodeInput,
                 H: codec::DecodeErrorHandler,
@@ -134,7 +134,7 @@ pub fn top_decode_or_default_impl(ast: &syn::DeriveInput) -> TokenStream {
 
     let gen = quote! {
         impl #impl_generics codec::TopDecode for #name #ty_generics #where_clause {
-            fn top_decode_or_handle_err<I, H>(top_input: I, h: H) -> core::result::Result<Self, H::HandledErr>
+            fn top_decode_or_handle_err<I, H>(top_input: I, __h__: H) -> core::result::Result<Self, H::HandledErr>
             where
                 I: codec::TopDecodeInput,
                 H: codec::DecodeErrorHandler,

--- a/data/codec-derive/src/top_en_derive.rs
+++ b/data/codec-derive/src/top_en_derive.rs
@@ -12,13 +12,13 @@ pub fn variant_top_encode_snippets(
         .iter()
         .enumerate()
         .map(|(variant_index, variant)| {
-            let variant_index_u8 = variant_index as u8;
+            let discriminant_u8 = variant_index as u8;
             let variant_ident = &variant.ident;
             if variant.fields.is_empty() {
                 // top-encode discriminant directly
                 quote! {
                     #name::#variant_ident =>
-                        codec::TopEncode::top_encode_or_handle_err(&#variant_index_u8, output, h),
+                        codec::TopEncode::top_encode_or_handle_err(&#discriminant_u8, output, __h__),
                 }
             } else {
                 // dep-encode to buffer first
@@ -29,11 +29,11 @@ pub fn variant_top_encode_snippets(
                 });
                 quote! {
                     #name::#variant_ident #local_var_declarations => {
-                        let mut buffer = output.start_nested_encode();
-                        let dest = &mut buffer;
-                        codec::NestedEncode::dep_encode_or_handle_err(&#variant_index_u8, dest, h)?;
+                        let mut __buffer__ = output.start_nested_encode();
+                        let __dest__ = &mut __buffer__;
+                        codec::NestedEncode::dep_encode_or_handle_err(&#discriminant_u8, __dest__, __h__)?;
                         #(#variant_field_snippets)*
-                        output.finalize_nested_encode(buffer);
+                        output.finalize_nested_encode(__buffer__);
                         core::result::Result::Ok(())
                     },
                 }
@@ -51,10 +51,10 @@ fn top_encode_method_body(ast: &syn::DeriveInput) -> proc_macro2::TokenStream {
                 dep_encode_snippet(&self_field_expr(index, field))
             });
             quote! {
-                let mut buffer = output.start_nested_encode();
-                let dest = &mut buffer;
+                let mut __buffer__ = output.start_nested_encode();
+                let __dest__ = &mut __buffer__;
                 #(#field_dep_encode_snippets)*
-                output.finalize_nested_encode(buffer);
+                output.finalize_nested_encode(__buffer__);
                 core::result::Result::Ok(())
             }
         },
@@ -82,7 +82,7 @@ pub fn top_encode_impl(ast: &syn::DeriveInput) -> TokenStream {
 
     let gen = quote! {
         impl #impl_generics codec::TopEncode for #name #ty_generics #where_clause {
-            fn top_encode_or_handle_err<O, H>(&self, output: O, h: H) -> core::result::Result<(), H::HandledErr>
+            fn top_encode_or_handle_err<O, H>(&self, output: O, __h__: H) -> core::result::Result<(), H::HandledErr>
             where
                 O: codec::TopEncodeOutput,
                 H: codec::EncodeErrorHandler,
@@ -101,7 +101,7 @@ pub fn top_encode_or_default_impl(ast: &syn::DeriveInput) -> TokenStream {
 
     let gen = quote! {
         impl #impl_generics codec::TopEncode for #name #ty_generics #where_clause {
-            fn top_encode_or_handle_err<O, H>(&self, output: O, h: H) -> core::result::Result<(), H::HandledErr>
+            fn top_encode_or_handle_err<O, H>(&self, output: O, __h__: H) -> core::result::Result<(), H::HandledErr>
             where
                 O: codec::TopEncodeOutput,
                 H: codec::EncodeErrorHandler,

--- a/data/codec/tests/derive_hygiene.rs
+++ b/data/codec/tests/derive_hygiene.rs
@@ -51,6 +51,9 @@ pub struct Struct {
     pub another_byte: u8,
     pub uint_32: u32,
     pub uint_64: u64,
+    buffer: bool, // used to occur in derive implementation
+    dest: bool,   // used to occur in derive implementation
+    h: bool,      // used to occur in derive implementation
 }
 
 #[derive(NestedEncode, NestedDecode, TopEncode, TopDecode, PartialEq, Eq, Clone, Debug)]
@@ -78,6 +81,9 @@ enum EnumWithEverything {
         another_byte: u8,
         uint_32: u32,
         uint_64: u64,
+        buffer: bool, // used to occur in derive implementation
+        dest: bool,   // used to occur in derive implementation
+        h: bool,      // used to occur in derive implementation
     },
 }
 


### PR DESCRIPTION
Fixes issue https://github.com/multiversx/mx-sdk-rs/issues/1271

Simply renamed generated variables in the codec derive.