### PR TITLE
deprecated legacy methods async_call and async_call_promise

### DIFF
--- a/contracts/examples/nft-minter/src/nft_module.rs
+++ b/contracts/examples/nft-minter/src/nft_module.rs
@@ -37,9 +37,8 @@ pub trait NftModule {
                     can_add_special_roles: true,
                 },
             )
-            .async_call()
             .with_callback(self.callbacks().issue_callback())
-            .call_and_exit()
+            .async_call_and_exit()
     }
 
     #[only_owner]
@@ -54,8 +53,7 @@ pub trait NftModule {
                 &self.nft_token_id().get(),
                 [EsdtLocalRole::NftCreate][..].iter().cloned(),
             )
-            .async_call()
-            .call_and_exit()
+            .async_call_and_exit()
     }
 
     // endpoints

--- a/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/child/src/lib.rs
+++ b/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/child/src/lib.rs
@@ -37,9 +37,8 @@ pub trait Child {
                     can_add_special_roles: true,
                 },
             )
-            .async_call()
             .with_callback(self.callbacks().esdt_issue_callback())
-            .call_and_exit()
+            .async_call_and_exit()
     }
 
     // callbacks

--- a/contracts/feature-tests/composability/forwarder-legacy/src/forwarder_legacy_main.rs
+++ b/contracts/feature-tests/composability/forwarder-legacy/src/forwarder_legacy_main.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![allow(clippy::type_complexity)]
 #![allow(clippy::let_unit_value)]
+#![allow(deprecated)]
 
 pub mod fwd_call_async_legacy;
 pub mod fwd_call_sync_legacy;

--- a/contracts/feature-tests/composability/forwarder-raw/src/forwarder_raw_async.rs
+++ b/contracts/feature-tests/composability/forwarder-raw/src/forwarder_raw_async.rs
@@ -66,8 +66,7 @@ pub trait ForwarderRawAsync: super::forwarder_raw_common::ForwarderRawCommon {
     ) {
         let (token, payment) = self.call_value().egld_or_single_fungible_esdt();
         self.forward_contract_call(to, token, payment, endpoint_name, args)
-            .async_call()
-            .call_and_exit()
+            .async_call_and_exit()
     }
 
     #[endpoint]
@@ -81,8 +80,7 @@ pub trait ForwarderRawAsync: super::forwarder_raw_common::ForwarderRawCommon {
         let (token, payment) = self.call_value().egld_or_single_fungible_esdt();
         let half_payment = payment / 2u32;
         self.forward_contract_call(to, token, half_payment, endpoint_name, args)
-            .async_call()
-            .call_and_exit()
+            .async_call_and_exit()
     }
 
     #[endpoint]

--- a/contracts/feature-tests/composability/forwarder/src/fwd_call_async.rs
+++ b/contracts/feature-tests/composability/forwarder/src/fwd_call_async.rs
@@ -62,8 +62,7 @@ pub trait ForwarderAsyncCallModule {
             .typed(vault_proxy::VaultProxy)
             .accept_funds()
             .payment(payment)
-            .async_call()
-            .call_and_exit()
+            .async_call_and_exit()
     }
 
     #[endpoint]
@@ -80,8 +79,7 @@ pub trait ForwarderAsyncCallModule {
                 payment.token_nonce,
                 &half_payment,
             )
-            .async_call()
-            .call_and_exit()
+            .async_call_and_exit()
     }
 
     #[payable("*")]
@@ -115,9 +113,8 @@ pub trait ForwarderAsyncCallModule {
             .to(&to)
             .typed(vault_proxy::VaultProxy)
             .retrieve_funds(token, token_nonce, amount)
-            .async_call()
             .callback(self.callbacks().retrieve_funds_callback())
-            .call_and_exit()
+            .async_call_and_exit()
     }
 
     #[callback]
@@ -196,8 +193,7 @@ pub trait ForwarderAsyncCallModule {
             .typed(vault_proxy::VaultProxy)
             .accept_funds()
             .payment(all_token_payments)
-            .async_call()
-            .call_and_exit();
+            .async_call_and_exit();
     }
 
     #[view]

--- a/contracts/feature-tests/composability/forwarder/src/fwd_esdt.rs
+++ b/contracts/feature-tests/composability/forwarder/src/fwd_esdt.rs
@@ -117,9 +117,8 @@ pub trait ForwarderEsdtModule: fwd_storage::ForwarderStorageModule {
                     can_add_special_roles: true,
                 },
             )
-            .async_call()
             .with_callback(self.callbacks().esdt_issue_callback(&caller))
-            .call_and_exit()
+            .async_call_and_exit()
     }
 
     #[callback]

--- a/contracts/feature-tests/composability/forwarder/src/fwd_nft.rs
+++ b/contracts/feature-tests/composability/forwarder/src/fwd_nft.rs
@@ -71,9 +71,8 @@ pub trait ForwarderNftModule: fwd_storage::ForwarderStorageModule {
                     can_add_special_roles: true,
                 },
             )
-            .async_call()
             .with_callback(self.callbacks().nft_issue_callback(&caller))
-            .call_and_exit()
+            .async_call_and_exit()
     }
 
     #[callback]

--- a/contracts/feature-tests/composability/forwarder/src/fwd_roles.rs
+++ b/contracts/feature-tests/composability/forwarder/src/fwd_roles.rs
@@ -14,9 +14,8 @@ pub trait ForwarderRolesModule: fwd_storage::ForwarderStorageModule {
         self.send()
             .esdt_system_sc_proxy()
             .set_special_roles(&address, &token_identifier, roles.into_iter())
-            .async_call()
             .with_callback(self.callbacks().change_roles_callback())
-            .call_and_exit()
+            .async_call_and_exit()
     }
 
     #[endpoint(unsetLocalRoles)]
@@ -29,9 +28,8 @@ pub trait ForwarderRolesModule: fwd_storage::ForwarderStorageModule {
         self.send()
             .esdt_system_sc_proxy()
             .unset_special_roles(&address, &token_identifier, roles.into_iter())
-            .async_call()
             .with_callback(self.callbacks().change_roles_callback())
-            .call_and_exit()
+            .async_call_and_exit()
     }
 
     #[callback]

--- a/contracts/feature-tests/composability/forwarder/src/fwd_sft.rs
+++ b/contracts/feature-tests/composability/forwarder/src/fwd_sft.rs
@@ -26,9 +26,8 @@ pub trait ForwarderSftModule: fwd_storage::ForwarderStorageModule {
                     can_add_special_roles: true,
                 },
             )
-            .async_call()
             .with_callback(self.callbacks().sft_issue_callback(&caller))
-            .call_and_exit()
+            .async_call_and_exit()
     }
 
     #[callback]

--- a/contracts/feature-tests/composability/local-esdt-and-nft/src/lib.rs
+++ b/contracts/feature-tests/composability/local-esdt-and-nft/src/lib.rs
@@ -48,9 +48,8 @@ pub trait LocalEsdtAndEsdtNft {
                     can_add_special_roles: true,
                 },
             )
-            .async_call()
             .with_callback(self.callbacks().esdt_issue_callback(&caller))
-            .call_and_exit()
+            .async_call_and_exit()
     }
 
     #[endpoint(localMint)]
@@ -87,9 +86,8 @@ pub trait LocalEsdtAndEsdtNft {
                     can_add_special_roles: true,
                 },
             )
-            .async_call()
             .with_callback(self.callbacks().nft_issue_callback(&caller))
-            .call_and_exit()
+            .async_call_and_exit()
     }
 
     #[endpoint(nftCreate)]
@@ -194,9 +192,8 @@ pub trait LocalEsdtAndEsdtNft {
                     can_add_special_roles: true,
                 },
             )
-            .async_call()
             .with_callback(self.callbacks().nft_issue_callback(&caller))
-            .call_and_exit()
+            .async_call_and_exit()
     }
 
     // common
@@ -211,9 +208,8 @@ pub trait LocalEsdtAndEsdtNft {
         self.send()
             .esdt_system_sc_proxy()
             .set_special_roles(&address, &token_identifier, roles.into_iter())
-            .async_call()
             .with_callback(self.callbacks().change_roles_callback())
-            .call_and_exit()
+            .async_call_and_exit()
     }
 
     #[endpoint(unsetLocalRoles)]
@@ -226,9 +222,8 @@ pub trait LocalEsdtAndEsdtNft {
         self.send()
             .esdt_system_sc_proxy()
             .unset_special_roles(&address, &token_identifier, roles.into_iter())
-            .async_call()
             .with_callback(self.callbacks().change_roles_callback())
-            .call_and_exit()
+            .async_call_and_exit()
     }
 
     #[endpoint(controlChanges)]
@@ -242,8 +237,7 @@ pub trait LocalEsdtAndEsdtNft {
         self.send()
             .esdt_system_sc_proxy()
             .control_changes(&token, &property_arguments)
-            .async_call()
-            .call_and_exit();
+            .async_call_and_exit();
     }
 
     // views

--- a/contracts/feature-tests/composability/promises-features/src/fwd_call_promise_direct.rs
+++ b/contracts/feature-tests/composability/promises-features/src/fwd_call_promise_direct.rs
@@ -20,7 +20,6 @@ pub trait CallPromisesDirectModule {
             .payment(payment)
             .arguments_raw(args.to_arg_buffer())
             .gas(gas_limit)
-            .async_call_promise()
             .callback(self.callbacks().the_one_callback(1001, 1002u32.into()))
             .gas_for_callback(extra_gas_for_callback)
             .register_promise();
@@ -46,7 +45,6 @@ pub trait CallPromisesDirectModule {
             .raw_call(endpoint_name)
             .payment(EgldOrMultiEsdtPayment::MultiEsdt(token_payments_vec))
             .gas(gas_limit)
-            .async_call_promise()
             .callback(self.callbacks().the_one_callback(2001, 2002u32.into()))
             .gas_for_callback(extra_gas_for_callback)
             .register_promise();

--- a/contracts/feature-tests/composability/promises-features/src/fwd_call_promises_bt.rs
+++ b/contracts/feature-tests/composability/promises-features/src/fwd_call_promises_bt.rs
@@ -21,7 +21,6 @@ pub trait CallPromisesBackTransfersModule: common::CommonModule {
             .typed(vault_proxy::VaultProxy)
             .retrieve_funds(token, token_nonce, amount)
             .gas(gas_limit)
-            .async_call()
             .callback(self.callbacks().retrieve_funds_back_transfers_callback())
             .gas_for_callback(10_000_000)
             .register_promise();

--- a/contracts/feature-tests/composability/proxy-test-first/src/proxy-test-first.rs
+++ b/contracts/feature-tests/composability/proxy-test-first/src/proxy-test-first.rs
@@ -73,8 +73,7 @@ pub trait ProxyTestFirst {
             .typed(pay_me_proxy::PayMeProxy)
             .pay_me(0x56)
             .egld(payment)
-            .async_call()
-            .call_and_exit();
+            .async_call_and_exit();
     }
 
     #[payable("EGLD")]
@@ -103,8 +102,7 @@ pub trait ProxyTestFirst {
                 [3u8; 3].to_vec(),
                 &ManagedAddress::from(&HARDCODED_ADDRESS),
             )
-            .async_call()
-            .call_and_exit()
+            .async_call_and_exit()
     }
 
     #[endpoint(messageOtherContractWithCallback)]

--- a/contracts/feature-tests/composability/recursive-caller/src/recursive_caller.rs
+++ b/contracts/feature-tests/composability/recursive-caller/src/recursive_caller.rs
@@ -51,8 +51,7 @@ pub trait RecursiveCaller {
                 .to(&self_address)
                 .typed(self_proxy::RecursiveCallerProxy)
                 .recursive_send_funds(to, token_identifier, amount, counter - 1)
-                .async_call()
-                .call_and_exit()
+                .async_call_and_exit()
         }
     }
 

--- a/contracts/modules/src/bonding_curve/utils/owner_endpoints.rs
+++ b/contracts/modules/src/bonding_curve/utils/owner_endpoints.rs
@@ -25,8 +25,7 @@ pub trait OwnerEndpointsModule: storage::StorageModule + events::EventsModule {
         self.send()
             .esdt_system_sc_proxy()
             .set_special_roles(&address, &token_identifier, roles.into_iter())
-            .async_call()
-            .call_and_exit()
+            .async_call_and_exit()
     }
 
     #[endpoint(unsetLocalRoles)]
@@ -39,8 +38,7 @@ pub trait OwnerEndpointsModule: storage::StorageModule + events::EventsModule {
         self.send()
             .esdt_system_sc_proxy()
             .unset_special_roles(&address, &token_identifier, roles.into_iter())
-            .async_call()
-            .call_and_exit()
+            .async_call_and_exit()
     }
 
     fn set_bonding_curve<T>(

--- a/contracts/modules/src/esdt.rs
+++ b/contracts/modules/src/esdt.rs
@@ -49,9 +49,8 @@ pub trait EsdtModule {
                 token_type,
                 num_decimals,
             )
-            .async_call()
             .with_callback(self.callbacks().issue_callback())
-            .call_and_exit()
+            .async_call_and_exit()
     }
 
     #[callback]

--- a/framework/base/src/storage/mappers/token/non_fungible_token_mapper.rs
+++ b/framework/base/src/storage/mappers/token/non_fungible_token_mapper.rs
@@ -145,9 +145,7 @@ where
         };
 
         storage_set(self.get_storage_key(), &TokenMapperState::<SA>::Pending);
-        contract_call
-            .with_callback(callback)
-            .async_call_and_exit();
+        contract_call.with_callback(callback).async_call_and_exit();
     }
 
     /// Important: If you use custom callback, remember to save the token ID in the callback and clear the mapper in case of error! Clear is unusable outside this specific case.

--- a/framework/base/src/storage/mappers/token/non_fungible_token_mapper.rs
+++ b/framework/base/src/storage/mappers/token/non_fungible_token_mapper.rs
@@ -146,9 +146,8 @@ where
 
         storage_set(self.get_storage_key(), &TokenMapperState::<SA>::Pending);
         contract_call
-            .async_call()
             .with_callback(callback)
-            .call_and_exit();
+            .async_call_and_exit();
     }
 
     /// Important: If you use custom callback, remember to save the token ID in the callback and clear the mapper in case of error! Clear is unusable outside this specific case.
@@ -200,9 +199,8 @@ where
                 token_type,
                 num_decimals,
             )
-            .async_call()
             .callback(callback)
-            .call_and_exit()
+            .async_call_and_exit()
     }
 
     pub fn clear(&mut self) {

--- a/framework/base/src/storage/mappers/token/token_mapper.rs
+++ b/framework/base/src/storage/mappers/token/token_mapper.rs
@@ -86,7 +86,7 @@ where
             .typed(ESDTSystemSCProxy)
             .set_special_roles(address, token_id, roles[..].iter().cloned())
             .callback(opt_callback)
-            .call_and_exit()
+            .async_call_and_exit()
     }
 
     fn get_sc_address() -> ManagedAddress<SA> {

--- a/framework/base/src/types/interaction/tx_exec/tx_exec_async.rs
+++ b/framework/base/src/types/interaction/tx_exec/tx_exec_async.rs
@@ -157,6 +157,10 @@ where
     RH: TxResultHandler<Env>,
 {
     /// Backwards compatibility only.
+    #[deprecated(
+        since = "0.50.2",
+        note = "Backwards compatibility only, does nothing. Just delete. Use `async_call_and_exit` to launch asynchronous calls."
+    )]
     #[inline]
     pub fn async_call(self) -> Tx<Env, From, To, Payment, Gas, Data, RH> {
         Tx {

--- a/framework/base/src/types/interaction/tx_exec/tx_exec_async_promises.rs
+++ b/framework/base/src/types/interaction/tx_exec/tx_exec_async_promises.rs
@@ -257,7 +257,11 @@ where
     Payment: TxPayment<TxScEnv<Api>>,
     Callback: TxPromisesCallback<Api>,
 {
-    /// Backwards compatibility only.
+    /// Backwards compatibility only.   
+    #[deprecated(
+        since = "0.50.2",
+        note = "Backwards compatibility only, does nothing. Just delete. Use `register_promise` to launch asynchronous calls."
+    )]
     #[inline]
     pub fn async_call_promise(self) -> Self {
         self

--- a/framework/base/src/types/interaction/tx_exec/tx_exec_async_promises.rs
+++ b/framework/base/src/types/interaction/tx_exec/tx_exec_async_promises.rs
@@ -222,7 +222,9 @@ where
     ///
     /// This version of the method must never be called. It is only here to provide a more readable error.
     pub unsafe fn register_promise(self) {
-        ErrorHelper::<Api>::signal_error_with_message("register_promise requires explicit gas and function call");
+        ErrorHelper::<Api>::signal_error_with_message(
+            "register_promise requires explicit gas and function call",
+        );
     }
 }
 


### PR DESCRIPTION
These methods have already caused a lot of confusion, it's time for them to be deprecated.