### PR TITLE
imports in modules instead of macros

### DIFF
--- a/framework/base/src/lib.rs
+++ b/framework/base/src/lib.rs
@@ -39,3 +39,41 @@ pub mod types;
 pub use hex_call_data::*;
 pub use hex_literal;
 pub use storage::{storage_clear, storage_get, storage_get_len, storage_set};
+
+/// Conveniently groups all framework imports required by a smart contract form the framework.
+pub mod imports {
+    pub use crate::{
+        abi::TypeAbi,
+        api::{ErrorApiImpl, ManagedTypeApi},
+        arrayvec::ArrayVec,
+        codec::{
+            multi_types::*, DecodeError, IntoMultiValue, NestedDecode, NestedEncode, TopDecode,
+            TopEncode,
+        },
+        contract_base::{ContractBase, ProxyObjBase},
+        err_msg,
+        esdt::*,
+        io::*,
+        non_zero_usize,
+        non_zero_util::*,
+        require, sc_format, sc_panic, sc_print,
+        storage::mappers::*,
+        types::*,
+    };
+    pub use core::ops::{
+        Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Div,
+        DivAssign, Mul, MulAssign, Rem, RemAssign, Shl, ShlAssign, Shr, ShrAssign, Sub, SubAssign,
+    };
+}
+
+/// Conveniently groups all imports required for deriving framework-related traits for types.
+pub mod derive_imports {
+    pub use crate::{
+        codec,
+        codec::derive::{
+            NestedDecode, NestedEncode, TopDecode, TopDecodeOrDefault, TopEncode,
+            TopEncodeOrDefault,
+        },
+        derive::{ManagedVecItem, TypeAbi},
+    };
+}

--- a/framework/base/src/lib.rs
+++ b/framework/base/src/lib.rs
@@ -1,15 +1,17 @@
 #![no_std]
+
 #![feature(never_type)]
 #![feature(exhaustive_patterns)]
 #![feature(try_trait_v2)]
 #![feature(control_flow_enum)]
-#![allow(clippy::type_complexity)]
-#![allow(deprecated)]
 #![feature(maybe_uninit_uninit_array)]
 #![feature(maybe_uninit_array_assume_init)]
 #![feature(negative_impls)]
 #![feature(generic_const_exprs)]
+
 #![allow(incomplete_features)]
+#![allow(deprecated)]
+
 pub use multiversx_sc_derive::{self as derive, contract, module, proxy};
 
 // re-export basic heap types

--- a/framework/base/src/macros.rs
+++ b/framework/base/src/macros.rs
@@ -5,29 +5,7 @@
 #[macro_export]
 macro_rules! imports {
     () => {
-        use core::ops::{
-            Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Div,
-            DivAssign, Mul, MulAssign, Rem, RemAssign, Shl, ShlAssign, Shr, ShrAssign, Sub,
-            SubAssign,
-        };
-        use multiversx_sc::{
-            abi::TypeAbi,
-            api::{ErrorApiImpl, ManagedTypeApi},
-            arrayvec::ArrayVec,
-            codec::{
-                multi_types::*, DecodeError, IntoMultiValue, NestedDecode, NestedEncode, TopDecode,
-                TopEncode,
-            },
-            contract_base::{ContractBase, ProxyObjBase},
-            err_msg,
-            esdt::*,
-            io::*,
-            non_zero_usize,
-            non_zero_util::*,
-            require, sc_format, sc_panic, sc_print,
-            storage::mappers::*,
-            types::*,
-        };
+        use multiversx_sc::imports::*;
     };
 }
 
@@ -35,14 +13,7 @@ macro_rules! imports {
 #[macro_export]
 macro_rules! derive_imports {
     () => {
-        use multiversx_sc::{
-            codec,
-            codec::derive::{
-                NestedDecode, NestedEncode, TopDecode, TopDecodeOrDefault, TopEncode,
-                TopEncodeOrDefault,
-            },
-            derive::{ManagedVecItem, TypeAbi},
-        };
+        use multiversx_sc::derive_imports::*;
     };
 }
 

--- a/framework/scenario/tests/contract_without_macros.rs
+++ b/framework/scenario/tests/contract_without_macros.rs
@@ -196,8 +196,7 @@ mod sample_adder {
                 Self::Api,
                 (multiversx_sc::types::BigInt<Self::Api>, ()),
             >(("value", ()));
-            let result = self.add(value);
-            multiversx_sc::io::finish_multi::<Self::Api, _>(&result);
+            self.add(value);
         }
 
         fn call(&self, fn_name: &str) -> bool {
@@ -417,15 +416,15 @@ fn contract_without_macros_basic() {
     adder.init(&BigInt::from(5));
     assert_eq!(BigInt::from(5), adder.get_sum());
 
-    let _ = adder.add(BigInt::from(7));
+    adder.add(BigInt::from(7));
     assert_eq!(BigInt::from(12), adder.get_sum());
 
-    let _ = adder.add(BigInt::from(-1));
+    adder.add(BigInt::from(-1));
     assert_eq!(BigInt::from(11), adder.get_sum());
 
     assert_eq!(BigInt::from(100), adder.version());
 
-    let _ = adder.add_version();
+    adder.add_version();
     assert_eq!(BigInt::from(111), adder.get_sum());
 
     assert!(!adder.call("invalid_endpoint"));

--- a/framework/wasm-adapter/src/lib.rs
+++ b/framework/wasm-adapter/src/lib.rs
@@ -1,6 +1,5 @@
 #![no_std]
 #![feature(panic_info_message)]
-#![feature(int_roundings)]
 
 // Allows us to use alloc::vec::Vec;
 // TODO: get rid of the legacy API and also of this.


### PR DESCRIPTION
We don't actually need a macro to provide the common imports for a smart contract ... a module re-exporting everything does just fine and is friendlier to the IDEs.