### PR TITLE
unified syntax - multi esdt reference cleanup

### DIFF
--- a/contracts/examples/digital-cash/src/digital_cash.rs
+++ b/contracts/examples/digital-cash/src/digital_cash.rs
@@ -64,7 +64,7 @@ pub trait DigitalCash:
         if !collected_esdt_fees.is_empty() {
             self.tx()
                 .to(&caller_address)
-                .multi_esdt_ref(&collected_esdt_fees)
+                .multi_esdt(&collected_esdt_fees)
                 .transfer();
         }
     }

--- a/contracts/examples/digital-cash/src/signature_operations.rs
+++ b/contracts/examples/digital-cash/src/signature_operations.rs
@@ -83,7 +83,7 @@ pub trait SignatureOperationsModule: storage::StorageModule + helpers::HelpersMo
         if !deposit.esdt_funds.is_empty() {
             self.tx()
                 .to(&caller_address)
-                .multi_esdt_ref(&deposit.esdt_funds)
+                .multi_esdt(&deposit.esdt_funds)
                 .transfer();
         }
         if deposited_fee.amount > 0 {

--- a/contracts/examples/esdt-transfer-with-fee/src/esdt_transfer_with_fee.rs
+++ b/contracts/examples/esdt-transfer-with-fee/src/esdt_transfer_with_fee.rs
@@ -40,7 +40,7 @@ pub trait EsdtTransferWithFee {
         }
         self.paid_fees().clear();
 
-        self.tx().to(ToCaller).multi_esdt_ref(&fees).transfer();
+        self.tx().to(ToCaller).multi_esdt(&fees).transfer();
     }
 
     #[payable("*")]

--- a/contracts/feature-tests/composability/forwarder-raw/src/forwarder_raw_async.rs
+++ b/contracts/feature-tests/composability/forwarder-raw/src/forwarder_raw_async.rs
@@ -23,7 +23,7 @@ pub trait ForwarderRawAsync: super::forwarder_raw_common::ForwarderRawCommon {
     #[payable("*")]
     fn forward_direct_esdt_multi(&self, to: ManagedAddress) {
         let payments = self.call_value().all_esdt_transfers();
-        self.tx().to(&to).multi_esdt_ref(&payments).transfer();
+        self.tx().to(&to).multi_esdt(payments).transfer();
     }
 
     fn forward_contract_call(

--- a/contracts/modules/src/token_merge/mod.rs
+++ b/contracts/modules/src/token_merge/mod.rs
@@ -120,7 +120,7 @@ pub trait TokenMergeModule:
 
         self.tx()
             .to(ToCaller)
-            .multi_esdt_ref(&output_payments)
+            .multi_esdt(&output_payments)
             .transfer();
 
         output_payments
@@ -169,7 +169,7 @@ pub trait TokenMergeModule:
 
         self.tx()
             .to(ToCaller)
-            .multi_esdt_ref(&tokens_to_remove)
+            .multi_esdt(&tokens_to_remove)
             .transfer();
 
         tokens_to_remove

--- a/framework/base/src/contract_base/wrappers/send_wrapper.rs
+++ b/framework/base/src/contract_base/wrappers/send_wrapper.rs
@@ -291,10 +291,7 @@ where
         to: &ManagedAddress<A>,
         payments: &ManagedVec<A, EsdtTokenPayment<A>>,
     ) {
-        Tx::new_tx_from_sc()
-            .to(to)
-            .multi_esdt_ref(payments)
-            .transfer();
+        Tx::new_tx_from_sc().to(to).multi_esdt(payments).transfer();
     }
 
     /// Performs a simple ESDT/NFT transfer, but via async call.  

--- a/framework/base/src/types/interaction/tx.rs
+++ b/framework/base/src/types/interaction/tx.rs
@@ -16,7 +16,7 @@ use super::{
     ExplicitGas, FromSource, FunctionCall, ManagedArgBuffer, OriginalResultMarker, RHList,
     RHListAppendNoRet, RHListAppendRet, RHListItem, TxCodeSource, TxCodeValue, TxData, TxEgldValue,
     TxEnv, TxFrom, TxFromSourceValue, TxGas, TxGasValue, TxPayment, TxPaymentEgldOnly,
-    TxProxyTrait, TxResultHandler, TxScEnv, TxTo, TxToSpecified, UpgradeCall,
+    TxPaymentMultiEsdt, TxProxyTrait, TxResultHandler, TxScEnv, TxTo, TxToSpecified, UpgradeCall,
 };
 
 #[must_use]
@@ -229,26 +229,10 @@ where
     }
 
     /// Adds a collection of ESDT payments to a transaction.
-    pub fn multi_esdt(
-        self,
-        payments: MultiEsdtPayment<Env::Api>, // TODO: references
-    ) -> Tx<Env, From, To, MultiEsdtPayment<Env::Api>, Gas, Data, RH> {
-        Tx {
-            env: self.env,
-            from: self.from,
-            to: self.to,
-            payment: payments,
-            gas: self.gas,
-            data: self.data,
-            result_handler: self.result_handler,
-        }
-    }
-
-    /// Sets a reference to multiple ESDT payments.
-    pub fn multi_esdt_ref(
-        self,
-        payments: &MultiEsdtPayment<Env::Api>,
-    ) -> Tx<Env, From, To, &MultiEsdtPayment<Env::Api>, Gas, Data, RH> {
+    pub fn multi_esdt<Payment>(self, payments: Payment) -> Tx<Env, From, To, Payment, Gas, Data, RH>
+    where
+        Payment: TxPaymentMultiEsdt<Env>,
+    {
         Tx {
             env: self.env,
             from: self.from,

--- a/framework/base/src/types/interaction/tx_payment.rs
+++ b/framework/base/src/types/interaction/tx_payment.rs
@@ -8,6 +8,7 @@ mod tx_payment_single_esdt_ref;
 
 pub use tx_payment_egld::{Egld, EgldPayment};
 pub use tx_payment_egld_value::TxEgldValue;
+pub use tx_payment_multi_esdt::TxPaymentMultiEsdt;
 
 use crate::{
     api::ManagedTypeApi,

--- a/framework/base/src/types/managed/multi_value/multi_value_managed_vec.rs
+++ b/framework/base/src/types/managed/multi_value/multi_value_managed_vec.rs
@@ -216,10 +216,11 @@ where
     T: ManagedVecItem,
 {
     fn type_name() -> TypeName {
-        let mut repr = TypeName::from("variadic<");
-        repr.push_str(T::type_name().as_str());
-        repr.push('>');
-        repr
+        crate::abi::type_name_variadic::<T>()
+    }
+
+    fn type_name_rust() -> TypeName {
+        alloc::format!("MultiValueManagedVec<$API, {}>", T::type_name_rust())
     }
 
     fn provide_type_descriptions<TDC: TypeDescriptionContainer>(accumulator: &mut TDC) {


### PR DESCRIPTION
`.multi_esdt(...)` can now be called with a reference directly, and the same time multi_esdt_ref became useless, so I deleted it. 