### PR TITLE
test address PartialEq implementation

### DIFF
--- a/framework/base/src/types/interaction/expr/test_address.rs
+++ b/framework/base/src/types/interaction/expr/test_address.rs
@@ -6,10 +6,12 @@ use crate::{
     abi::TypeAbiFrom,
     api::ManagedTypeApi,
     types::{
-        AnnotatedValue, ManagedAddress, ManagedBuffer, TxEnv, TxFrom, TxFromSpecified, TxTo,
-        TxToSpecified,
+        heap::Address, AnnotatedValue, ManagedAddress, ManagedBuffer, TxEnv, TxFrom,
+        TxFromSpecified, TxTo, TxToSpecified,
     },
 };
+
+use super::TestSCAddress;
 
 const ADDRESS_PREFIX: &str = "address:";
 
@@ -40,9 +42,47 @@ impl<'a> TestAddress<'a> {
         result
     }
 
+    pub fn to_address(&self) -> Address {
+        self.eval_to_array().into()
+    }
+
+    pub fn to_managed_address<Api: ManagedTypeApi>(&self) -> ManagedAddress<Api> {
+        self.eval_to_array().into()
+    }
+
     #[cfg(feature = "alloc")]
     pub fn eval_to_expr(&self) -> alloc::string::String {
         alloc::format!("{ADDRESS_PREFIX}{}", self.name)
+    }
+}
+
+impl<'a, 'b> PartialEq<TestSCAddress<'b>> for TestAddress<'a> {
+    fn eq(&self, other: &TestSCAddress) -> bool {
+        self.to_address() == other.to_address()
+    }
+}
+
+impl<'a> PartialEq<Address> for TestAddress<'a> {
+    fn eq(&self, other: &Address) -> bool {
+        &self.to_address() == other
+    }
+}
+
+impl<'a> PartialEq<TestAddress<'a>> for Address {
+    fn eq(&self, other: &TestAddress<'a>) -> bool {
+        self == &other.to_address()
+    }
+}
+
+impl<'a, Api: ManagedTypeApi> PartialEq<ManagedAddress<Api>> for TestAddress<'a> {
+    fn eq(&self, other: &ManagedAddress<Api>) -> bool {
+        self.to_address() == other.to_address()
+    }
+}
+
+impl<'a, Api: ManagedTypeApi> PartialEq<TestAddress<'a>> for ManagedAddress<Api> {
+    fn eq(&self, other: &TestAddress<'a>) -> bool {
+        self.to_address() == other.to_address()
     }
 }
 

--- a/framework/base/src/types/interaction/expr/test_sc_address.rs
+++ b/framework/base/src/types/interaction/expr/test_sc_address.rs
@@ -11,6 +11,8 @@ use crate::{
     },
 };
 
+use super::TestAddress;
+
 const SC_PREFIX: &str = "sc:";
 const VM_TYPE_LEN: usize = 2;
 const DEFAULT_VM_TYPE: &[u8] = &[5, 0];
@@ -48,8 +50,41 @@ where
 
 impl<'a> TestSCAddress<'a> {
     pub fn to_address(&self) -> Address {
-        let expr: [u8; 32] = self.eval_to_array();
-        expr.into()
+        self.eval_to_array().into()
+    }
+
+    pub fn to_managed_address<Api: ManagedTypeApi>(&self) -> ManagedAddress<Api> {
+        self.eval_to_array().into()
+    }
+}
+
+impl<'a, 'b> PartialEq<TestAddress<'b>> for TestSCAddress<'a> {
+    fn eq(&self, other: &TestAddress) -> bool {
+        self.to_address() == other.to_address()
+    }
+}
+
+impl<'a> PartialEq<Address> for TestSCAddress<'a> {
+    fn eq(&self, other: &Address) -> bool {
+        &self.to_address() == other
+    }
+}
+
+impl<'a> PartialEq<TestSCAddress<'a>> for Address {
+    fn eq(&self, other: &TestSCAddress<'a>) -> bool {
+        self == &other.to_address()
+    }
+}
+
+impl<'a, Api: ManagedTypeApi> PartialEq<ManagedAddress<Api>> for TestSCAddress<'a> {
+    fn eq(&self, other: &ManagedAddress<Api>) -> bool {
+        self.to_address() == other.to_address()
+    }
+}
+
+impl<'a, Api: ManagedTypeApi> PartialEq<TestSCAddress<'a>> for ManagedAddress<Api> {
+    fn eq(&self, other: &TestSCAddress<'a>) -> bool {
+        self.to_address() == other.to_address()
     }
 }
 

--- a/framework/scenario/tests/address_eq_test.rs
+++ b/framework/scenario/tests/address_eq_test.rs
@@ -1,0 +1,39 @@
+use multiversx_sc::types::TestAddress;
+use multiversx_sc_scenario::api::StaticApi;
+
+const ALICE: TestAddress = TestAddress::new("alice");
+const SC_ADDR: TestAddress = TestAddress::new("sc");
+
+#[test]
+fn test_address_eq() {
+    let alice2 = TestAddress::new("alice");
+
+    assert_eq!(ALICE, alice2);
+    assert_eq!(ALICE, alice2.to_address());
+    assert_eq!(ALICE.to_address(), alice2);
+    assert_eq!(ALICE.to_address(), alice2.to_address());
+
+    assert_eq!(ALICE, alice2.to_managed_address::<StaticApi>());
+    assert_eq!(ALICE.to_managed_address::<StaticApi>(), alice2);
+    assert_eq!(
+        ALICE.to_managed_address::<StaticApi>(),
+        alice2.to_managed_address::<StaticApi>()
+    );
+}
+
+#[test]
+fn test_sc_address_eq() {
+    let sc2 = TestAddress::new("sc");
+
+    assert_eq!(SC_ADDR, sc2);
+    assert_eq!(SC_ADDR, sc2.to_address());
+    assert_eq!(SC_ADDR.to_address(), sc2);
+    assert_eq!(SC_ADDR.to_address(), sc2.to_address());
+
+    assert_eq!(SC_ADDR, sc2.to_managed_address::<StaticApi>());
+    assert_eq!(SC_ADDR.to_managed_address::<StaticApi>(), sc2);
+    assert_eq!(
+        SC_ADDR.to_managed_address::<StaticApi>(),
+        sc2.to_managed_address::<StaticApi>()
+    );
+}


### PR DESCRIPTION
Added missing conversion and `==` implementation for test addresses.