### PR TITLE
Removed set_current_dir_from_workspace from tests

### DIFF
--- a/contracts/benchmarks/large-storage/tests/large_storage_scenario_rs_test.rs
+++ b/contracts/benchmarks/large-storage/tests/large_storage_scenario_rs_test.rs
@@ -2,7 +2,6 @@ use multiversx_sc_scenario::*;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/benchmarks/large-storage");
     blockchain.register_contract(
         "mxsc:output/large-storage.mxsc.json",
         large_storage::ContractBuilder,

--- a/contracts/benchmarks/mappers/linked-list-repeat/tests/linked_list_repeat_blackbox_test.rs
+++ b/contracts/benchmarks/mappers/linked-list-repeat/tests/linked_list_repeat_blackbox_test.rs
@@ -8,7 +8,6 @@ const WASM_PATH_EXPR: &str = "mxsc:output/linked-list-repeat.mxsc.json";
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/benchmarks/mappers/linked-list-repeat");
 
     blockchain.register_contract(WASM_PATH_EXPR, linked_list_repeat::ContractBuilder);
     blockchain

--- a/contracts/benchmarks/mappers/linked-list-repeat/tests/scenario_rs_test.rs
+++ b/contracts/benchmarks/mappers/linked-list-repeat/tests/scenario_rs_test.rs
@@ -2,7 +2,6 @@ use multiversx_sc_scenario::*;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/benchmarks/mappers/linked-list-repeat");
 
     blockchain.register_contract(
         "mxsc:output/linked-list-repeat.mxsc.json",

--- a/contracts/benchmarks/mappers/map-repeat/tests/scenario_rs_test.rs
+++ b/contracts/benchmarks/mappers/map-repeat/tests/scenario_rs_test.rs
@@ -2,7 +2,6 @@ use multiversx_sc_scenario::*;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/benchmarks/mappers/map-repeat");
 
     blockchain.register_contract(
         "mxsc:output/map-repeat.mxsc.json",

--- a/contracts/benchmarks/mappers/queue-repeat/tests/scenario_rs_test.rs
+++ b/contracts/benchmarks/mappers/queue-repeat/tests/scenario_rs_test.rs
@@ -2,7 +2,6 @@ use multiversx_sc_scenario::*;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/benchmarks/mappers/queue-repeat");
 
     blockchain.register_contract(
         "mxsc:output/queue-repeat.mxsc.json",

--- a/contracts/benchmarks/mappers/set-repeat/tests/scenario_rs_test.rs
+++ b/contracts/benchmarks/mappers/set-repeat/tests/scenario_rs_test.rs
@@ -2,7 +2,6 @@ use multiversx_sc_scenario::*;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/benchmarks/mappers/set-repeat");
 
     blockchain.register_contract(
         "mxsc:output/set-repeat.mxsc.json",

--- a/contracts/benchmarks/mappers/single-value-repeat/tests/scenario_rs_test.rs
+++ b/contracts/benchmarks/mappers/single-value-repeat/tests/scenario_rs_test.rs
@@ -2,7 +2,6 @@ use multiversx_sc_scenario::*;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/benchmarks/mappers/single-value-repeat");
 
     blockchain.register_contract(
         "mxsc:output/single-value-repeat.mxsc.json",

--- a/contracts/benchmarks/mappers/vec-repeat/tests/scenario_rs_test.rs
+++ b/contracts/benchmarks/mappers/vec-repeat/tests/scenario_rs_test.rs
@@ -2,7 +2,6 @@ use multiversx_sc_scenario::*;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/benchmarks/mappers/vec-repeat");
 
     blockchain.register_contract(
         "mxsc:output/vec-repeat.mxsc.json",

--- a/contracts/core/price-aggregator/tests/price_aggregator_blackbox_test.rs
+++ b/contracts/core/price-aggregator/tests/price_aggregator_blackbox_test.rs
@@ -24,7 +24,6 @@ const PRICE_AGGREGATOR_PATH: MxscPath =
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
 
-    blockchain.set_current_dir_from_workspace("contracts/core/price-aggregator");
     blockchain.register_contract(
         PRICE_AGGREGATOR_PATH,
         multiversx_price_aggregator_sc::ContractBuilder,

--- a/contracts/core/price-aggregator/tests/price_aggregator_whitebox_test.rs
+++ b/contracts/core/price-aggregator/tests/price_aggregator_whitebox_test.rs
@@ -24,7 +24,6 @@ const PRICE_AGGREGATOR_PATH_EXPR: &str = "mxsc:output/multiversx-price-aggregato
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
 
-    blockchain.set_current_dir_from_workspace("contracts/core/price-aggregator");
     blockchain.register_contract(
         PRICE_AGGREGATOR_PATH_EXPR,
         multiversx_price_aggregator_sc::ContractBuilder,

--- a/contracts/core/wegld-swap/tests/wegld_swap_scenario_rs_test.rs
+++ b/contracts/core/wegld-swap/tests/wegld_swap_scenario_rs_test.rs
@@ -2,7 +2,6 @@ use multiversx_sc_scenario::*;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/core/wegld-swap");
 
     blockchain.register_contract(
         "mxsc:output/multiversx-wegld-swap-sc.mxsc.json",

--- a/contracts/examples/adder/tests/adder_blackbox_test.rs
+++ b/contracts/examples/adder/tests/adder_blackbox_test.rs
@@ -8,7 +8,6 @@ const CODE_PATH: MxscPath = MxscPath::new("output/adder.mxsc.json");
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/examples/adder");
 
     blockchain.register_contract(CODE_PATH, adder::ContractBuilder);
     blockchain

--- a/contracts/examples/adder/tests/adder_scenario_rs_test.rs
+++ b/contracts/examples/adder/tests/adder_scenario_rs_test.rs
@@ -2,7 +2,6 @@ use multiversx_sc_scenario::*;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/examples/adder");
 
     blockchain.register_contract("mxsc:output/adder.mxsc.json", adder::ContractBuilder);
     blockchain

--- a/contracts/examples/adder/tests/adder_whitebox_test.rs
+++ b/contracts/examples/adder/tests/adder_whitebox_test.rs
@@ -5,7 +5,6 @@ const ADDER_PATH_EXPR: &str = "mxsc:output/adder.mxsc.json";
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/examples/adder");
 
     blockchain.register_contract("mxsc:output/adder.mxsc.json", adder::ContractBuilder);
     blockchain

--- a/contracts/examples/crowdfunding-esdt/tests/crowdfunding_esdt_scenario_rs_test.rs
+++ b/contracts/examples/crowdfunding-esdt/tests/crowdfunding_esdt_scenario_rs_test.rs
@@ -2,7 +2,6 @@ use multiversx_sc_scenario::*;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/examples/crowdfunding-esdt");
 
     blockchain.register_contract(
         "mxsc:output/crowdfunding-esdt.mxsc.json",

--- a/contracts/examples/crypto-bubbles/tests/crypto_bubbles_scenario_rs_test.rs
+++ b/contracts/examples/crypto-bubbles/tests/crypto_bubbles_scenario_rs_test.rs
@@ -2,7 +2,6 @@ use multiversx_sc_scenario::*;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/examples/crypto-bubbles");
 
     blockchain.register_contract(
         "mxsc:output/crypto-bubbles.mxsc.json",

--- a/contracts/examples/digital-cash/tests/digital_cash_scenario_rs_test.rs
+++ b/contracts/examples/digital-cash/tests/digital_cash_scenario_rs_test.rs
@@ -2,7 +2,6 @@ use multiversx_sc_scenario::*;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/examples/digital-cash");
 
     blockchain.register_contract(
         "mxsc:output/digital-cash.mxsc.json",

--- a/contracts/examples/empty/tests/empty_scenario_rs_test.rs
+++ b/contracts/examples/empty/tests/empty_scenario_rs_test.rs
@@ -2,7 +2,6 @@ use multiversx_sc_scenario::*;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/examples/empty");
 
     blockchain.register_contract("mxsc:output/empty.mxsc.json", empty::ContractBuilder);
     blockchain

--- a/contracts/examples/esdt-transfer-with-fee/tests/esdt_transfer_with_fee_scenario_rs_test.rs
+++ b/contracts/examples/esdt-transfer-with-fee/tests/esdt_transfer_with_fee_scenario_rs_test.rs
@@ -2,7 +2,6 @@ use multiversx_sc_scenario::*;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/examples/esdt-transfer-with-fee");
 
     blockchain.register_contract(
         "mxsc:output/esdt-transfer-with-fee.mxsc.json",

--- a/contracts/examples/factorial/tests/factorial_scenario_rs_test.rs
+++ b/contracts/examples/factorial/tests/factorial_scenario_rs_test.rs
@@ -2,7 +2,6 @@ use multiversx_sc_scenario::*;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/examples/factorial");
 
     blockchain.register_contract(
         "mxsc:output/factorial.mxsc.json",

--- a/contracts/examples/lottery-esdt/tests/lottery_esdt_scenario_rs_test.rs
+++ b/contracts/examples/lottery-esdt/tests/lottery_esdt_scenario_rs_test.rs
@@ -2,7 +2,6 @@ use multiversx_sc_scenario::*;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/examples/lottery-esdt");
 
     blockchain.register_contract(
         "mxsc:output/lottery-esdt.mxsc.json",

--- a/contracts/examples/multisig/tests/multisig_blackbox_test.rs
+++ b/contracts/examples/multisig/tests/multisig_blackbox_test.rs
@@ -18,7 +18,6 @@ const QUORUM_SIZE: usize = 1;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/examples/multisig");
 
     blockchain.register_contract(MULTISIG_CODE_PATH, multisig::ContractBuilder);
     blockchain.register_contract(ADDER_CODE_PATH, adder::ContractBuilder);

--- a/contracts/examples/multisig/tests/multisig_scenario_rs_test.rs
+++ b/contracts/examples/multisig/tests/multisig_scenario_rs_test.rs
@@ -4,7 +4,6 @@ const WEGLD_SWAP_EXPR: &str = "0x0061736d0100000001661160000060017f0060027f7f017
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/examples/multisig");
 
     blockchain.register_partial_contract::<multisig::AbiProvider, _>(
         "mxsc:output/multisig.mxsc.json",

--- a/contracts/examples/multisig/tests/multisig_whitebox_test.rs
+++ b/contracts/examples/multisig/tests/multisig_whitebox_test.rs
@@ -51,7 +51,6 @@ pub struct CallActionDataRaw {
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/examples/multisig");
 
     blockchain.register_contract(MULTISIG_PATH_EXPR, multisig::ContractBuilder);
     blockchain

--- a/contracts/examples/nft-minter/tests/nft_minter_scenario_rs_test.rs
+++ b/contracts/examples/nft-minter/tests/nft_minter_scenario_rs_test.rs
@@ -2,7 +2,6 @@ use multiversx_sc_scenario::*;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/examples/nft-minter");
 
     blockchain.register_contract(
         "mxsc:output/nft-minter.mxsc.json",

--- a/contracts/examples/nft-subscription/tests/nft_subscription_scenario_rs_test.rs
+++ b/contracts/examples/nft-subscription/tests/nft_subscription_scenario_rs_test.rs
@@ -2,7 +2,6 @@ use multiversx_sc_scenario::*;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/examples/nft-subscription");
 
     blockchain.register_contract(
         "mxsc:output/nft-subscription.mxsc.json",

--- a/contracts/examples/order-book/pair/tests/pair_scenario_rs_test.rs
+++ b/contracts/examples/order-book/pair/tests/pair_scenario_rs_test.rs
@@ -2,7 +2,6 @@ use multiversx_sc_scenario::*;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/examples/order-book/pair");
 
     blockchain.register_contract(
         "mxsc:output/order-book-pair.mxsc.json",

--- a/contracts/examples/ping-pong-egld/tests/ping_pong_egld_scenario_rs_test.rs
+++ b/contracts/examples/ping-pong-egld/tests/ping_pong_egld_scenario_rs_test.rs
@@ -2,7 +2,6 @@ use multiversx_sc_scenario::*;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/examples/ping-pong-egld");
 
     blockchain.register_contract(
         "mxsc:output/ping-pong-egld.mxsc.json",

--- a/contracts/examples/proxy-pause/tests/proxy_pause_scenario_rs_test.rs
+++ b/contracts/examples/proxy-pause/tests/proxy_pause_scenario_rs_test.rs
@@ -2,7 +2,6 @@ use multiversx_sc_scenario::*;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/examples/proxy-pause");
 
     blockchain.register_contract(
         "mxsc:output/proxy-pause.mxsc.json",

--- a/contracts/examples/token-release/tests/token_release_scenario_rs_test.rs
+++ b/contracts/examples/token-release/tests/token_release_scenario_rs_test.rs
@@ -2,7 +2,6 @@ use multiversx_sc_scenario::*;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/examples/token-release");
 
     blockchain.register_contract(
         "mxsc:output/token-release.mxsc.json",

--- a/contracts/feature-tests/abi-tester/tests/abi_tester_abi_test.rs
+++ b/contracts/feature-tests/abi-tester/tests/abi_tester_abi_test.rs
@@ -12,8 +12,7 @@ use multiversx_sc_scenario::ScenarioWorld;
 
 #[test]
 fn abi_tester_abi_generated_ok() {
-    let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/feature-tests/abi-tester");
+    let blockchain = ScenarioWorld::new();
 
     // generate ABI
     let multi_contract_config = multiversx_sc_meta::multi_contract_config::<abi_tester::AbiProvider>(
@@ -72,7 +71,6 @@ fn abi_tester_esdt_attr_abi_generated_ok() {
 #[test]
 fn check_multi_contract_config() {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/feature-tests/abi-tester");
 
     let multi_contract_config = multiversx_sc_meta::multi_contract_config::<abi_tester::AbiProvider>(
         blockchain.current_dir().as_path(),

--- a/contracts/feature-tests/alloc-features/tests/alloc_features_scenario_rs_test.rs
+++ b/contracts/feature-tests/alloc-features/tests/alloc_features_scenario_rs_test.rs
@@ -2,7 +2,6 @@ use multiversx_sc_scenario::*;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/feature-tests/alloc-features");
 
     blockchain.register_partial_contract::<alloc_features::AbiProvider, _>(
         "mxsc:output/alloc-features.mxsc.json",

--- a/contracts/feature-tests/basic-features/tests/basic_features_is_builtin_function_rs_test.rs
+++ b/contracts/feature-tests/basic-features/tests/basic_features_is_builtin_function_rs_test.rs
@@ -2,7 +2,6 @@ use multiversx_sc_scenario::*;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/feature-tests/basic-features");
 
     blockchain.register_contract(
         "mxsc:output/basic-features.mxsc.json",

--- a/contracts/feature-tests/basic-features/tests/basic_features_scenario_rs_test.rs
+++ b/contracts/feature-tests/basic-features/tests/basic_features_scenario_rs_test.rs
@@ -2,7 +2,6 @@ use multiversx_sc_scenario::*;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/feature-tests/basic-features");
 
     blockchain.register_contract(
         "mxsc:output/basic-features.mxsc.json",

--- a/contracts/feature-tests/big-float-features/tests/big_float_scenario_rs_test.rs
+++ b/contracts/feature-tests/big-float-features/tests/big_float_scenario_rs_test.rs
@@ -2,7 +2,6 @@ use multiversx_sc_scenario::*;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/feature-tests/big-float-features");
 
     blockchain.register_contract(
         "mxsc:output/big-float-features.mxsc.json",

--- a/contracts/feature-tests/composability/tests/composability_scenario_rs_test.rs
+++ b/contracts/feature-tests/composability/tests/composability_scenario_rs_test.rs
@@ -2,7 +2,6 @@ use multiversx_sc_scenario::*;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/feature-tests/composability");
 
     blockchain.register_contract(
         "mxsc:builtin-func-features/output/builtin-func-features.mxsc.json",

--- a/contracts/feature-tests/composability/tests/forwarder_blackbox_legacy_test.rs
+++ b/contracts/feature-tests/composability/tests/forwarder_blackbox_legacy_test.rs
@@ -21,7 +21,6 @@ type ForwarderContract = ContractInfo<forwarder_legacy::Proxy<StaticApi>>;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/composability/");
 
     blockchain.register_contract(FORWARDER_PATH_EXPR, forwarder_legacy::ContractBuilder);
     blockchain

--- a/contracts/feature-tests/composability/tests/forwarder_whitebox_legacy_test.rs
+++ b/contracts/feature-tests/composability/tests/forwarder_whitebox_legacy_test.rs
@@ -17,7 +17,6 @@ const NFT_TOKEN_ID: &[u8] = b"COOL-123456";
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/composability/forwarder_legacy");
 
     blockchain.register_contract(FORWARDER_PATH_EXPR, forwarder_legacy::ContractBuilder);
     blockchain

--- a/contracts/feature-tests/composability/tests/forwarder_whitebox_test.rs
+++ b/contracts/feature-tests/composability/tests/forwarder_whitebox_test.rs
@@ -10,7 +10,6 @@ const NFT_TOKEN_ID: &[u8] = b"COOL-123456";
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/composability/forwarder");
 
     blockchain.register_contract(FORWARDER_PATH_EXPR, forwarder::ContractBuilder);
     blockchain

--- a/contracts/feature-tests/composability/tests/promises_feature_blackbox_test.rs
+++ b/contracts/feature-tests/composability/tests/promises_feature_blackbox_test.rs
@@ -20,7 +20,6 @@ type VaultContract = ContractInfo<vault::Proxy<StaticApi>>;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/feature-tests/composability");
 
     blockchain.register_contract(
         PROMISES_FEATURES_PATH_EXPR,

--- a/contracts/feature-tests/composability/transfer-role-features/tests/transfer_role_whitebox_test.rs
+++ b/contracts/feature-tests/composability/transfer-role-features/tests/transfer_role_whitebox_test.rs
@@ -16,10 +16,6 @@ const REJECT_FUNDS_FUNC_NAME: &[u8] = b"reject_funds";
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace(
-        "contracts/composability/feature-tests/transfer-role-features",
-    );
-
     blockchain.register_contract(
         TRANSFER_ROLE_FEATURES_PATH_EXPR,
         transfer_role_features::ContractBuilder,

--- a/contracts/feature-tests/erc-style-contracts/crowdfunding-erc20/tests/crowdfunding_erc20_scenario_rs_test.rs
+++ b/contracts/feature-tests/erc-style-contracts/crowdfunding-erc20/tests/crowdfunding_erc20_scenario_rs_test.rs
@@ -2,20 +2,14 @@ use multiversx_sc_scenario::*;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace(
-        "contracts/feature-tests/erc-style-contracts/crowdfunding-erc20",
-    );
-
     blockchain.register_contract(
         "mxsc:output/crowdfunding-erc20.mxsc.json",
         crowdfunding_erc20::ContractBuilder,
     );
-
     blockchain.register_contract(
         "mxsc:../erc20/output/erc20.mxsc.json",
         erc20::ContractBuilder,
     );
-
     blockchain
 }
 

--- a/contracts/feature-tests/erc-style-contracts/erc20/tests/erc20_scenario_rs_test.rs
+++ b/contracts/feature-tests/erc-style-contracts/erc20/tests/erc20_scenario_rs_test.rs
@@ -2,7 +2,6 @@ use multiversx_sc_scenario::*;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/feature-tests/erc-style-contracts/erc20");
 
     blockchain.register_contract("mxsc:output/erc20.mxsc.json", erc20::ContractBuilder);
     blockchain

--- a/contracts/feature-tests/erc-style-contracts/lottery-erc20/tests/lottery_erc20_scenario_rs_test.rs
+++ b/contracts/feature-tests/erc-style-contracts/lottery-erc20/tests/lottery_erc20_scenario_rs_test.rs
@@ -2,10 +2,6 @@ use multiversx_sc_scenario::*;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace(
-        "contracts/feature-tests/erc-style-contracts/lottery-erc20",
-    );
-
     blockchain.register_contract(
         "mxsc:output/lottery-erc20.mxsc.json",
         lottery_erc20::ContractBuilder,

--- a/contracts/feature-tests/esdt-system-sc-mock/tests/esdt_system_sc_mock_scenario_rs_test.rs
+++ b/contracts/feature-tests/esdt-system-sc-mock/tests/esdt_system_sc_mock_scenario_rs_test.rs
@@ -2,7 +2,6 @@ use multiversx_sc_scenario::*;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/feature-tests/esdt-system-sc-mock");
 
     blockchain.register_contract(
         "mxsc:output/esdt-system-sc-mock.mxsc.json",

--- a/contracts/feature-tests/exchange-features/tests/exchange_features_blackbox_test.rs
+++ b/contracts/feature-tests/exchange-features/tests/exchange_features_blackbox_test.rs
@@ -4,7 +4,6 @@ const EXCHANGE_FEATURES_PATH_EXPR: &str = "mxsc:output/exchange-features.mxsc.js
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/feature-tests/exchange-features");
 
     blockchain.register_contract(
         EXCHANGE_FEATURES_PATH_EXPR,

--- a/contracts/feature-tests/formatted-message-features/tests/msg_scenario_rs_test.rs
+++ b/contracts/feature-tests/formatted-message-features/tests/msg_scenario_rs_test.rs
@@ -2,7 +2,6 @@ use multiversx_sc_scenario::*;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/feature-tests/formatted-message-features");
 
     blockchain.register_contract(
         "mxsc:output/formatted-message-features.mxsc.json",

--- a/contracts/feature-tests/managed-map-features/tests/managed_map_scenario_rs_test.rs
+++ b/contracts/feature-tests/managed-map-features/tests/managed_map_scenario_rs_test.rs
@@ -2,7 +2,6 @@ use multiversx_sc_scenario::*;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/feature-tests/managed-map-features");
     blockchain.register_contract(
         "mxsc:output/managed-map-features.mxsc.json",
         managed_map_features::ContractBuilder,

--- a/contracts/feature-tests/multi-contract-features/tests/multi_contract_scenario_rs_test.rs
+++ b/contracts/feature-tests/multi-contract-features/tests/multi_contract_scenario_rs_test.rs
@@ -2,7 +2,6 @@ use multiversx_sc_scenario::*;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/feature-tests/multi-contract-features");
 
     blockchain.register_partial_contract::<multi_contract_features::AbiProvider, _>(
         "mxsc:output/multi-contract-features.mxsc.json",

--- a/contracts/feature-tests/panic-message-features/tests/pmf_blackbox_test.rs
+++ b/contracts/feature-tests/panic-message-features/tests/pmf_blackbox_test.rs
@@ -8,7 +8,6 @@ const CODE_EXPR: &str = "mxsc:output/panic-message-features.mxsc.json";
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/examples/adder");
 
     blockchain.register_contract(CODE_EXPR, panic_message_features::ContractBuilder);
     blockchain

--- a/contracts/feature-tests/panic-message-features/tests/pmf_scenario_rs_test.rs
+++ b/contracts/feature-tests/panic-message-features/tests/pmf_scenario_rs_test.rs
@@ -2,7 +2,6 @@ use multiversx_sc_scenario::*;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/feature-tests/panic-message-features");
 
     blockchain.register_partial_contract::<panic_message_features::AbiProvider, _>(
         "mxsc:output/panic-message-features.mxsc.json",

--- a/contracts/feature-tests/payable-features/tests/payable_blackbox_test.rs
+++ b/contracts/feature-tests/payable-features/tests/payable_blackbox_test.rs
@@ -4,7 +4,6 @@ const PF_PATH_EXPR: &str = "mxsc:output/payable-features.mxsc.json";
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/feature-tests/payable-features");
 
     blockchain.register_contract(PF_PATH_EXPR, payable_features::ContractBuilder);
     blockchain

--- a/contracts/feature-tests/payable-features/tests/payable_scenario_rs_test.rs
+++ b/contracts/feature-tests/payable-features/tests/payable_scenario_rs_test.rs
@@ -2,7 +2,6 @@ use multiversx_sc_scenario::*;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/feature-tests/payable-features");
     blockchain.register_contract(
         "mxsc:output/payable-features.mxsc.json",
         payable_features::ContractBuilder,

--- a/contracts/feature-tests/rust-testing-framework-tester/tests/rust_testing_framework_tester_scenario_rs_test.rs
+++ b/contracts/feature-tests/rust-testing-framework-tester/tests/rust_testing_framework_tester_scenario_rs_test.rs
@@ -2,9 +2,6 @@ use multiversx_sc_scenario::*;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain
-        .set_current_dir_from_workspace("contracts/feature-tests/rust-testing-framework-tester");
-
     blockchain.register_contract(
         "file:output/rust-testing-framework-tester.wasm",
         rust_testing_framework_tester::ContractBuilder,

--- a/contracts/feature-tests/rust-testing-framework-tester/tests/tester_blackbox_test.rs
+++ b/contracts/feature-tests/rust-testing-framework-tester/tests/tester_blackbox_test.rs
@@ -5,9 +5,6 @@ const WASM_PATH_EXPR: &str = "mxsc:output/rust-testing-framework-tester.mxsc.jso
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain
-        .set_current_dir_from_workspace("contracts/feature_tests/rust-testing-framework-tester");
-
     blockchain.register_contract(
         WASM_PATH_EXPR,
         rust_testing_framework_tester::ContractBuilder,

--- a/contracts/feature-tests/scenario-tester/tests/st_blackbox_chained_test.rs
+++ b/contracts/feature-tests/scenario-tester/tests/st_blackbox_chained_test.rs
@@ -7,7 +7,6 @@ const ADDER_PATH_EXPR: &str = "mxsc:output/scenario-tester.mxsc.json";
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/feature-tests/scenario-tester");
 
     blockchain.register_contract(ADDER_PATH_EXPR, scenario_tester::ContractBuilder);
     blockchain

--- a/contracts/feature-tests/scenario-tester/tests/st_blackbox_legacy_proxy_test.rs
+++ b/contracts/feature-tests/scenario-tester/tests/st_blackbox_legacy_proxy_test.rs
@@ -12,7 +12,6 @@ const CODE_EXPR: MxscPath = MxscPath::new("output/adder.mxsc.json");
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/examples/adder");
 
     blockchain.register_contract(ADDER_PATH_EXPR, scenario_tester::ContractBuilder);
     blockchain

--- a/contracts/feature-tests/scenario-tester/tests/st_blackbox_raw_steps_test.rs
+++ b/contracts/feature-tests/scenario-tester/tests/st_blackbox_raw_steps_test.rs
@@ -4,7 +4,6 @@ const SCENARIO_TESTER_PATH_EXPR: &str = "mxsc:output/scenario-tester.mxsc.json";
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/feature-tests/scenario-tester");
 
     blockchain.register_contract(SCENARIO_TESTER_PATH_EXPR, scenario_tester::ContractBuilder);
     blockchain

--- a/contracts/feature-tests/scenario-tester/tests/st_blackbox_test.rs
+++ b/contracts/feature-tests/scenario-tester/tests/st_blackbox_test.rs
@@ -15,7 +15,6 @@ const NFT_ID: TestTokenIdentifier = TestTokenIdentifier::new("NFT-123456");
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/examples/scenario-tester");
 
     blockchain.register_contract(
         SC_SCENARIO_TESTER_PATH_EXPR,

--- a/contracts/feature-tests/scenario-tester/tests/st_blackbox_upgrade_test.rs
+++ b/contracts/feature-tests/scenario-tester/tests/st_blackbox_upgrade_test.rs
@@ -4,7 +4,6 @@ const ADDER_PATH_EXPR: &str = "mxsc:output/scenario-tester.mxsc.json";
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/feature-tests/scenario-tester");
 
     blockchain.register_contract(
         "mxsc:output/scenario-tester.mxsc.json",

--- a/contracts/feature-tests/scenario-tester/tests/st_scenario_rs_test.rs
+++ b/contracts/feature-tests/scenario-tester/tests/st_scenario_rs_test.rs
@@ -2,7 +2,6 @@ use multiversx_sc_scenario::*;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/feature-tests/scenario-tester");
 
     blockchain.register_contract(
         "mxsc:output/scenario-tester.mxsc.json",

--- a/contracts/feature-tests/scenario-tester/tests/st_whitebox_test.rs
+++ b/contracts/feature-tests/scenario-tester/tests/st_whitebox_test.rs
@@ -5,7 +5,6 @@ const ADDER_PATH_EXPR: &str = "mxsc:output/scenario-tester.mxsc.json";
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/feature-tests/scenario-tester");
 
     blockchain.register_contract(
         "mxsc:output/scenario-tester.mxsc.json",

--- a/contracts/feature-tests/use-module/tests/gov_module_whitebox_test.rs
+++ b/contracts/feature-tests/use-module/tests/gov_module_whitebox_test.rs
@@ -31,7 +31,6 @@ pub struct Payment {
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/features-tests/use-module");
 
     blockchain.register_contract(USE_MODULE_PATH_EXPR, use_module::ContractBuilder);
     blockchain

--- a/contracts/feature-tests/use-module/tests/staking_module_whitebox_test.rs
+++ b/contracts/feature-tests/use-module/tests/staking_module_whitebox_test.rs
@@ -21,7 +21,6 @@ const USE_MODULE_PATH_EXPR: &str = "mxsc:output/use-module.mxsc.json";
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/features-tests/use-module");
 
     blockchain.register_contract(USE_MODULE_PATH_EXPR, use_module::ContractBuilder);
     blockchain

--- a/contracts/feature-tests/use-module/tests/token_merge_module_whitebox_test.rs
+++ b/contracts/feature-tests/use-module/tests/token_merge_module_whitebox_test.rs
@@ -33,8 +33,6 @@ const SECOND_URIS: &[&[u8]] = &[b"cool.com/safe_file.exe"];
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/features-tests/use-module");
-
     blockchain.register_contract(USE_MODULE_PATH_EXPR, use_module::ContractBuilder);
     blockchain
 }

--- a/contracts/feature-tests/use-module/tests/use_module_abi_test.rs
+++ b/contracts/feature-tests/use-module/tests/use_module_abi_test.rs
@@ -5,8 +5,7 @@ use std::{fs, fs::File, io::Write};
 
 #[test]
 fn use_module_abi_generated_ok() {
-    let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("contracts/feature-tests/use-module");
+    let blockchain = ScenarioWorld::new();
 
     // generate ABI
     let multi_contract_config = multiversx_sc_meta::multi_contract_config::<use_module::AbiProvider>(

--- a/framework/scenario/src/facade/scenario_world.rs
+++ b/framework/scenario/src/facade/scenario_world.rs
@@ -103,8 +103,11 @@ impl ScenarioWorld {
         self
     }
 
-    /// Tells the tests where the crate lies relative to the workspace.
-    /// This ensures that the paths are set correctly, including in debug mode.
+    /// Older versions of the Rust compiler were setting a wrong path in the environment when debugging.
+    /// This method was made as a workaround to avoid this problem.
+    ///
+    /// Fortunately, the issue was fixed in Rust, and so this function is no longer necessary.
+    #[deprecated(since = "0.50.2", note = "No longer needed, simply delete.")]
     pub fn set_current_dir_from_workspace(&mut self, relative_path: &str) -> &mut Self {
         let mut path = find_current_workspace().unwrap();
         path.push(relative_path);

--- a/framework/scenario/tests/scenarios_self_test.rs
+++ b/framework/scenario/tests/scenarios_self_test.rs
@@ -4,7 +4,6 @@ use multiversx_sc_scenario::*;
 
 fn world() -> ScenarioWorld {
     let mut blockchain = ScenarioWorld::new();
-    blockchain.set_current_dir_from_workspace("framework/scenario");
     blockchain
 }
 


### PR DESCRIPTION
Turns out, we don't need this method anymore.

The issue it was avoiding was fixed.