### PR TITLE
fix/sdk: Allow signature to be empty in core sdk TransactionOnNetwork

### DIFF
--- a/sdk/core/src/data/transaction.rs
+++ b/sdk/core/src/data/transaction.rs
@@ -62,6 +62,7 @@ pub struct TransactionOnNetwork {
     pub sender: Address,
     pub gas_price: u64,
     pub gas_limit: u64,
+    #[serde(default)]
     pub signature: String,
     pub source_shard: u32,
     pub destination_shard: u32,
@@ -287,6 +288,85 @@ mod test {
         assert_eq!(
             event_log.data,
             LogData::Vec(vec!["data1".to_owned(), "data2".to_owned()])
+        );
+    }
+
+    #[test]
+    fn parse_transaction_info_no_signature() {
+        let data = r#"
+{
+    "data": {
+        "transaction": {
+            "type": "unsigned",
+            "processingTypeOnSource": "SCInvoking",
+            "processingTypeOnDestination": "SCInvoking",
+            "hash": "34cd9c6d0f68c0975971352ed4dcaacc1acd9a2dbd8f5840a2866d09b1d72298",
+            "nonce": 0,
+            "round": 5616535,
+            "epoch": 2314,
+            "value": "0",
+            "receiver": "erd1qqqqqqqqqqqqqpgq0mhy244pyr9pzdhahvvyze4rw3xl29q4kklszyzq72",
+            "sender": "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u",
+            "gasPrice": 1000000000,
+            "gasLimit": 25411165,
+            "gasUsed": 1197500,
+            "data": "",
+            "previousTransactionHash": "6c105dc2bb6ca8b89cfcac910a46310812b51312a281837096fc94dd771bb652",
+            "originalTransactionHash": "100d1edd0434938ec39e6cb5059601b4618a1ca25b91c38e5be9e75444b3c4f5",
+            "originalSender": "erd1wavgcxq9tfyrw49k3s3h34085mayu82wqvpd4h6akyh8559pkklsknwhwh",
+            "sourceShard": 4294967295,
+            "destinationShard": 1,
+            "blockNonce": 5547876,
+            "blockHash": "0d7caaf8f2bf46e913f91867527d44cd1c77453c9aee50d91a10739bd272d00c",
+            "notarizedAtSourceInMetaNonce": 5551265,
+            "NotarizedAtSourceInMetaHash": "4c87bc5161925a3902e43a7f9f186e63f21f827ef1129ad0e609a0d45dca016a",
+            "notarizedAtDestinationInMetaNonce": 5551269,
+            "notarizedAtDestinationInMetaHash": "83bfa8463558ee6d2c90b34ee03782619b699fea667acfb98924227bacbba93d",
+            "miniblockType": "SmartContractResultBlock",
+            "miniblockHash": "c12693db88e3b69b68d5279fd8939ec75b7f0d8e529e7fd950c83b5716a436bd",
+            "hyperblockNonce": 5551269,
+            "hyperblockHash": "83bfa8463558ee6d2c90b34ee03782619b699fea667acfb98924227bacbba93d",
+            "timestamp": 1727699210,
+            "logs": {
+                "address": "erd1qqqqqqqqqqqqqpgq0mhy244pyr9pzdhahvvyze4rw3xl29q4kklszyzq72",
+                "events": [
+                    {
+                        "address": "erd1qqqqqqqqqqqqqpgq0mhy244pyr9pzdhahvvyze4rw3xl29q4kklszyzq72",
+                        "identifier": "transferValueOnly",
+                        "topics": [
+                            "I4byb8EAAA==",
+                            "AAAAAAAAAAAFAMMiO8pDAH5z5hUCqfc+N03C7UI6tb8="
+                        ],
+                        "data": "RXhlY3V0ZU9uRGVzdENvbnRleHQ=",
+                        "additionalData": [
+                            "RXhlY3V0ZU9uRGVzdENvbnRleHQ=",
+                            "ZGVwbG95SW50ZXJjaGFpblRva2Vu",
+                            "GeLN3wLxaJKDPbaxdmqkIh0pFNi1l8WJeqy9TofeG40=",
+                            "YXZhbGFuY2hlLWZ1amk=",
+                            "SVRTVGVzdFRva2Vu",
+                            "SVRTVFQ=",
+                            "Bg==",
+                            "d1iMGAVaSDdUtowjeNXnpvpOHU4DAtrfXbEuelChtb8="
+                        ]
+                    }
+                ]
+            },
+            "status": "success",
+            "operation": "transfer",
+            "fee": "0",
+            "callType": "asynchronousCallBack",
+            "options": 0
+        }
+    },
+    "error": "",
+    "code": "successful"
+}
+        "#;
+
+        let transaction = serde_json::from_str::<TransactionInfo>(data).unwrap();
+        assert_eq!(
+            transaction.data.unwrap().transaction.hash.unwrap(),
+            "34cd9c6d0f68c0975971352ed4dcaacc1acd9a2dbd8f5840a2866d09b1d72298"
         );
     }
 }


### PR DESCRIPTION
Hello, I recently ran into an issue with the Rust SDK not being able to retrieve `unsigned` transactions from the blockchain (i.e: inter contract transactions in a callback):
https://devnet-gateway.multiversx.com/transaction/34cd9c6d0f68c0975971352ed4dcaacc1acd9a2dbd8f5840a2866d09b1d72298?withResults=true

It seems that the issue was that in the SDK the `signature` field was required, while for these kinds of transactions there is no signature.

Added a default value to the field in order to preserve backwards compatibility.