### PR TITLE
Fix/back transfers multi call payment 

### DIFF
--- a/contracts/feature-tests/composability/promises-features/src/call_sync_bt.rs
+++ b/contracts/feature-tests/composability/promises-features/src/call_sync_bt.rs
@@ -16,9 +16,55 @@ pub trait BackTransfersFeatureModule {
     ) {
         let ((), back_transfers) = self
             .vault_proxy()
+            .contract(to.clone())
+            .retrieve_funds(token.clone(), token_nonce, amount.clone())
+            .execute_on_dest_context_with_back_transfers::<()>();
+
+        require!(
+            back_transfers.esdt_payments.len() == 1,
+            "Only one ESDT payment expected"
+        );
+
+        self.back_transfers_event(
+            &back_transfers.total_egld_amount,
+            &back_transfers.esdt_payments.into_multi_value(),
+        );
+    }
+
+    #[endpoint]
+    fn forward_sync_retrieve_funds_multi_call_bt(
+        &self,
+        to: ManagedAddress,
+        token: EgldOrEsdtTokenIdentifier,
+        token_nonce: u64,
+        amount: BigUint,
+    ) {
+        let ((), back_transfers) = self
+            .vault_proxy()
+            .contract(to.clone())
+            .retrieve_funds(token.clone(), token_nonce, amount.clone())
+            .execute_on_dest_context_with_back_transfers::<()>();
+
+        require!(
+            back_transfers.esdt_payments.len() == 1,
+            "Only one ESDT payment expected"
+        );
+
+        self.back_transfers_event(
+            &back_transfers.total_egld_amount,
+            &back_transfers.esdt_payments.into_multi_value(),
+        );
+
+        let ((), back_transfers) = self
+            .vault_proxy()
             .contract(to)
             .retrieve_funds(token, token_nonce, amount)
             .execute_on_dest_context_with_back_transfers::<()>();
+
+        require!(
+            back_transfers.esdt_payments.len() == 1,
+            "Only one ESDT payment expected"
+        );
 
         self.back_transfers_event(
             &back_transfers.total_egld_amount,

--- a/contracts/feature-tests/composability/promises-features/src/call_sync_bt.rs
+++ b/contracts/feature-tests/composability/promises-features/src/call_sync_bt.rs
@@ -16,8 +16,8 @@ pub trait BackTransfersFeatureModule {
     ) {
         let ((), back_transfers) = self
             .vault_proxy()
-            .contract(to.clone())
-            .retrieve_funds(token.clone(), token_nonce, amount.clone())
+            .contract(to)
+            .retrieve_funds(token, token_nonce, amount)
             .execute_on_dest_context_with_back_transfers::<()>();
 
         require!(

--- a/contracts/feature-tests/composability/promises-features/src/call_sync_bt.rs
+++ b/contracts/feature-tests/composability/promises-features/src/call_sync_bt.rs
@@ -21,7 +21,7 @@ pub trait BackTransfersFeatureModule {
             .execute_on_dest_context_with_back_transfers::<()>();
 
         require!(
-            back_transfers.esdt_payments.len() == 1,
+            back_transfers.esdt_payments.len() == 1 || back_transfers.total_egld_amount != 0,
             "Only one ESDT payment expected"
         );
 
@@ -46,7 +46,7 @@ pub trait BackTransfersFeatureModule {
             .execute_on_dest_context_with_back_transfers::<()>();
 
         require!(
-            back_transfers.esdt_payments.len() == 1,
+            back_transfers.esdt_payments.len() == 1 || back_transfers.total_egld_amount != 0,
             "Only one ESDT payment expected"
         );
 
@@ -62,7 +62,7 @@ pub trait BackTransfersFeatureModule {
             .execute_on_dest_context_with_back_transfers::<()>();
 
         require!(
-            back_transfers.esdt_payments.len() == 1,
+            back_transfers.esdt_payments.len() == 1 || back_transfers.total_egld_amount != 0,
             "Only one ESDT payment expected"
         );
 

--- a/contracts/feature-tests/composability/promises-features/src/call_sync_bt.rs
+++ b/contracts/feature-tests/composability/promises-features/src/call_sync_bt.rs
@@ -32,7 +32,7 @@ pub trait BackTransfersFeatureModule {
     }
 
     #[endpoint]
-    fn forward_sync_retrieve_funds_multi_call_bt(
+    fn forward_sync_retrieve_funds_bt_twice(
         &self,
         to: ManagedAddress,
         token: EgldOrEsdtTokenIdentifier,

--- a/contracts/feature-tests/composability/tests/promises_feature_blackbox_test.rs
+++ b/contracts/feature-tests/composability/tests/promises_feature_blackbox_test.rs
@@ -110,7 +110,7 @@ fn test_multi_call_back_transfers() {
         ScCallStep::new().from(USER_ADDRESS_EXPR).call(
             state
                 .promises_features_contract
-                .forward_sync_retrieve_funds_multi_call_bt(
+                .forward_sync_retrieve_funds_bt_twice(
                     vault_address.clone(),
                     TOKEN_ID,
                     0u64,

--- a/contracts/feature-tests/composability/tests/promises_feature_blackbox_test.rs
+++ b/contracts/feature-tests/composability/tests/promises_feature_blackbox_test.rs
@@ -98,3 +98,31 @@ fn test_back_transfers() {
             CheckAccount::new().esdt_balance(TOKEN_ID_EXPR, token_amount),
         ));
 }
+
+#[test]
+fn test_multi_call_back_transfers() {
+    let mut state = PromisesFeaturesTestState::new();
+    let token_amount = BigUint::from(1000u64);
+    let half_token_amount = token_amount.clone() / 2u64;
+    let vault_address = state.vault_contract.to_address();
+
+    state.world.sc_call(
+        ScCallStep::new().from(USER_ADDRESS_EXPR).call(
+            state
+                .promises_features_contract
+                .forward_sync_retrieve_funds_multi_call_bt(
+                    vault_address.clone(),
+                    TOKEN_ID,
+                    0u64,
+                    &half_token_amount,
+                ),
+        ),
+    );
+
+    state
+        .world
+        .check_state_step(CheckStateStep::new().put_account(
+            state.promises_features_contract,
+            CheckAccount::new().esdt_balance(TOKEN_ID_EXPR, token_amount),
+        ));
+}

--- a/vm/src/tx_mock/tx_back_transfers.rs
+++ b/vm/src/tx_mock/tx_back_transfers.rs
@@ -43,36 +43,3 @@ impl BackTransfers {
     }
     
 }
-
-// func (host *vmHost) addNewBackTransfersFromVMOutput(vmOutput *vmcommon.VMOutput, parent, child []byte) {
-// 	if vmOutput == nil || vmOutput.ReturnCode != vmcommon.Ok {
-// 		return
-// 	}
-// 	callerOutAcc, ok := vmOutput.OutputAccounts[string(parent)]
-// 	if !ok {
-// 		return
-// 	}
-
-// 	for _, transfer := range callerOutAcc.OutputTransfers {
-// 		if !bytes.Equal(transfer.SenderAddress, child) {
-// 			continue
-// 		}
-// 		if transfer.CallType == vm.AsynchronousCallBack {
-// 			continue
-// 		}
-
-// 		if transfer.Value.Cmp(vmhost.Zero) > 0 {
-// 			if len(transfer.Data) == 0 {
-// 				host.managedTypesContext.AddValueOnlyBackTransfer(transfer.Value)
-// 			}
-// 			continue
-// 		}
-
-// 		esdtTransfers, isWithoutExec := host.isESDTTransferWithoutExecution(transfer.Data, parent, child)
-// 		if !isWithoutExec {
-// 			continue
-// 		}
-
-// 		host.managedTypesContext.AddBackTransfers(esdtTransfers.ESDTTransfers)
-// 	}
-// }

--- a/vm/src/tx_mock/tx_back_transfers.rs
+++ b/vm/src/tx_mock/tx_back_transfers.rs
@@ -16,15 +16,12 @@ impl BackTransfers {
     }
 
     pub fn new_from_result(
+        &mut self,
         own_address: &VMAddress,
         result: &TxResult,
         builtin_functions: &BuiltinFunctionContainer,
-    ) -> Self {
+    ) {
         let mut bt = BackTransfers::default();
-
-        if result.result_status != 0 {
-            return bt;
-        }
 
         for call in &result.all_calls {
             // TODO: refactor, check type
@@ -41,13 +38,10 @@ impl BackTransfers {
             }
         }
 
-        bt
+        self.call_value = bt.call_value;
+        self.esdt_transfers = bt.esdt_transfers;
     }
-
-    pub fn merge(&mut self, other: &BackTransfers) {
-        self.call_value += &other.call_value;
-        self.esdt_transfers.extend_from_slice(&other.esdt_transfers);
-    }
+    
 }
 
 // func (host *vmHost) addNewBackTransfersFromVMOutput(vmOutput *vmcommon.VMOutput, parent, child []byte) {

--- a/vm/src/vm_hooks/vh_impl/vh_debug_api.rs
+++ b/vm/src/vm_hooks/vh_impl/vh_debug_api.rs
@@ -239,10 +239,7 @@ impl DebugApiVMHooksHandler {
 
         let contract_address = &self.0.input_ref().to;
         let builtin_functions = &self.0.vm_ref.builtin_functions;
-        let current_back_transfers =
-            BackTransfers::new_from_result(contract_address, &tx_result, builtin_functions);
-
-        self.back_transfers_lock().merge(&current_back_transfers);
+        self.back_transfers_lock().new_from_result(contract_address, &tx_result, builtin_functions);
 
         tx_result.result_values
     }


### PR DESCRIPTION
Back transfers are not cleared after a call; therefore in a multi call transaction, back transfers are merged and multiple values are returned.