### PR TITLE
removed all branching from `top_encode_number`

### DIFF
--- a/data/codec/src/num_conv.rs
+++ b/data/codec/src/num_conv.rs
@@ -22,15 +22,23 @@ pub fn top_encode_number(x: u64, signed: bool, buffer: &mut [u8; 8]) -> &[u8] {
     let irrelevant_byte = if negative { 0xffu8 } else { 0x00u8 };
 
     let mut offset = 0usize;
-    while buffer[offset] == irrelevant_byte {
-        debug_assert!(offset < 7);
-        offset += 1;
-    }
-
-    if signed && buffer[offset] >> 7 != negative as u8 {
-        debug_assert!(offset > 0);
-        offset -= 1;
-    }
+    let mut cursor = 1usize;
+    cursor &= (buffer[0] == irrelevant_byte) as usize;
+    offset += cursor;
+    cursor &= (buffer[1] == irrelevant_byte) as usize;
+    offset += cursor;
+    cursor &= (buffer[2] == irrelevant_byte) as usize;
+    offset += cursor;
+    cursor &= (buffer[3] == irrelevant_byte) as usize;
+    offset += cursor;
+    cursor &= (buffer[4] == irrelevant_byte) as usize;
+    offset += cursor;
+    cursor &= (buffer[5] == irrelevant_byte) as usize;
+    offset += cursor;
+    cursor &= (buffer[6] == irrelevant_byte) as usize;
+    offset += cursor;
+    cursor &= (buffer[7] == irrelevant_byte) as usize;
+    offset += cursor;
 
     &buffer[offset..]
 }

--- a/data/codec/src/num_conv.rs
+++ b/data/codec/src/num_conv.rs
@@ -1,15 +1,15 @@
-pub const TOP_ENCODE_NUMBER_BUFFER_SIZE: usize = 9;
+pub type TopEncodeNumberBuffer = [u8; 9];
+
+pub const fn top_encode_number_buffer() -> TopEncodeNumberBuffer {
+    [0u8; 9]
+}
 
 /// Encodes number to minimimum number of bytes (top-encoding).
 ///
 /// Smaller types need to be converted to u64 before using this function.
 ///
 /// No generics here, we avoid monomorphization to make the SC binary as small as possible.
-pub fn top_encode_number(
-    x: u64,
-    signed: bool,
-    buffer: &mut [u8; TOP_ENCODE_NUMBER_BUFFER_SIZE],
-) -> &[u8] {
+pub fn top_encode_number(x: u64, signed: bool, buffer: &mut TopEncodeNumberBuffer) -> &[u8] {
     let offset = fill_buffer_find_offset(x, signed, buffer);
 
     debug_assert!(offset < 9);
@@ -24,11 +24,7 @@ pub fn top_encode_number(
 ///
 /// This function is hyper-optimized to not contain any jumps. There are no ifs or loops in this,
 /// the entire algorithm is performed via arithmetic, boolean and bitwise operations.
-fn fill_buffer_find_offset(
-    x: u64,
-    signed: bool,
-    buffer: &mut [u8; TOP_ENCODE_NUMBER_BUFFER_SIZE],
-) -> usize {
+fn fill_buffer_find_offset(x: u64, signed: bool, buffer: &mut TopEncodeNumberBuffer) -> usize {
     let b0 = (x >> 56 & 0xff) as u8;
 
     let negative = signed && msbit_is_one(b0);
@@ -167,7 +163,7 @@ mod test {
     /// Only checks the filling out of the buffer.
     #[test]
     fn test_populate_buffer() {
-        let mut buffer = [0u8; TOP_ENCODE_NUMBER_BUFFER_SIZE];
+        let mut buffer = top_encode_number_buffer();
         let _ = fill_buffer_find_offset(0x12345678abcdef12, false, &mut buffer);
         assert_eq!(
             buffer,
@@ -176,7 +172,7 @@ mod test {
     }
 
     fn test_encode_decode(x: u64, signed: bool, bytes: &[u8]) {
-        let mut buffer = [0u8; TOP_ENCODE_NUMBER_BUFFER_SIZE];
+        let mut buffer = top_encode_number_buffer();
         assert_eq!(
             top_encode_number(x, signed, &mut buffer),
             bytes,

--- a/data/codec/src/num_conv.rs
+++ b/data/codec/src/num_conv.rs
@@ -1,46 +1,101 @@
+pub const TOP_ENCODE_NUMBER_BUFFER_SIZE: usize = 9;
+
 /// Encodes number to minimimum number of bytes (top-encoding).
 ///
 /// Smaller types need to be converted to u64 before using this function.
 ///
 /// No generics here, we avoid monomorphization to make the SC binary as small as possible.
-pub fn top_encode_number(x: u64, signed: bool, buffer: &mut [u8; 8]) -> &[u8] {
-    *buffer = x.to_be_bytes();
-    if x == 0 {
-        // 0 is a special case
-        return &[];
-    }
+pub fn top_encode_number(
+    x: u64,
+    signed: bool,
+    buffer: &mut [u8; TOP_ENCODE_NUMBER_BUFFER_SIZE],
+) -> &[u8] {
+    let offset = fill_buffer_find_offset(x, signed, buffer);
 
-    if signed && x == u64::MAX {
-        // -1 is a special case
-        // will return a single 0xFF byte
-        return &buffer[7..];
-    }
+    debug_assert!(offset < 9);
 
-    let negative = signed &&  // only possible when signed flag
-        msb_is_one(buffer[0]); // most significant bit is 1
+    unsafe { buffer.get_unchecked(offset..8) }
+}
 
-    let irrelevant_byte = if negative { 0xffu8 } else { 0x00u8 };
+/// At the same time fills the buffer,
+/// and performs the algorithm that tells us how many bytes can be skipped.
+///
+/// Everything done in one function instead of 2, to avoid any unwanted bounds checks.
+///
+/// This function is hyper-optimized to not contain any jumps. There are no ifs or loops in this,
+/// the entire algorithm is performed via arithmetic, boolean and bitwise operations.
+fn fill_buffer_find_offset(
+    x: u64,
+    signed: bool,
+    buffer: &mut [u8; TOP_ENCODE_NUMBER_BUFFER_SIZE],
+) -> usize {
+    let b0 = (x >> 56 & 0xff) as u8;
+
+    let negative = signed && msbit_is_one(b0);
+    let skippable_byte = skippable_byte(negative);
 
     let mut offset = 0usize;
     let mut cursor = 1usize;
-    cursor &= (buffer[0] == irrelevant_byte) as usize;
-    offset += cursor;
-    cursor &= (buffer[1] == irrelevant_byte) as usize;
-    offset += cursor;
-    cursor &= (buffer[2] == irrelevant_byte) as usize;
-    offset += cursor;
-    cursor &= (buffer[3] == irrelevant_byte) as usize;
-    offset += cursor;
-    cursor &= (buffer[4] == irrelevant_byte) as usize;
-    offset += cursor;
-    cursor &= (buffer[5] == irrelevant_byte) as usize;
-    offset += cursor;
-    cursor &= (buffer[6] == irrelevant_byte) as usize;
-    offset += cursor;
-    cursor &= (buffer[7] == irrelevant_byte) as usize;
+
+    change_one_to_zero_unless(&mut cursor, b0 == skippable_byte);
     offset += cursor;
 
-    &buffer[offset..]
+    let b1 = (x >> 48 & 0xff) as u8;
+    change_one_to_zero_unless(&mut cursor, b1 == skippable_byte);
+    offset += cursor;
+
+    let b2 = (x >> 40 & 0xff) as u8;
+    change_one_to_zero_unless(&mut cursor, b2 == skippable_byte);
+    offset += cursor;
+
+    let b3 = (x >> 32 & 0xff) as u8;
+    change_one_to_zero_unless(&mut cursor, b3 == skippable_byte);
+    offset += cursor;
+
+    let b4 = (x >> 24 & 0xff) as u8;
+    change_one_to_zero_unless(&mut cursor, b4 == skippable_byte);
+    offset += cursor;
+
+    let b5 = (x >> 16 & 0xff) as u8;
+    change_one_to_zero_unless(&mut cursor, b5 == skippable_byte);
+    offset += cursor;
+
+    let b6 = (x >> 8 & 0xff) as u8;
+    change_one_to_zero_unless(&mut cursor, b6 == skippable_byte);
+    offset += cursor;
+
+    let b7 = (x & 0xff) as u8;
+    change_one_to_zero_unless(&mut cursor, b7 == skippable_byte);
+    offset += cursor;
+
+    buffer[0] = b0;
+    buffer[1] = b1;
+    buffer[2] = b2;
+    buffer[3] = b3;
+    buffer[4] = b4;
+    buffer[5] = b5;
+    buffer[6] = b6;
+    buffer[7] = b7;
+    buffer[8] = 0;
+
+    // For signed numbers, it can sometimes happen that we are skipping too many bytes,
+    // and the most significant bit ends up different than what we started with.
+    // In this case we need to backtrack one step.
+    // e.g. 255: [255] -> [0, 255]
+    // e.g. -129: [0x7f] -> [0xff, 0x7f]
+    cursor = 1;
+    change_one_to_zero_unless(&mut cursor, signed);
+    change_one_to_zero_unless(&mut cursor, offset > 0);
+    let msbit_corrupted =
+        msbit_is_one(unsafe { *buffer.get_unchecked(offset) }) != msbit_is_one(b0);
+    change_one_to_zero_unless(&mut cursor, msbit_corrupted);
+
+    // According to this algorithm, it should be impossible to underflow
+    // using wrapping_sub to avoid unnecessary underflow check
+    debug_assert!(offset >= cursor);
+    offset = offset.wrapping_sub(cursor);
+
+    offset
 }
 
 /// Handles both top-encoding and nested-encoding, signed and unsigned, of any length.
@@ -52,7 +107,7 @@ pub fn universal_decode_number(bytes: &[u8], signed: bool) -> u64 {
     if bytes.is_empty() {
         return 0;
     }
-    let negative = signed && msb_is_one(bytes[0]);
+    let negative = signed && msbit_is_one(bytes[0]);
     let mut result = if negative {
         // start with all bits set to 1,
         // to ensure that if there are fewer bytes than the result type width,
@@ -70,22 +125,72 @@ pub fn universal_decode_number(bytes: &[u8], signed: bool) -> u64 {
 
 /// Most significant bit is 1.
 #[inline]
-fn msb_is_one(byte: u8) -> bool {
+fn msbit_is_one(byte: u8) -> bool {
     byte >= 0b1000_0000u8
 }
 
+#[inline]
+fn change_one_to_zero_unless(x: &mut usize, condition: bool) {
+    debug_assert!(*x <= 1);
+    *x &= condition as usize;
+}
+
+/// For negative = true, yields 0xff.
+///
+/// For negative = true, yields 0x00.
+///
+/// Has no if, doesn't branch.
+#[inline]
+fn skippable_byte(negative: bool) -> u8 {
+    0u8.wrapping_sub(negative as u8)
+}
+
 #[cfg(test)]
-#[rustfmt::skip]
 mod test {
     use super::*;
 
-    fn test_encode_decode(x: u64, signed: bool, bytes: &[u8]) {
-        let mut buffer = [0u8; 8];
-        assert_eq!(top_encode_number(x, signed, &mut buffer), bytes);
-        assert_eq!(universal_decode_number(bytes, signed,), x);
+    #[test]
+    fn test_set_to_zero_unless() {
+        let mut x = 1;
+        change_one_to_zero_unless(&mut x, true);
+        assert_eq!(x, 1);
+        change_one_to_zero_unless(&mut x, false);
+        assert_eq!(x, 0);
     }
 
     #[test]
+    fn test_skippable_byte() {
+        assert_eq!(skippable_byte(true), 0xffu8);
+        assert_eq!(skippable_byte(false), 0x00u8);
+    }
+
+    /// Only checks the filling out of the buffer.
+    #[test]
+    fn test_populate_buffer() {
+        let mut buffer = [0u8; TOP_ENCODE_NUMBER_BUFFER_SIZE];
+        let _ = fill_buffer_find_offset(0x12345678abcdef12, false, &mut buffer);
+        assert_eq!(
+            buffer,
+            [0x12, 0x34, 0x56, 0x78, 0xab, 0xcd, 0xef, 0x12, 0x00]
+        );
+    }
+
+    fn test_encode_decode(x: u64, signed: bool, bytes: &[u8]) {
+        let mut buffer = [0u8; TOP_ENCODE_NUMBER_BUFFER_SIZE];
+        assert_eq!(
+            top_encode_number(x, signed, &mut buffer),
+            bytes,
+            "encode failed for {x}"
+        );
+        assert_eq!(
+            universal_decode_number(bytes, signed,),
+            x,
+            "decode failed for {x}"
+        );
+    }
+
+    #[test]
+    #[rustfmt::skip]
     fn test_top_encode_number() {
         // unsigned
         test_encode_decode(0x00, false, &[]);

--- a/data/codec/src/single/top_en_output.rs
+++ b/data/codec/src/single/top_en_output.rs
@@ -1,5 +1,5 @@
 use crate::{
-    num_conv::{top_encode_number, TOP_ENCODE_NUMBER_BUFFER_SIZE},
+    num_conv::{top_encode_number, top_encode_number_buffer},
     EncodeError, EncodeErrorHandler, NestedEncodeOutput, TryStaticCast,
 };
 use alloc::vec::Vec;
@@ -21,13 +21,13 @@ pub trait TopEncodeOutput: Sized {
     fn set_slice_u8(self, bytes: &[u8]);
 
     fn set_u64(self, value: u64) {
-        let mut buffer = [0u8; TOP_ENCODE_NUMBER_BUFFER_SIZE];
+        let mut buffer = top_encode_number_buffer();
         let slice = top_encode_number(value, false, &mut buffer);
         self.set_slice_u8(slice);
     }
 
     fn set_i64(self, value: i64) {
-        let mut buffer = [0u8; TOP_ENCODE_NUMBER_BUFFER_SIZE];
+        let mut buffer = top_encode_number_buffer();
         let slice = top_encode_number(value as u64, true, &mut buffer);
         self.set_slice_u8(slice);
     }

--- a/data/codec/src/single/top_en_output.rs
+++ b/data/codec/src/single/top_en_output.rs
@@ -1,5 +1,6 @@
 use crate::{
-    num_conv::top_encode_number, EncodeError, EncodeErrorHandler, NestedEncodeOutput, TryStaticCast,
+    num_conv::{top_encode_number, TOP_ENCODE_NUMBER_BUFFER_SIZE},
+    EncodeError, EncodeErrorHandler, NestedEncodeOutput, TryStaticCast,
 };
 use alloc::vec::Vec;
 
@@ -20,13 +21,13 @@ pub trait TopEncodeOutput: Sized {
     fn set_slice_u8(self, bytes: &[u8]);
 
     fn set_u64(self, value: u64) {
-        let mut buffer = [0u8; 8];
+        let mut buffer = [0u8; TOP_ENCODE_NUMBER_BUFFER_SIZE];
         let slice = top_encode_number(value, false, &mut buffer);
         self.set_slice_u8(slice);
     }
 
     fn set_i64(self, value: i64) {
-        let mut buffer = [0u8; 8];
+        let mut buffer = [0u8; TOP_ENCODE_NUMBER_BUFFER_SIZE];
         let slice = top_encode_number(value as u64, true, &mut buffer);
         self.set_slice_u8(slice);
     }

--- a/framework/base/src/storage/mappers/queue_mapper.rs
+++ b/framework/base/src/storage/mappers/queue_mapper.rs
@@ -280,7 +280,7 @@ where
         QueueMapper {
             _phantom_api: PhantomData::<SA>,
             address,
-            base_key: base_key.clone(),
+            base_key,
             _phantom_item: PhantomData::<T>,
         }
     }


### PR DESCRIPTION
`top_encode_number` wasm code:

**Before:**
```
  (func $_ZN19multiversx_sc_codec8num_conv17top_encode_number17h070ce2d0e91e3699E (;472;) (type 35) (param i32 i64 i32 i32)
    (local i64 i32 i32 i32 i32)
    local.get 3
    local.get 1
    i64.const 56
    i64.shl
    local.get 1
    i64.const 65280
    i64.and
    i64.const 40
    i64.shl
    i64.or
    local.get 1
    i64.const 16711680
    i64.and
    i64.const 24
    i64.shl
    local.get 1
    i64.const 4278190080
    i64.and
    i64.const 8
    i64.shl
    i64.or
    i64.or
    local.get 1
    i64.const 8
    i64.shr_u
    i64.const 4278190080
    i64.and
    local.get 1
    i64.const 24
    i64.shr_u
    i64.const 16711680
    i64.and
    i64.or
    local.get 1
    i64.const 40
    i64.shr_u
    i64.const 65280
    i64.and
    local.get 1
    i64.const 56
    i64.shr_u
    local.tee 4
    i64.or
    i64.or
    i64.or
    i64.store align=1
    block ;; label = @1
      block ;; label = @2
        local.get 1
        i64.eqz
        i32.eqz
        br_if 0 (;@2;)
        i32.const 134144
        local.set 3
        i32.const 0
        local.set 5
        br 1 (;@1;)
      end
      i32.const 0
      local.set 5
      i32.const 0
      local.set 6
      i32.const 0
      local.set 7
      block ;; label = @2
        local.get 2
        i32.eqz
        br_if 0 (;@2;)
        block ;; label = @3
          local.get 1
          i64.const -1
          i64.ne
          br_if 0 (;@3;)
          local.get 3
          i32.const 7
          i32.add
          local.set 3
          i32.const 1
          local.set 5
          br 2 (;@1;)
        end
        local.get 4
        i32.wrap_i64
        i32.extend8_s
        local.tee 8
        i32.const 7
        i32.shr_s
        local.set 7
        local.get 8
        i32.const 0
        i32.lt_s
        local.set 6
      end
      local.get 7
      i32.const 255
      i32.and
      local.set 7
      block ;; label = @2
        block ;; label = @3
          loop ;; label = @4
            local.get 5
            i32.const 8
            i32.eq
            br_if 1 (;@3;)
            block ;; label = @5
              local.get 3
              local.get 5
              i32.add
              i32.load8_u
              local.tee 8
              local.get 7
              i32.eq
              br_if 0 (;@5;)
              local.get 2
              i32.eqz
              br_if 3 (;@2;)
              local.get 8
              i32.const 7
              i32.shr_u
              local.get 6
              i32.eq
              br_if 3 (;@2;)
              block ;; label = @6
                local.get 5
                i32.eqz
                br_if 0 (;@6;)
                local.get 5
                i32.const -1
                i32.add
                local.set 5
                br 4 (;@2;)
              end
              i32.const 134144
              i32.const 33
              call $_ZN4core9panicking5panic17h1706caa25459d907E
              unreachable
            end
            local.get 5
            i32.const 1
            i32.add
            local.set 5
            br 0 (;@4;)
          end
        end
        i32.const 8
        i32.const 8
        call $_ZN4core5slice29_$LT$impl$u20$$u5b$T$u5d$$GT$15copy_from_slice17len_mismatch_fail17he2ddc4e697a9eb6eE
        unreachable
      end
      local.get 3
      local.get 5
      i32.add
      local.set 3
      i32.const 8
      local.get 5
      i32.sub
      local.set 5
    end
    local.get 0
    local.get 5
    i32.store offset=4
    local.get 0
    local.get 3
    i32.store
  )
```

**After:**
```
(func $_ZN19multiversx_sc_codec8num_conv17top_encode_number17h070ce2d0e91e3699E (;473;) (type 35) (param i32 i64 i32 i32)
    (local i64 i64 i32 i32 i32 i32)
    local.get 3
    local.get 1
    i64.const 56
    i64.shl
    local.get 1
    i64.const 65280
    i64.and
    i64.const 40
    i64.shl
    i64.or
    local.get 1
    i64.const 16711680
    i64.and
    i64.const 24
    i64.shl
    local.get 1
    i64.const 4278190080
    i64.and
    i64.const 8
    i64.shl
    i64.or
    i64.or
    local.get 1
    i64.const 8
    i64.shr_u
    i64.const 4278190080
    i64.and
    local.get 1
    i64.const 24
    i64.shr_u
    i64.const 16711680
    i64.and
    i64.or
    local.get 1
    i64.const 40
    i64.shr_u
    local.tee 4
    i64.const 65280
    i64.and
    local.get 1
    i64.const 56
    i64.shr_u
    local.tee 5
    i64.or
    i64.or
    i64.or
    i64.store align=1
    local.get 0
    i32.const 8
    i32.const 0
    local.get 1
    i64.const 0
    i64.lt_s
    local.tee 6
    local.get 2
    i32.and
    i32.sub
    i32.const 255
    i32.and
    local.tee 7
    local.get 5
    i32.wrap_i64
    i32.eq
    local.tee 8
    local.get 7
    local.get 1
    i64.const 48
    i64.shr_u
    i32.wrap_i64
    i32.const 255
    i32.and
    i32.eq
    i32.and
    local.tee 9
    local.get 8
    i32.add
    local.get 7
    local.get 4
    i32.wrap_i64
    i32.const 255
    i32.and
    i32.eq
    local.get 9
    i32.and
    local.tee 8
    i32.add
    local.get 7
    local.get 1
    i64.const 32
    i64.shr_u
    i32.wrap_i64
    i32.const 255
    i32.and
    i32.eq
    local.get 8
    i32.and
    local.tee 9
    i32.add
    local.get 7
    local.get 1
    i32.wrap_i64
    local.tee 8
    i32.const 24
    i32.shr_u
    i32.eq
    local.get 9
    i32.and
    local.tee 9
    i32.add
    local.get 7
    local.get 8
    i32.const 16
    i32.shr_u
    i32.const 255
    i32.and
    i32.eq
    local.get 9
    i32.and
    local.tee 9
    i32.add
    local.get 7
    local.get 8
    i32.const 8
    i32.shr_u
    i32.const 255
    i32.and
    i32.eq
    local.get 9
    i32.and
    local.tee 7
    i32.add
    local.get 7
    local.get 1
    i64.eqz
    i32.and
    i32.add
    local.tee 7
    local.get 7
    i32.const 0
    i32.ne
    local.get 6
    local.get 3
    local.get 7
    i32.const 7
    i32.and
    i32.add
    i32.load8_s
    i32.const 0
    i32.lt_s
    i32.xor
    i32.and
    local.get 2
    i32.and
    i32.sub
    local.tee 7
    i32.sub
    i32.store offset=4
    local.get 0
    local.get 3
    local.get 7
    i32.add
    i32.store
  )
```