### PR TITLE
sc-meta support for framework deps as path or git

### DIFF
--- a/framework/meta/src/cmd/info.rs
+++ b/framework/meta/src/cmd/info.rs
@@ -1,9 +1,10 @@
-use super::upgrade::print_tree_dir_metadata;
 use crate::{
     cli::InfoArgs,
     folder_structure::{dir_pretty_print, RelevantDirectories},
     version_history::LAST_UPGRADE_VERSION,
 };
+
+use super::print_util::print_tree_dir_metadata;
 
 pub fn call_info(args: &InfoArgs) {
     let path = if let Some(some_path) = &args.path {

--- a/framework/meta/src/cmd/print_util.rs
+++ b/framework/meta/src/cmd/print_util.rs
@@ -1,5 +1,8 @@
 use colored::Colorize;
+use multiversx_sc_meta_lib::version::FrameworkVersion;
 use std::path::Path;
+
+use crate::folder_structure::{DependencyReference, DirectoryType, RelevantDirectory};
 
 pub fn print_all_count(num_contract_crates: usize) {
     println!(
@@ -23,4 +26,34 @@ pub fn print_all_command(meta_path: &Path, cargo_run_args: &[String]) {
         "Calling".green(),
         cargo_run_args.join(" "),
     );
+}
+
+pub fn print_tree_dir_metadata(dir: &RelevantDirectory, last_version: &FrameworkVersion) {
+    match dir.dir_type {
+        DirectoryType::Contract => print!(" {}", "[contract]".blue()),
+        DirectoryType::Lib => print!(" {}", "[lib]".magenta()),
+    }
+
+    match &dir.version {
+        DependencyReference::Version(version_req) => {
+            let version_string = format!("[{}]", version_req.semver);
+            if version_req.semver == *last_version {
+                print!(" {}", version_string.green());
+            } else {
+                print!(" {}", version_string.red());
+            };
+        },
+        DependencyReference::Git(git_reference) => {
+            let git_string = format!(
+                "[git: {} rev: {}]",
+                git_reference.git.truecolor(255, 127, 0),
+                git_reference.rev.truecolor(255, 127, 0)
+            );
+            print!(" {}", git_string.truecolor(255, 198, 0));
+        },
+        DependencyReference::Path(path_buf) => {
+            let git_string = format!("[path: {}]", path_buf.truecolor(255, 127, 0));
+            print!(" {}", git_string.truecolor(255, 198, 0));
+        },
+    }
 }

--- a/framework/meta/src/cmd/upgrade.rs
+++ b/framework/meta/src/cmd/upgrade.rs
@@ -8,5 +8,4 @@ mod upgrade_print;
 mod upgrade_selector;
 mod upgrade_settings;
 
-pub use upgrade_print::print_tree_dir_metadata;
 pub use upgrade_selector::upgrade_sc;

--- a/framework/meta/src/cmd/upgrade/upgrade_print.rs
+++ b/framework/meta/src/cmd/upgrade/upgrade_print.rs
@@ -1,8 +1,5 @@
 use crate::{
-    folder_structure::{
-        DirectoryType::{Contract, Lib},
-        RelevantDirectory,
-    },
+    folder_structure::{DependencyReference, RelevantDirectory},
     version::FrameworkVersion,
 };
 use colored::Colorize;
@@ -82,20 +79,6 @@ pub fn print_postprocessing_after_39_1(path: &Path) {
     );
 }
 
-pub fn print_tree_dir_metadata(dir: &RelevantDirectory, last_version: &FrameworkVersion) {
-    match dir.dir_type {
-        Contract => print!(" {}", "[contract]".blue()),
-        Lib => print!(" {}", "[lib]".magenta()),
-    }
-
-    let version_string = format!("[{}]", dir.version.semver);
-    if dir.version.semver == *last_version {
-        print!(" {}", version_string.green());
-    } else {
-        print!(" {}", version_string.red());
-    };
-}
-
 pub fn print_cargo_dep_remove(path: &Path, dep_name: &str) {
     println!(
         "{}/dependencies/{}",
@@ -113,15 +96,17 @@ pub fn print_cargo_dep_add(path: &Path, dep_name: &str) {
 }
 
 pub fn print_cargo_check(dir: &RelevantDirectory) {
-    println!(
-        "\n{}",
-        format!(
-            "Running cargo check after upgrading to version {} in {}\n",
-            dir.version.semver,
-            dir.path.display(),
-        )
-        .purple()
-    );
+    if let DependencyReference::Version(version_req) = &dir.version {
+        println!(
+            "\n{}",
+            format!(
+                "Running cargo check after upgrading to version {} in {}\n",
+                version_req.semver,
+                dir.path.display(),
+            )
+            .purple()
+        );
+    }
 }
 
 pub fn print_cargo_check_fail() {

--- a/framework/meta/src/cmd/upgrade/upgrade_selector.rs
+++ b/framework/meta/src/cmd/upgrade/upgrade_selector.rs
@@ -1,6 +1,6 @@
 use crate::{
     cli::UpgradeArgs,
-    cmd::upgrade::upgrade_settings::UpgradeSettings,
+    cmd::{print_util::print_tree_dir_metadata, upgrade::upgrade_settings::UpgradeSettings},
     folder_structure::{dir_pretty_print, RelevantDirectories, RelevantDirectory},
     version::FrameworkVersion,
     version_history::{versions_iter, CHECK_AFTER_UPGRADE_TO, LAST_UPGRADE_VERSION, VERSIONS},

--- a/framework/meta/src/folder_structure/version_req.rs
+++ b/framework/meta/src/folder_structure/version_req.rs
@@ -3,6 +3,24 @@ use crate::{
     version_history::{find_version_by_str, LAST_VERSION},
 };
 
+/// Models how a dependency is expressed in Cargo.toml.
+#[derive(Debug, Clone)]
+pub enum DependencyReference {
+    Version(VersionReq),
+    Git(GitReference),
+    Path(String),
+}
+
+impl DependencyReference {
+    pub fn is_framework_version(&self, version: &FrameworkVersion) -> bool {
+        if let DependencyReference::Version(version_req) = self {
+            &version_req.semver == version
+        } else {
+            false
+        }
+    }
+}
+
 /// Crate version requirements, as expressed in Cargo.toml. A very crude version.
 ///
 /// TODO: replace with semver::VersionReq at some point.
@@ -35,4 +53,13 @@ impl VersionReq {
             self.semver.to_string()
         }
     }
+}
+
+/// A dependency reference to a git commit. We mostly use git commits when referencing git.
+///
+/// TODO: add support for `branch` and `tag`.
+#[derive(Debug, Clone)]
+pub struct GitReference {
+    pub git: String,
+    pub rev: String,
 }


### PR DESCRIPTION
`sc-meta info` also displays this info in nice colors

![Screenshot 2024-10-09 at 14 47 40](https://github.com/user-attachments/assets/fb5efa38-6b6a-4501-b509-91c65f6c41af)
