### PR TITLE
temporarily removed diagnostic::on_unimplemented

### DIFF
--- a/framework/base/Cargo.toml
+++ b/framework/base/Cargo.toml
@@ -2,7 +2,6 @@
 name = "multiversx-sc"
 version = "0.50.5"
 edition = "2021"
-rust-version = "1.78"
 
 authors = ["Andrei Marinica <andrei.marinica@multiversx.com>", "MultiversX <contact@multiversx.com>"]
 license = "GPL-3.0-only"

--- a/framework/base/src/types/interaction/tx_data/tx_code_source.rs
+++ b/framework/base/src/types/interaction/tx_data/tx_code_source.rs
@@ -14,11 +14,6 @@ where
 {
 }
 
-#[diagnostic::on_unimplemented(
-    message = "Type `{Self}` cannot be used as code (does not implement `TxCodeValue<{Env}>`)",
-    label = "not a valid smart contract byte code",
-    note = "there are multiple ways to specify SC byte code, but `{Self}` is not one of them"
-)]
 pub trait TxCodeValue<Env>: AnnotatedValue<Env, ManagedBuffer<Env::Api>>
 where
     Env: TxEnv,
@@ -44,11 +39,6 @@ where
 {
 }
 
-#[diagnostic::on_unimplemented(
-    message = "Type `{Self}` cannot be used as code source value (does not implement `TxFromSourceValue<{Env}>`)",
-    label = "not an address from where to copy the code",
-    note = "there are multiple ways to specify a code source address, but `{Self}` is not one of them"
-)]
 pub trait TxFromSourceValue<Env>: AnnotatedValue<Env, ManagedAddress<Env::Api>>
 where
     Env: TxEnv,

--- a/framework/base/src/types/interaction/tx_from.rs
+++ b/framework/base/src/types/interaction/tx_from.rs
@@ -13,11 +13,6 @@ where
 /// Marks the non-empty sender of a transaction.
 ///
 /// Enforces the reciipent to be explicitly specified.
-#[diagnostic::on_unimplemented(
-    message = "Type `{Self}` cannot be used as a sender value (does not implement `TxFromSpecified<{Env}>`)",
-    label = "sender needs to be explicit",
-    note = "there are multiple ways to specify the sender value for a transaction, but `{Self}` is not one of them"
-)]
 pub trait TxFromSpecified<Env>:
     TxFrom<Env> + AnnotatedValue<Env, ManagedAddress<Env::Api>>
 where

--- a/framework/base/src/types/interaction/tx_gas.rs
+++ b/framework/base/src/types/interaction/tx_gas.rs
@@ -33,11 +33,6 @@ where
     }
 }
 
-#[diagnostic::on_unimplemented(
-    message = "Type `{Self}` cannot be used as gas value (does not implement `TxGasValue<{Env}>`)",
-    label = "not a valid value for gas",
-    note = "there are multiple ways to specify the gas value for a transaction, but `{Self}` is not one of them"
-)]
 pub trait TxGasValue<Env>: AnnotatedValue<Env, u64>
 where
     Env: TxEnv,

--- a/framework/base/src/types/interaction/tx_payment.rs
+++ b/framework/base/src/types/interaction/tx_payment.rs
@@ -24,11 +24,6 @@ use crate::{
 use super::{AnnotatedValue, FunctionCall, TxEnv, TxFrom, TxToSpecified};
 
 /// Describes a payment that is part of a transaction.
-#[diagnostic::on_unimplemented(
-    message = "Type `{Self}` cannot be used as payment (does not implement `TxPayment<{Env}>`)",
-    label = "not a valid payment type",
-    note = "there are multiple ways to specify the transaction payment, but `{Self}` is not one of them"
-)]
 pub trait TxPayment<Env>
 where
     Env: TxEnv,

--- a/framework/base/src/types/interaction/tx_result_handler_list/tx_result_handler_list_item.rs
+++ b/framework/base/src/types/interaction/tx_result_handler_list/tx_result_handler_list_item.rs
@@ -3,11 +3,6 @@ use crate::types::TxEnv;
 /// Result handler list item.
 ///
 /// It acts as a result handler that produces a single result.
-#[diagnostic::on_unimplemented(
-    message = "Type `{Self}` cannot be used as a decoder result handler (does not implement `RHListItem<{Env}>`)",
-    label = "not a valid decoder result handler",
-    note = "there are multiple ways to specify the result handling, but `{Self}` is not one of them"
-)]
 pub trait RHListItem<Env, Original>
 where
     Env: TxEnv,

--- a/framework/base/src/types/interaction/tx_to.rs
+++ b/framework/base/src/types/interaction/tx_to.rs
@@ -14,11 +14,6 @@ impl<Env> TxTo<Env> for () where Env: TxEnv {}
 /// Marks the non-empty recipient of a transaction.
 ///
 /// Enforces the recipient to be explicitly specified.
-#[diagnostic::on_unimplemented(
-    message = "Type `{Self}` cannot be used as recipient value (does not implement `TxToSpecified<{Env}>`)",
-    label = "recipient needs to be explicit",
-    note = "there are multiple ways to specify the recipient value for a transaction, but `{Self}` is not one of them"
-)]
 pub trait TxToSpecified<Env>: TxTo<Env> + AnnotatedValue<Env, ManagedAddress<Env::Api>>
 where
     Env: TxEnv,


### PR DESCRIPTION
In order to remove rustc 1.78 dependency in 0.50, temporarily removed feature.