### PR TITLE
Removed features: promises, managed-map, back-transfers

### DIFF
--- a/contracts/feature-tests/composability/Cargo.toml
+++ b/contracts/feature-tests/composability/Cargo.toml
@@ -35,7 +35,6 @@ path = "vault"
 [dependencies.multiversx-sc]
 version = "0.45.2"
 path = "../../../framework/base"
-features = ["promises", "back-transfers"]
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.45.2"

--- a/contracts/feature-tests/composability/forwarder-queue/Cargo.toml
+++ b/contracts/feature-tests/composability/forwarder-queue/Cargo.toml
@@ -8,9 +8,6 @@ publish = false
 [lib]
 path = "src/forwarder_queue.rs"
 
-[features]
-promises = ["multiversx-sc/promises"]
-
 [dependencies.vault]
 path = "../vault"
 

--- a/contracts/feature-tests/composability/forwarder-queue/sc-config.toml
+++ b/contracts/feature-tests/composability/forwarder-queue/sc-config.toml
@@ -7,5 +7,4 @@ name = "forwarder-queue"
 [contracts.promises]
 name = "forwarder-queue-promises"
 add-labels = ["promises-callback"]
-features = ["promises"]
 ei = "1.3"

--- a/contracts/feature-tests/composability/forwarder-queue/src/forwarder_queue.rs
+++ b/contracts/feature-tests/composability/forwarder-queue/src/forwarder_queue.rs
@@ -191,7 +191,6 @@ pub trait ForwarderQueue {
                         .transfer_execute();
                 },
                 QueuedCallType::Promise => {
-                    #[cfg(feature = "promises")]
                     contract_call
                         .with_gas_limit(call.gas_limit)
                         .with_raw_arguments(call.args)

--- a/contracts/feature-tests/composability/forwarder-queue/wasm-forwarder-queue-promises/Cargo.toml
+++ b/contracts/feature-tests/composability/forwarder-queue/wasm-forwarder-queue-promises/Cargo.toml
@@ -23,7 +23,6 @@ overflow-checks = false
 
 [dependencies.forwarder-queue]
 path = ".."
-features = ["promises"]
 
 [dependencies.multiversx-sc-wasm-adapter]
 version = "0.45.2"

--- a/contracts/feature-tests/composability/promises-features/Cargo.toml
+++ b/contracts/feature-tests/composability/promises-features/Cargo.toml
@@ -14,5 +14,4 @@ path = "../vault"
 [dependencies.multiversx-sc]
 version = "0.45.2"
 path = "../../../../framework/base"
-features = ["promises", "back-transfers"]
 

--- a/contracts/feature-tests/composability/vault/Cargo.toml
+++ b/contracts/feature-tests/composability/vault/Cargo.toml
@@ -12,7 +12,6 @@ path = "src/vault.rs"
 [dependencies.multiversx-sc]
 version = "0.45.2"
 path = "../../../../framework/base"
-features = ["promises"]
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.45.2"

--- a/contracts/feature-tests/managed-map-features/Cargo.toml
+++ b/contracts/feature-tests/managed-map-features/Cargo.toml
@@ -7,11 +7,10 @@ publish = false
 
 [lib]
 path = "src/mmap_features.rs"
+
 [dependencies.multiversx-sc]
 version = "0.45.2"
 path = "../../../framework/base"
-
-features = ["managed-map"]
 
 [dev-dependencies.multiversx-sc-scenario]
 version = "0.45.2"

--- a/contracts/feature-tests/multi-contract-features/multicontract.toml
+++ b/contracts/feature-tests/multi-contract-features/multicontract.toml
@@ -7,6 +7,14 @@ main = "multi-contract-main"
 # main contract can have any id and any name
 name = "multi-contract-features"
 
+# all default values below:
+external-view = false
+panic-message = false
+ei = "1.3"
+allocator = "fail"
+stack-size = "64k"
+features = []
+
 [contracts.multi-contract-main.profile]
 # these are just the defaults, checking that parsing works fine
 codegen-units = 1  

--- a/framework/base/Cargo.toml
+++ b/framework/base/Cargo.toml
@@ -19,9 +19,6 @@ all-features = true
 [features]
 num-bigint = ["multiversx-sc-codec/num-bigint"]
 alloc = ["multiversx-sc-codec/alloc"]
-promises = []
-managed-map = []
-back-transfers = []
 esdt-token-payment-legacy-decode = []
 
 [dependencies]

--- a/framework/base/src/contract_base/wrappers/blockchain_wrapper.rs
+++ b/framework/base/src/contract_base/wrappers/blockchain_wrapper.rs
@@ -10,8 +10,9 @@ use crate::{
     err_msg::{ONLY_OWNER_CALLER, ONLY_USER_ACCOUNT_CALLER},
     storage::{self},
     types::{
-        BigUint, EgldOrEsdtTokenIdentifier, EsdtLocalRoleFlags, EsdtTokenData, EsdtTokenType,
-        ManagedAddress, ManagedBuffer, ManagedByteArray, ManagedType, ManagedVec, TokenIdentifier,
+        BackTransfers, BigUint, EgldOrEsdtTokenIdentifier, EsdtLocalRoleFlags, EsdtTokenData,
+        EsdtTokenType, ManagedAddress, ManagedBuffer, ManagedByteArray, ManagedType, ManagedVec,
+        TokenIdentifier,
     },
 };
 
@@ -347,8 +348,7 @@ where
     /// Works after:
     /// - synchronous calls
     /// - asynchronous calls too, in callbacks.
-    #[cfg(feature = "back-transfers")]
-    pub fn get_back_transfers(&self) -> crate::types::BackTransfers<A> {
+    pub fn get_back_transfers(&self) -> BackTransfers<A> {
         let esdt_transfer_value_handle: A::BigIntHandle =
             use_raw_handle(A::static_var_api_impl().next_handle());
         let call_value_handle: A::BigIntHandle =
@@ -359,7 +359,7 @@ where
             call_value_handle.get_raw_handle(),
         );
 
-        crate::types::BackTransfers {
+        BackTransfers {
             total_egld_amount: BigUint::from_raw_handle(call_value_handle.get_raw_handle()),
             esdt_payments: ManagedVec::from_raw_handle(esdt_transfer_value_handle.get_raw_handle()),
         }

--- a/framework/base/src/types/interaction/contract_call_exec.rs
+++ b/framework/base/src/types/interaction/contract_call_exec.rs
@@ -74,7 +74,6 @@ where
         }
     }
 
-    #[cfg(feature = "promises")]
     pub(super) fn async_call_promise(self) -> super::AsyncCallPromises<SA> {
         super::AsyncCallPromises {
             to: self.basic.to,

--- a/framework/base/src/types/interaction/contract_call_trait.rs
+++ b/framework/base/src/types/interaction/contract_call_trait.rs
@@ -80,7 +80,6 @@ where
 
     /// Converts to an async promise.
     #[inline]
-    #[cfg(feature = "promises")]
     fn async_call_promise(self) -> super::AsyncCallPromises<SA> {
         self.into_normalized().async_call_promise()
     }
@@ -98,7 +97,6 @@ where
     /// Executes immediately, synchronously, and returns contract call result.
     /// Only works if the target contract is in the same shard.
     #[inline]
-    #[cfg(feature = "back-transfers")]
     fn execute_on_dest_context_with_back_transfers<RequestedResult>(
         self,
     ) -> (RequestedResult, super::BackTransfers<SA>)

--- a/framework/base/src/types/managed/basic/mod.rs
+++ b/framework/base/src/types/managed/basic/mod.rs
@@ -12,6 +12,7 @@ mod big_uint_operators;
 mod cast_to_i64;
 mod elliptic_curve;
 mod managed_buffer;
+mod managed_map;
 
 pub use big_float::BigFloat;
 pub use big_int::BigInt;
@@ -19,8 +20,4 @@ pub use big_int_sign::Sign;
 pub use big_uint::BigUint;
 pub use elliptic_curve::{EllipticCurve, EllipticCurveComponents};
 pub use managed_buffer::ManagedBuffer;
-
-#[cfg(feature = "managed-map")]
-mod managed_map;
-#[cfg(feature = "managed-map")]
 pub use managed_map::ManagedMap;

--- a/framework/meta/Cargo.toml
+++ b/framework/meta/Cargo.toml
@@ -53,7 +53,7 @@ common-path = { version = "1.0.0", optional = true }
 [dependencies.multiversx-sc]
 version = "=0.45.2"
 path = "../base"
-features = ["alloc", "num-bigint", "promises"]
+features = ["alloc", "num-bigint"]
 
 [dev-dependencies]
 multiversx-sc-meta = { path = ".", features = ["standalone"] }

--- a/framework/meta/src/cmd/contract/sc_config/multi_contract_serde.rs
+++ b/framework/meta/src/cmd/contract/sc_config/multi_contract_serde.rs
@@ -2,6 +2,7 @@ use serde::Deserialize;
 use std::collections::HashMap;
 
 #[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct MultiContractConfigSerde {
     #[serde(default)]
     pub settings: MultiContractGeneralSettingsSerde,
@@ -13,6 +14,7 @@ pub struct MultiContractConfigSerde {
 }
 
 #[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct ContractVariantSerde {
     pub name: Option<String>,
 
@@ -57,11 +59,13 @@ pub struct ContractVariantSerde {
 }
 
 #[derive(Deserialize, Default, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct MultiContractGeneralSettingsSerde {
     pub main: Option<String>,
 }
 
 #[derive(Deserialize, Default, Debug, Clone, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct ContractVariantProfileSerde {
     #[serde(default)]
     #[serde(rename = "codegen-units")]

--- a/framework/meta/src/cmd/contract/sc_config/oc_settings/oc_parse_stack_size.rs
+++ b/framework/meta/src/cmd/contract/sc_config/oc_settings/oc_parse_stack_size.rs
@@ -44,5 +44,8 @@ mod tests {
         assert_eq!(parse_stack_size_expr("1 pages"), 65536);
         assert_eq!(parse_stack_size_expr("2 pages"), 65536 * 2);
         assert_eq!(parse_stack_size_expr("10 pages"), 65536 * 10);
+
+        assert_eq!(parse_stack_size_expr("128k"), DEFAULT_STACK_SIZE);
+        assert_eq!(parse_stack_size_expr("2 pages"), DEFAULT_STACK_SIZE);
     }
 }

--- a/framework/meta/src/ei/ei_version.rs
+++ b/framework/meta/src/ei/ei_version.rs
@@ -21,12 +21,12 @@ pub enum EIVersion {
     /// - more managed crypto hooks
     /// - big floats
     /// - some managed ESDT properties.
-    #[default]
     V1_2,
 
-    /// VM Hooks version planned to be released with VM 1.5 in Q2 2023.
+    /// Latest VM Hooks version, released with VM 1.5 in January 2024.
     ///
     /// It adds the new async call functionality (promises).
+    #[default]
     V1_3,
 }
 


### PR DESCRIPTION
Also changed the default EI version from 1.2 to 1.3.
Also made the parsing of `sc-config.toml` strict (unrecognized fields no longer allowed)