### PR TITLE
Error messages tweak

### DIFF
--- a/contracts/examples/fractional-nfts/src/fractional_uri_info.rs
+++ b/contracts/examples/fractional-nfts/src/fractional_uri_info.rs
@@ -26,7 +26,7 @@ impl<M: ManagedTypeApi> FractionalUriInfo<M> {
         let serializer = ManagedSerializer::new();
         serializer.top_decode_from_managed_buffer_custom_message(
             &first_uri,
-            b"Invalid Fractional URI info",
+            "Invalid Fractional URI info",
         )
     }
 

--- a/data/codec/src/codec_err.rs
+++ b/data/codec/src/codec_err.rs
@@ -8,15 +8,6 @@ impl From<&'static str> for EncodeError {
     }
 }
 
-// TODO: convert to "from_bytes" deprecated method in next minor release.
-// Please avoid: it bloats the contract with an unnecessary utf8 validation.
-impl From<&'static [u8]> for EncodeError {
-    #[inline]
-    fn from(message_bytes: &'static [u8]) -> Self {
-        EncodeError(core::str::from_utf8(message_bytes).unwrap())
-    }
-}
-
 impl EncodeError {
     #[inline]
     pub fn message_bytes(&self) -> &'static [u8] {
@@ -38,15 +29,6 @@ impl From<&'static str> for DecodeError {
     #[inline]
     fn from(message_bytes: &'static str) -> Self {
         DecodeError(message_bytes)
-    }
-}
-
-// TODO: convert to "from_bytes" deprecated method in next minor release.
-// Please avoid: it bloats the contract with an unnecessary utf8 validation.
-impl From<&'static [u8]> for DecodeError {
-    #[inline]
-    fn from(message_bytes: &'static [u8]) -> Self {
-        DecodeError(core::str::from_utf8(message_bytes).unwrap())
     }
 }
 
@@ -72,35 +54,4 @@ impl DecodeError {
 
     pub const MULTI_TOO_FEW_ARGS: DecodeError = DecodeError("too few arguments");
     pub const MULTI_TOO_MANY_ARGS: DecodeError = DecodeError("too many arguments");
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn decode_error_from_bytes() {
-        let from_bytes = DecodeError::from(&b"error as bytes"[..]);
-        assert_eq!(from_bytes.message_bytes(), b"error as bytes");
-        assert_eq!(from_bytes.message_str(), "error as bytes");
-    }
-
-    #[test]
-    #[should_panic]
-    fn decode_error_from_bad_bytes() {
-        let _ = DecodeError::from(&[0, 159, 146, 150][..]);
-    }
-
-    #[test]
-    fn encode_error_from_bytes() {
-        let from_bytes = EncodeError::from(&b"error as bytes"[..]);
-        assert_eq!(from_bytes.message_bytes(), b"error as bytes");
-        assert_eq!(from_bytes.message_str(), "error as bytes");
-    }
-
-    #[test]
-    #[should_panic]
-    fn encode_error_from_bad_bytes() {
-        let _ = EncodeError::from(&[0, 159, 146, 150][..]);
-    }
 }

--- a/framework/base/src/api/managed_types/big_int_api.rs
+++ b/framework/base/src/api/managed_types/big_int_api.rs
@@ -37,7 +37,7 @@ pub trait BigIntApiImpl: HandleTypeInfo + ErrorApi {
     ) {
         self.bi_sub(dest.clone(), x, y);
         if self.bi_sign(dest) == Sign::Minus {
-            Self::error_api_impl().signal_error(err_msg::BIG_UINT_SUB_NEGATIVE);
+            Self::error_api_impl().signal_error(err_msg::BIG_UINT_SUB_NEGATIVE.as_bytes());
         }
     }
 

--- a/framework/base/src/contract_base/wrappers/blockchain_wrapper.rs
+++ b/framework/base/src/contract_base/wrappers/blockchain_wrapper.rs
@@ -77,7 +77,7 @@ where
 
     pub fn check_caller_is_owner(&self) {
         if self.get_owner_address() != self.get_caller() {
-            A::error_api_impl().signal_error(ONLY_OWNER_CALLER);
+            A::error_api_impl().signal_error(ONLY_OWNER_CALLER.as_bytes());
         }
     }
 
@@ -85,7 +85,7 @@ where
         let mbuf_temp_1: A::ManagedBufferHandle = use_raw_handle(const_handles::MBUF_TEMPORARY_1);
         A::blockchain_api_impl().load_caller_managed(mbuf_temp_1.clone());
         if A::blockchain_api_impl().is_smart_contract(mbuf_temp_1) {
-            A::error_api_impl().signal_error(ONLY_USER_ACCOUNT_CALLER);
+            A::error_api_impl().signal_error(ONLY_USER_ACCOUNT_CALLER.as_bytes());
         }
     }
 

--- a/framework/base/src/contract_base/wrappers/serializer.rs
+++ b/framework/base/src/contract_base/wrappers/serializer.rs
@@ -59,7 +59,7 @@ where
     pub fn top_decode_from_managed_buffer_custom_message<T: TopDecode>(
         &self,
         buffer: &ManagedBuffer<M>,
-        error_message: &'static [u8],
+        error_message: &'static str,
     ) -> T {
         T::top_decode_or_handle_err(
             buffer.clone(), // TODO: remove clone
@@ -83,16 +83,16 @@ where
     M: ManagedTypeApi + ErrorApi,
 {
     _phantom: PhantomData<M>,
-    pub base_message: &'static [u8],
+    pub base_message: &'static str,
 }
 
 impl<M> Copy for ExitCodecErrorHandler<M> where M: ManagedTypeApi + ErrorApi {}
 
-impl<M> From<&'static [u8]> for ExitCodecErrorHandler<M>
+impl<M> From<&'static str> for ExitCodecErrorHandler<M>
 where
     M: ManagedTypeApi + ErrorApi,
 {
-    fn from(base_message: &'static [u8]) -> Self {
+    fn from(base_message: &'static str) -> Self {
         ExitCodecErrorHandler {
             _phantom: PhantomData,
             base_message,
@@ -107,7 +107,7 @@ where
     type HandledErr = Infallible;
 
     fn handle_error(&self, err: EncodeError) -> Self::HandledErr {
-        let mut message_buffer = ManagedBuffer::<M>::new_from_bytes(self.base_message);
+        let mut message_buffer = ManagedBuffer::<M>::new_from_bytes(self.base_message.as_bytes());
         message_buffer.append_bytes(err.message_bytes());
         M::error_api_impl().signal_error_from_buffer(message_buffer.get_handle())
     }
@@ -120,7 +120,7 @@ where
     type HandledErr = Infallible;
 
     fn handle_error(&self, err: DecodeError) -> Self::HandledErr {
-        let mut message_buffer = ManagedBuffer::<M>::new_from_bytes(self.base_message);
+        let mut message_buffer = ManagedBuffer::<M>::new_from_bytes(self.base_message.as_bytes());
         message_buffer.append_bytes(err.message_bytes());
         M::error_api_impl().signal_error_from_buffer(message_buffer.get_handle())
     }

--- a/framework/base/src/err_msg.rs
+++ b/framework/base/src/err_msg.rs
@@ -3,7 +3,7 @@ pub const MEM_ALLOC_ERROR: &str = "memory allocation error";
 
 pub const NON_PAYABLE_FUNC_ESDT: &str = "function does not accept ESDT payment";
 pub const BAD_TOKEN_PROVIDED: &str = "bad call value token provided";
-pub const BAD_TOKEN_TICKER_FORMAT: &[u8] = b"bad token ticker format";
+pub const BAD_TOKEN_TICKER_FORMAT: &str = "bad token ticker format";
 pub const SINGLE_ESDT_EXPECTED: &str = "function expects single ESDT payment";
 pub const TOO_MANY_ESDT_TRANSFERS: &str = "too many ESDT transfers";
 pub const ESDT_INVALID_TOKEN_INDEX: &str = "invalid token index";
@@ -11,34 +11,33 @@ pub const INCORRECT_NUM_ESDT_TRANSFERS: &str = "incorrect number of ESDT transfe
 pub static FUNGIBLE_TOKEN_EXPECTED_ERR_MSG: &str = "fungible ESDT token expected";
 
 pub const ARG_WRONG_NUMBER: &str = "wrong number of arguments";
-pub const ARG_ASYNC_WRONG_NUMBER: &[u8] = b"wrong number of arguments provided to async call";
-pub const ARG_ASYNC_RETURN_WRONG_NUMBER: &[u8] =
-    b"wrong number of arguments returned by async call";
-pub const ARG_CALLBACK_TOO_FEW: &[u8] = b"too few callback arguments provided";
-pub const ARG_CALLBACK_TOO_MANY: &[u8] = b"too many callback arguments provided";
+pub const ARG_ASYNC_WRONG_NUMBER: &str = "wrong number of arguments provided to async call";
+pub const ARG_ASYNC_RETURN_WRONG_NUMBER: &str = "wrong number of arguments returned by async call";
+pub const ARG_CALLBACK_TOO_FEW: &str = "too few callback arguments provided";
+pub const ARG_CALLBACK_TOO_MANY: &str = "too many callback arguments provided";
 
 pub const ARG_OUT_OF_RANGE: &str = "argument out of range";
-pub const ARG_BAD_LENGTH: &[u8] = b"argument has wrong length";
-pub const ARG_BAD_LENGTH_32: &[u8] = b"argument has wrong length: 32 bytes expected";
-pub const ARG_DECODE_ERROR_1: &[u8] = b"argument decode error (";
-pub const ARG_DECODE_ERROR_2: &[u8] = b"): ";
-pub const STORAGE_VALUE_OUT_OF_RANGE: &[u8] = b"storage value out of range";
-pub const STORAGE_DECODE_ERROR: &[u8] = b"storage decode error: ";
-pub const STORAGE_ENCODE_ERROR: &[u8] = b"storage encode error: ";
-pub const STORAGE_KEY_ENCODE_ERROR: &[u8] = b"storage key encode error: ";
-pub const STORAGE_VALUE_EXCEEDS_BUFFER: &[u8] = b"storage value exceeds buffer";
-pub const FINISH_ENCODE_ERROR: &[u8] = b"endpoint result encode error: ";
-pub const SERIALIZER_DECODE_ERROR: &[u8] = b"serializer decode error: ";
-pub const SERIALIZER_ENCODE_ERROR: &[u8] = b"serializer encode error: ";
-pub const FORMATTER_ENCODE_ERROR: &[u8] = b"formatter encode error: ";
-pub const LOG_TOPIC_ENCODE_ERROR: &[u8] = b"log topic encode error: ";
-pub const LOG_DATA_ENCODE_ERROR: &[u8] = b"log data encode error: ";
-pub const CONTRACT_CALL_ENCODE_ERROR: &[u8] = b"contract call encode error: ";
+pub const ARG_BAD_LENGTH: &str = "argument has wrong length";
+pub const ARG_BAD_LENGTH_32: &str = "argument has wrong length: 32 bytes expected";
+pub const ARG_DECODE_ERROR_1: &str = "argument decode error (";
+pub const ARG_DECODE_ERROR_2: &str = "): ";
+pub const STORAGE_VALUE_OUT_OF_RANGE: &str = "storage value out of range";
+pub const STORAGE_DECODE_ERROR: &str = "storage decode error: ";
+pub const STORAGE_ENCODE_ERROR: &str = "storage encode error: ";
+pub const STORAGE_KEY_ENCODE_ERROR: &str = "storage key encode error: ";
+pub const STORAGE_VALUE_EXCEEDS_BUFFER: &str = "storage value exceeds buffer";
+pub const FINISH_ENCODE_ERROR: &str = "endpoint result encode error: ";
+pub const SERIALIZER_DECODE_ERROR: &str = "serializer decode error: ";
+pub const SERIALIZER_ENCODE_ERROR: &str = "serializer encode error: ";
+pub const FORMATTER_ENCODE_ERROR: &str = "formatter encode error: ";
+pub const LOG_TOPIC_ENCODE_ERROR: &str = "log topic encode error: ";
+pub const LOG_DATA_ENCODE_ERROR: &str = "log data encode error: ";
+pub const CONTRACT_CALL_ENCODE_ERROR: &str = "contract call encode error: ";
 
-pub const VALUE_EXCEEDS_SLICE: &[u8] = b"value exceeds target slice";
-pub const CAST_TO_I64_ERROR: &[u8] = b"cast to i64 error";
-pub const BIG_UINT_EXCEEDS_SLICE: &[u8] = b"big uint as_bytes exceed target slice";
-pub const BIG_UINT_SUB_NEGATIVE: &[u8] = b"cannot subtract because result would be negative";
+pub const VALUE_EXCEEDS_SLICE: &str = "value exceeds target slice";
+pub const CAST_TO_I64_ERROR: &str = "cast to i64 error";
+pub const BIG_UINT_EXCEEDS_SLICE: &str = "big uint as_bytes exceed target slice";
+pub const BIG_UINT_SUB_NEGATIVE: &str = "cannot subtract because result would be negative";
 
 pub const DESERIALIZATION_INVALID_BYTE: &str = "call data deserialization error: not a valid byte";
 pub const DESERIALIZATION_NOT_32_BYTES: &str =
@@ -48,14 +47,14 @@ pub const DESERIALIZATION_ODD_DIGITS: &str =
 pub const DESERIALIZATION_ARG_OUT_OF_RANGE: &str =
     "call data deserialization error: argument out of range";
 
-pub const CALLBACK_BAD_FUNC: &[u8] = b"no callback function with that name exists in contract";
+pub const CALLBACK_BAD_FUNC: &str = "no callback function with that name exists in contract";
 
 pub const RECIPIENT_ADDRESS_NOT_SET: &str = "recipient address not set";
-pub static ONLY_OWNER_CALLER: &[u8] = b"Endpoint can only be called by owner";
-pub static ONLY_USER_ACCOUNT_CALLER: &[u8] = b"Endpoint can only be called by user accounts";
+pub static ONLY_OWNER_CALLER: &str = "Endpoint can only be called by owner";
+pub static ONLY_USER_ACCOUNT_CALLER: &str = "Endpoint can only be called by user accounts";
 
-pub const STORAGE_NOT_I64: &[u8] = b"storage not i64";
-pub const STORAGE_NOT_32_BYTES: &[u8] = b"32 bytes of data expected in storage at key";
+pub const STORAGE_NOT_I64: &str = "storage not i64";
+pub const STORAGE_NOT_32_BYTES: &str = "32 bytes of data expected in storage at key";
 
 /// An additional non-VM status, meant just to signal an error in the debugger infrastructure of in the tests.
 pub const DEBUG_API_ERR_STATUS: u64 = 100;

--- a/framework/base/src/io/signal_error.rs
+++ b/framework/base/src/io/signal_error.rs
@@ -10,9 +10,10 @@ pub fn signal_arg_de_error<EA>(arg_id: ArgId, decode_err: DecodeError) -> !
 where
     EA: ManagedTypeApi + ErrorApi,
 {
-    let mut message_buffer = ManagedBuffer::<EA>::new_from_bytes(err_msg::ARG_DECODE_ERROR_1);
+    let mut message_buffer =
+        ManagedBuffer::<EA>::new_from_bytes(err_msg::ARG_DECODE_ERROR_1.as_bytes());
     message_buffer.append_bytes(arg_id.as_bytes());
-    message_buffer.append_bytes(err_msg::ARG_DECODE_ERROR_2);
+    message_buffer.append_bytes(err_msg::ARG_DECODE_ERROR_2.as_bytes());
     message_buffer.append_bytes(decode_err.message_bytes());
     EA::error_api_impl().signal_error_from_buffer(message_buffer.get_handle())
 }

--- a/framework/base/src/storage/storage_get.rs
+++ b/framework/base/src/storage/storage_get.rs
@@ -183,7 +183,8 @@ where
     type HandledErr = Infallible;
 
     fn handle_error(&self, err: DecodeError) -> Self::HandledErr {
-        let mut message_buffer = ManagedBuffer::<M>::new_from_bytes(err_msg::STORAGE_DECODE_ERROR);
+        let mut message_buffer =
+            ManagedBuffer::<M>::new_from_bytes(err_msg::STORAGE_DECODE_ERROR.as_bytes());
         message_buffer.append_bytes(err.message_bytes());
         M::error_api_impl().signal_error_from_buffer(message_buffer.get_handle())
     }

--- a/framework/base/src/types/managed/basic/cast_to_i64.rs
+++ b/framework/base/src/types/managed/basic/cast_to_i64.rs
@@ -12,5 +12,5 @@ where
 {
     value
         .try_into()
-        .unwrap_or_else(|_| M::error_api_impl().signal_error(err_msg::CAST_TO_I64_ERROR))
+        .unwrap_or_else(|_| M::error_api_impl().signal_error(err_msg::CAST_TO_I64_ERROR.as_bytes()))
 }

--- a/framework/base/src/types/managed/wrapped/esdt_token_data.rs
+++ b/framework/base/src/types/managed/wrapped/esdt_token_data.rs
@@ -15,7 +15,7 @@ use crate::{
 use crate as multiversx_sc; // needed by the TypeAbi generated code
 use crate::derive::type_abi;
 
-const DECODE_ATTRIBUTE_ERROR_PREFIX: &[u8] = b"error decoding ESDT attributes: ";
+const DECODE_ATTRIBUTE_ERROR_PREFIX: &str = "error decoding ESDT attributes: ";
 
 #[type_abi]
 #[derive(Clone, TopDecode, TopEncode, NestedDecode, NestedEncode, Debug, ManagedVecItem)]

--- a/framework/base/src/types/managed/wrapped/token_identifier.rs
+++ b/framework/base/src/types/managed/wrapped/token_identifier.rs
@@ -69,9 +69,9 @@ impl<M: ManagedTypeApi> TokenIdentifier<M> {
     pub fn ticker(&self) -> ManagedBuffer<M> {
         let token_id_len = self.buffer.len();
         let ticker_len = M::managed_type_impl().get_token_ticker_len(token_id_len);
-        self.buffer
-            .copy_slice(0, ticker_len)
-            .unwrap_or_else(|| M::error_api_impl().signal_error(err_msg::BAD_TOKEN_TICKER_FORMAT))
+        self.buffer.copy_slice(0, ticker_len).unwrap_or_else(|| {
+            M::error_api_impl().signal_error(err_msg::BAD_TOKEN_TICKER_FORMAT.as_bytes())
+        })
     }
 }
 

--- a/framework/derive/src/generate/callback_gen.rs
+++ b/framework/derive/src/generate/callback_gen.rs
@@ -51,7 +51,7 @@ pub fn generate_callback_selector_and_main(
                         self::EndpointWrappers::callback_selector(self, ___cb_closure___) {
                         multiversx_sc::api::ErrorApiImpl::signal_error(
                             &<Self::Api as multiversx_sc::api::ErrorApi>::error_api_impl(),
-                            err_msg::CALLBACK_BAD_FUNC,
+                            err_msg::CALLBACK_BAD_FUNC.as_bytes(),
                         );
                     }
                 }


### PR DESCRIPTION
Removed a method that had the potential to add terrible bloat to contracts.

Also made all error messaged be str, for better debugging experience.