### PR TITLE
Reference newer CI version. Allow some workflows to be ran on demand

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+  workflow_dispatch:
 
 permissions:
   checks: write

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   contracts:
     name: Contracts
-    uses: multiversx/mx-sc-actions/.github/workflows/contracts.yml@v2.3.3
+    uses: multiversx/mx-sc-actions/.github/workflows/contracts.yml@v2.3.5
     with:
       rust-toolchain: nightly-2023-12-11
       vmtools-version: v1.5.19

--- a/.github/workflows/lldb-formatter-tests.yml
+++ b/.github/workflows/lldb-formatter-tests.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           default: true
-          toolchain: nightly-2023-05-26
+          toolchain: nightly-2023-12-11
 
       - name: Download vscode-lldb
         uses: robinraju/release-downloader@v1.5

--- a/.github/workflows/lldb-formatter-tests.yml
+++ b/.github/workflows/lldb-formatter-tests.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+  workflow_dispatch:
 
 jobs:
   format_tests:

--- a/.github/workflows/release-upload.yml
+++ b/.github/workflows/release-upload.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           default: true
-          toolchain: nightly-2023-05-26
+          toolchain: nightly-2023-12-11
           target: wasm32-unknown-unknown
 
       - name: Setup the PATH variable

--- a/.github/workflows/template-test-current.yml
+++ b/.github/workflows/template-test-current.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           default: true
-          toolchain: nightly-2023-05-26
+          toolchain: nightly-2023-12-11
           target: wasm32-unknown-unknown
 
       - name: Setup the PATH variable

--- a/.github/workflows/template-test-released.yml
+++ b/.github/workflows/template-test-released.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           default: true
-          toolchain: nightly-2023-05-26
+          toolchain: nightly-2023-12-11
           target: wasm32-unknown-unknown
 
       - name: Setup the PATH variable


### PR DESCRIPTION
 - Reference newer CI version: https://github.com/multiversx/mx-sc-actions/releases/tag/v2.3.5
 - Allow some workflows to be ran on demand