### PR TITLE
exact deps for base framework

### DIFF
--- a/contracts/core/price-aggregator/Cargo.toml
+++ b/contracts/core/price-aggregator/Cargo.toml
@@ -31,6 +31,6 @@ version = "0.46.1"
 path = "../../../framework/scenario"
 
 [dependencies]
-arrayvec = { version = "0.7.1", default-features = false }
+arrayvec = { version = "0.7", default-features = false }
 rand = { version = "0.8.5" }
 getrandom = { version = "0.2", features = ["js"] }

--- a/contracts/examples/check-pause/Cargo.toml
+++ b/contracts/examples/check-pause/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 path = "src/check_pause.rs"
 
 [dev-dependencies]
-num-bigint = "0.4.2"
+num-bigint = "0.4"
 
 [dependencies.multiversx-sc]
 version = "0.46.1"

--- a/contracts/examples/crowdfunding-esdt/Cargo.toml
+++ b/contracts/examples/crowdfunding-esdt/Cargo.toml
@@ -17,6 +17,6 @@ version = "0.46.1"
 path = "../../../framework/scenario"
 
 [dev-dependencies]
-num-bigint = "0.4.2"
+num-bigint = "0.4"
 num-traits = "0.2"
 hex = "0.4"

--- a/contracts/examples/empty/Cargo.toml
+++ b/contracts/examples/empty/Cargo.toml
@@ -17,4 +17,4 @@ version = "0.46.1"
 path = "../../../framework/scenario"
 
 [dev-dependencies]
-num-bigint = "0.4.2"
+num-bigint = "0.4"

--- a/contracts/examples/multisig/Cargo.toml
+++ b/contracts/examples/multisig/Cargo.toml
@@ -31,6 +31,6 @@ version = "0.46.1"
 path = "../../core/wegld-swap"
 
 [dev-dependencies]
-num-bigint = "0.4.2"
+num-bigint = "0.4"
 num-traits = "0.2"
 hex = "0.4"

--- a/contracts/feature-tests/rust-testing-framework-tester/Cargo.toml
+++ b/contracts/feature-tests/rust-testing-framework-tester/Cargo.toml
@@ -21,7 +21,7 @@ version = "0.46.1"
 path = "../../../framework/scenario"
 
 [dev-dependencies]
-num-bigint = "0.4.2"
+num-bigint = "0.4"
 num-traits = "0.2"
 hex = "0.4"
 

--- a/data/codec-derive/Cargo.toml
+++ b/data/codec-derive/Cargo.toml
@@ -21,7 +21,7 @@ proc-macro = true
 default = ["syn/full", "syn/parsing", "syn/extra-traits"]
 
 [dependencies]
-proc-macro2 = "1.0.66"
-quote = "1.0.33"
-syn = "2.0.39"
-hex = "0.4"
+proc-macro2 = "=1.0.75"
+quote = "=1.0.35"
+syn = "=2.0.48"
+hex = "=0.4.3"

--- a/data/codec/Cargo.toml
+++ b/data/codec/Cargo.toml
@@ -23,8 +23,8 @@ version = "=0.18.3"
 optional = true
 
 [dependencies]
-arrayvec = { version = "0.7.1", default-features = false }
-num-bigint = { version = "0.4.2", optional = true } # can only be used in std contexts
+arrayvec = { version = "=0.7.4", default-features = false }
+num-bigint = { version = "=0.4.4", optional = true } # can only be used in std contexts
 
 [dev-dependencies.multiversx-sc-codec-derive]
 path = "../codec-derive"

--- a/framework/base/Cargo.toml
+++ b/framework/base/Cargo.toml
@@ -22,9 +22,9 @@ alloc = ["multiversx-sc-codec/alloc"]
 esdt-token-payment-legacy-decode = []
 
 [dependencies]
-hex-literal = "0.4.1"
-bitflags = "2.4.1"
-num-traits = { version = "0.2", default-features = false }
+hex-literal = "=0.4.1"
+bitflags = "=2.4.1"
+num-traits = { version = "=0.2.17", default-features = false }
 
 [dependencies.multiversx-sc-derive]
 version = "=0.46.1"

--- a/framework/derive/Cargo.toml
+++ b/framework/derive/Cargo.toml
@@ -14,11 +14,11 @@ keywords = ["multiversx", "blockchain", "contract"]
 categories = ["cryptography::cryptocurrencies", "development-tools::procedural-macro-helpers"]
 
 [dependencies]
-proc-macro2 = "1.0.66"
-quote = "1.0.33"
-syn = "2.0.39"
-hex = "0.4"
-radix_trie = "0.2.1"
+proc-macro2 = "=1.0.75"
+quote = "=1.0.35"
+syn = "=2.0.48"
+hex = "=0.4.3"
+radix_trie = "=0.2.1"
 
 [features]
 default = ["syn/full", "syn/parsing", "syn/extra-traits"]

--- a/tools/mxpy-snippet-generator/Cargo.toml
+++ b/tools/mxpy-snippet-generator/Cargo.toml
@@ -15,6 +15,6 @@ path = "../../framework/base"
 
 [dependencies]
 bech32 = "0.9"
-num-bigint = "0.4.2"
+num-bigint = "0.4"
 num-traits = "0.2"
 hex = "0.4"

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -26,8 +26,8 @@ rand = "0.8.5"
 rand_seeder = "0.2.2"
 ed25519-dalek = "2.0.0"
 itertools = "0.12.0"
-hex-literal = "0.4.1"
-bitflags = "2.4.1"
+hex-literal = "=0.4.1"
+bitflags = "=2.4.1"
 
 [dependencies.multiversx-chain-vm-executor]
 version = "0.2.0"


### PR DESCRIPTION
Exact version dependencies for the base framework, so that reproducible builds are easier to do.
Only changed these dependencies for what ends up in a contract:
- codec
- codec derive
- base
- derive
- wasm-adapter (has no dependency, hail minimalism!)

Did not constrain like this:
- meta crate
- vm
- scenarios
- interactor
- tooling

No changes in the workspace `Cargo.lock` showed me that these are the exact versions we were running with before.