### PR TITLE
unified syntax - removed need for `prepare_async()`

### DIFF
--- a/contracts/examples/adder/interact/src/basic_interact.rs
+++ b/contracts/examples/adder/interact/src/basic_interact.rs
@@ -118,7 +118,6 @@ impl AdderInteract {
             .code(ADDER_CODE_PATH)
             .code_metadata(CodeMetadata::UPGRADEABLE)
             .returns(ReturnsNewBech32Address)
-            .prepare_async()
             .run()
             .await;
 
@@ -185,7 +184,6 @@ impl AdderInteract {
             .from(&self.wallet_address)
             .to(self.state.current_adder_address())
             .egld(NumExpr("0,050000000000000000"))
-            .prepare_async()
             .run()
             .await;
     }
@@ -198,7 +196,6 @@ impl AdderInteract {
             .gas(6_000_000)
             .typed(adder_proxy::AdderProxy)
             .add(value)
-            .prepare_async()
             .run()
             .await;
 
@@ -213,7 +210,6 @@ impl AdderInteract {
             .typed(adder_proxy::AdderProxy)
             .sum()
             .returns(ReturnsResultUnmanaged)
-            .prepare_async()
             .run()
             .await;
 
@@ -239,7 +235,6 @@ impl AdderInteract {
                     .code_metadata(CodeMetadata::UPGRADEABLE)
                     .code(ADDER_CODE_PATH)
                     .returns(ExpectError(code, msg))
-                    .prepare_async()
                     .run()
                     .await;
 
@@ -255,7 +250,6 @@ impl AdderInteract {
                     .upgrade(new_value)
                     .code_metadata(CodeMetadata::UPGRADEABLE)
                     .code(ADDER_CODE_PATH)
-                    .prepare_async()
                     .run()
                     .await;
 
@@ -266,7 +260,6 @@ impl AdderInteract {
                     .typed(adder_proxy::AdderProxy)
                     .sum()
                     .returns(ReturnsResultUnmanaged)
-                    .prepare_async()
                     .run()
                     .await;
 

--- a/contracts/examples/multisig/interact/src/multisig_interact.rs
+++ b/contracts/examples/multisig/interact/src/multisig_interact.rs
@@ -145,7 +145,6 @@ impl MultisigInteract {
             .code(&self.multisig_code)
             .gas(NumExpr("100,000,000"))
             .returns(ReturnsNewBech32Address)
-            .prepare_async()
             .run()
             .await;
 
@@ -202,7 +201,6 @@ impl MultisigInteract {
             .from(&self.wallet_address)
             .to(self.state.current_multisig_address())
             .egld(BigUint::from(50_000_000_000_000_000u64)) // 0,05 or 5 * 10^16
-            .prepare_async()
             .run()
             .await;
     }
@@ -220,7 +218,6 @@ impl MultisigInteract {
             .gas(gas_expr)
             .typed(multisig_proxy::MultisigProxy)
             .perform_action_endpoint(action_id)
-            .prepare_async()
             .run()
             .await;
 
@@ -273,7 +270,6 @@ impl MultisigInteract {
             .typed(multisig_proxy::MultisigProxy)
             .quorum_reached(action_id)
             .returns(ReturnsResult)
-            .prepare_async()
             .run()
             .await
     }
@@ -285,7 +281,6 @@ impl MultisigInteract {
             .typed(multisig_proxy::MultisigProxy)
             .signed(signer, action_id)
             .returns(ReturnsResult)
-            .prepare_async()
             .run()
             .await
     }
@@ -340,7 +335,6 @@ impl MultisigInteract {
             .gas(NumExpr("30,000,000"))
             .typed(multisig_proxy::MultisigProxy)
             .dns_register(dns_address, name)
-            .prepare_async()
             .run()
             .await;
 
@@ -355,7 +349,6 @@ impl MultisigInteract {
             .typed(multisig_proxy::MultisigProxy)
             .quorum()
             .returns(ReturnsResult)
-            .prepare_async()
             .run()
             .await;
 
@@ -370,7 +363,6 @@ impl MultisigInteract {
             .typed(multisig_proxy::MultisigProxy)
             .num_board_members()
             .returns(ReturnsResult)
-            .prepare_async()
             .run()
             .await;
 

--- a/contracts/examples/multisig/interact/src/multisig_interact_nfts.rs
+++ b/contracts/examples/multisig/interact/src/multisig_interact_nfts.rs
@@ -50,7 +50,6 @@ impl MultisigInteract {
                     .argument(&0u32),
             )
             .returns(ReturnsResult)
-            .prepare_async()
             .run()
             .await;
 
@@ -75,7 +74,6 @@ impl MultisigInteract {
             .typed(multisig_proxy::MultisigProxy)
             .perform_action_endpoint(action_id)
             .returns(ReturnsNewTokenIdentifier)
-            .prepare_async()
             .run()
             .await;
         self.collection_token_identifier = new_token_id.to_string();
@@ -102,7 +100,6 @@ impl MultisigInteract {
                     .argument(&COLLECTION_TICKER),
             )
             .returns(ReturnsResult)
-            .prepare_async()
             .run()
             .await;
 
@@ -127,7 +124,6 @@ impl MultisigInteract {
             .typed(multisig_proxy::MultisigProxy)
             .perform_action_endpoint(action_id)
             .returns(ReturnsNewTokenIdentifier)
-            .prepare_async()
             .run()
             .await;
         self.collection_token_identifier = new_token_id;
@@ -156,7 +152,6 @@ impl MultisigInteract {
                     .argument(&"ESDTRoleNFTCreate"),
             )
             .returns(ReturnsResult)
-            .prepare_async()
             .run()
             .await;
 

--- a/contracts/examples/multisig/interact/src/multisig_interact_wegld.rs
+++ b/contracts/examples/multisig/interact/src/multisig_interact_wegld.rs
@@ -56,7 +56,6 @@ impl MultisigInteract {
             .typed(multisig_proxy::MultisigProxy)
             .propose_async_call(&self.config.wegld_address, WRAP_AMOUNT, function_call)
             .returns(ReturnsResult)
-            .prepare_async()
             .run()
             .await;
 
@@ -72,7 +71,6 @@ impl MultisigInteract {
             .typed(wegld_proxy::EgldEsdtSwapProxy)
             .wrapped_egld_token_id()
             .returns(ReturnsResult)
-            .prepare_async()
             .run()
             .await;
 
@@ -104,7 +102,6 @@ impl MultisigInteract {
             .typed(multisig_proxy::MultisigProxy)
             .propose_async_call(normalized_to, 0u64, normalized_data)
             .returns(ReturnsResult)
-            .prepare_async()
             .run()
             .await;
 

--- a/contracts/examples/ping-pong-egld/dapp/src/interactor.rs
+++ b/contracts/examples/ping-pong-egld/dapp/src/interactor.rs
@@ -1,12 +1,9 @@
-use imports::{Address, Bech32Address, BytesValue};
-use multiversx_sc_snippets_dapp::*;
+use multiversx_sc_snippets_dapp::imports::*;
 use serde::{Deserialize, Serialize};
 
-const GATEWAY: &str = sdk::core::gateway::DEVNET_GATEWAY;
+const GATEWAY: &str = multiversx_sc_snippets_dapp::sdk::core::gateway::DEVNET_GATEWAY;
 const CONTRACT_ADDRESS: &str = "erd1qqqqqqqqqqqqqpgq6tqvj5f59xrgxwrtwy30elgpu7l4zrv6d8ssnjdwxq";
 const PING_PONG_CODE: &[u8] = include_bytes!("../ping-pong-egld.wasm");
-
-use multiversx_sc_snippets_dapp::imports::*;
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct Config {

--- a/contracts/examples/ping-pong-egld/dapp/src/requests/transaction.rs
+++ b/contracts/examples/ping-pong-egld/dapp/src/requests/transaction.rs
@@ -1,8 +1,5 @@
 use crate::interactor::ContractInteract;
-use multiversx_sc_snippets_dapp::imports::{
-    Bech32Address, BigUint, IgnoreValue, InteractorPrepareAsync, OptionalValue, ReturnsMessage,
-    ReturnsNewBech32Address, ReturnsStatus,
-};
+use multiversx_sc_snippets_dapp::imports::*;
 
 use super::proxy;
 
@@ -29,7 +26,6 @@ pub async fn deploy_sc() -> Result<Bech32Address, String> {
         .returns(ReturnsNewBech32Address)
         .returns(ReturnsStatus)
         .returns(ReturnsMessage)
-        .prepare_async()
         .run()
         .await;
 
@@ -57,7 +53,6 @@ pub async fn ping() -> Result<String, String> {
         .typed(proxy::PingPongProxy)
         .ping(_data)
         .egld(BigUint::from(amount))
-        .prepare_async()
         .run()
         .await;
 

--- a/contracts/feature-tests/basic-features/interact/src/bf_interact.rs
+++ b/contracts/feature-tests/basic-features/interact/src/bf_interact.rs
@@ -86,7 +86,6 @@ impl BasicFeaturesInteract {
             .code(&self.code_expr)
             .gas(NumExpr("4,000,000"))
             .returns(ReturnsNewBech32Address)
-            .prepare_async()
             .run()
             .await;
 
@@ -103,7 +102,6 @@ impl BasicFeaturesInteract {
             .gas(NumExpr("600,000,000"))
             .typed(basic_features_proxy::BasicFeaturesProxy)
             .store_bytes(value)
-            .prepare_async()
             .run()
             .await;
 
@@ -118,7 +116,6 @@ impl BasicFeaturesInteract {
             .typed(basic_features_proxy::BasicFeaturesProxy)
             .load_bytes()
             .returns(ReturnsResult)
-            .prepare_async()
             .run()
             .await;
 

--- a/contracts/feature-tests/composability/interact/src/call_tree_calling_functions.rs
+++ b/contracts/feature-tests/composability/interact/src/call_tree_calling_functions.rs
@@ -124,7 +124,6 @@ impl ComposabilityInteract {
             .to(&root_addr)
             .typed(forwarder_queue_proxy::ForwarderQueueProxy)
             .forward_queued_calls()
-            .prepare_async()
             .run()
             .await;
 

--- a/framework/meta-lib/src/contract/generate_snippets/snippet_sc_functions_gen.rs
+++ b/framework/meta-lib/src/contract/generate_snippets/snippet_sc_functions_gen.rs
@@ -65,7 +65,7 @@ fn write_deploy_method_impl(file: &mut File, init_abi: &EndpointAbi, name: &Stri
             .init({})
             .code(&self.contract_code)
             .returns(ReturnsNewAddress)
-            .prepare_async()
+            
             .run()
             .await;
         let new_address_bech32 = bech32::encode(&new_address);
@@ -101,7 +101,7 @@ fn write_upgrade_endpoint_impl(file: &mut File, upgrade_abi: &EndpointAbi, name:
             .code(&self.contract_code)
             .code_metadata(CodeMetadata::UPGRADEABLE)
             .returns(ReturnsNewAddress)
-            .prepare_async()
+            
             .run()
             .await;
 
@@ -214,7 +214,7 @@ fn write_contract_call(file: &mut File, endpoint_abi: &EndpointAbi, name: &Strin
             .typed(proxy::{}Proxy)
             .{}({}){}
             .returns(ReturnsResultUnmanaged)
-            .prepare_async()
+            
             .run()
             .await;
 
@@ -237,7 +237,7 @@ fn write_contract_query(file: &mut File, endpoint_abi: &EndpointAbi, name: &Stri
             .typed(proxy::{}Proxy)
             .{}({})
             .returns(ReturnsResultUnmanaged)
-            .prepare_async()
+            
             .run()
             .await;
 

--- a/framework/snippets-base/src/interactor_tx.rs
+++ b/framework/snippets-base/src/interactor_tx.rs
@@ -13,6 +13,6 @@ mod interactor_query_step;
 
 pub use interactor_exec_env::InteractorEnvExec;
 pub use interactor_exec_step::InteractorExecStep;
-pub use interactor_prepare_async::InteractorPrepareAsync;
+pub use interactor_prepare_async::{InteractorPrepareAsync, InteractorRunAsync};
 pub use interactor_query_env::InteractorEnvQuery;
 pub use interactor_query_step::InteractorQueryStep;

--- a/framework/snippets-base/src/interactor_tx/interactor_exec_deploy.rs
+++ b/framework/snippets-base/src/interactor_tx/interactor_exec_deploy.rs
@@ -19,6 +19,7 @@ use super::{
     InteractorPrepareAsync,
 };
 
+#[allow(clippy::type_complexity)]
 async fn run_async_deploy<'w, GatewayProxy, From, Payment, Gas, CodeValue, RH>(
     tx: Tx<
         InteractorEnvExec<'w, GatewayProxy>,

--- a/framework/snippets-base/src/interactor_tx/interactor_exec_deploy.rs
+++ b/framework/snippets-base/src/interactor_tx/interactor_exec_deploy.rs
@@ -14,7 +14,65 @@ use multiversx_sdk::gateway::GatewayAsyncService;
 
 use crate::InteractorBase;
 
-use super::{InteractorEnvExec, InteractorExecStep, InteractorPrepareAsync};
+use super::{
+    interactor_prepare_async::InteractorRunAsync, InteractorEnvExec, InteractorExecStep,
+    InteractorPrepareAsync,
+};
+
+async fn run_async_deploy<'w, GatewayProxy, From, Payment, Gas, CodeValue, RH>(
+    tx: Tx<
+        InteractorEnvExec<'w, GatewayProxy>,
+        From,
+        (),
+        Payment,
+        Gas,
+        DeployCall<InteractorEnvExec<'w, GatewayProxy>, Code<CodeValue>>,
+        RH,
+    >,
+) -> <RH::ListReturns as NestedTupleFlatten>::Unpacked
+where
+    GatewayProxy: GatewayAsyncService,
+    From: TxFromSpecified<InteractorEnvExec<'w, GatewayProxy>>,
+    Payment: TxPayment<InteractorEnvExec<'w, GatewayProxy>>,
+    Gas: TxGas<InteractorEnvExec<'w, GatewayProxy>>,
+    CodeValue: TxCodeValue<InteractorEnvExec<'w, GatewayProxy>>,
+    RH: RHListExec<TxResponse, InteractorEnvExec<'w, GatewayProxy>>,
+    RH::ListReturns: NestedTupleFlatten,
+{
+    let mut step_wrapper = tx.tx_to_step();
+    step_wrapper
+        .env
+        .world
+        .sc_deploy(&mut step_wrapper.step)
+        .await;
+    step_wrapper.process_result()
+}
+
+impl<'w, GatewayProxy, From, Payment, Gas, CodeValue, RH> InteractorRunAsync
+    for Tx<
+        InteractorEnvExec<'w, GatewayProxy>,
+        From,
+        (),
+        Payment,
+        Gas,
+        DeployCall<InteractorEnvExec<'w, GatewayProxy>, Code<CodeValue>>,
+        RH,
+    >
+where
+    GatewayProxy: GatewayAsyncService,
+    From: TxFromSpecified<InteractorEnvExec<'w, GatewayProxy>>,
+    Payment: TxPayment<InteractorEnvExec<'w, GatewayProxy>>,
+    Gas: TxGas<InteractorEnvExec<'w, GatewayProxy>>,
+    CodeValue: TxCodeValue<InteractorEnvExec<'w, GatewayProxy>>,
+    RH: RHListExec<TxResponse, InteractorEnvExec<'w, GatewayProxy>>,
+    RH::ListReturns: NestedTupleFlatten,
+{
+    type Result = <RH::ListReturns as NestedTupleFlatten>::Unpacked;
+
+    fn run(self) -> impl std::future::Future<Output = Self::Result> {
+        run_async_deploy(self)
+    }
+}
 
 impl<'w, GatewayProxy, From, Payment, Gas, CodeValue, RH> InteractorPrepareAsync
     for Tx<

--- a/framework/snippets-base/src/interactor_tx/interactor_exec_transf.rs
+++ b/framework/snippets-base/src/interactor_tx/interactor_exec_transf.rs
@@ -5,7 +5,36 @@ use multiversx_sc_scenario::{
 };
 use multiversx_sdk::gateway::GatewayAsyncService;
 
-use super::{InteractorEnvExec, InteractorExecStep, InteractorPrepareAsync};
+use super::{InteractorEnvExec, InteractorExecStep, InteractorPrepareAsync, InteractorRunAsync};
+
+async fn run_async_transfer<'w, GatewayProxy, From, To, Payment, Gas>(
+    tx: Tx<InteractorEnvExec<'w, GatewayProxy>, From, To, Payment, Gas, (), ()>,
+) where
+    GatewayProxy: GatewayAsyncService,
+    From: TxFromSpecified<InteractorEnvExec<'w, GatewayProxy>>,
+    To: TxToSpecified<InteractorEnvExec<'w, GatewayProxy>>,
+    Payment: TxPayment<InteractorEnvExec<'w, GatewayProxy>>,
+    Gas: TxGas<InteractorEnvExec<'w, GatewayProxy>>,
+{
+    let step_wrapper = tx.tx_to_step();
+    step_wrapper.env.world.transfer(step_wrapper.step).await;
+}
+
+impl<'w, GatewayProxy, From, To, Payment, Gas> InteractorRunAsync
+    for Tx<InteractorEnvExec<'w, GatewayProxy>, From, To, Payment, Gas, (), ()>
+where
+    GatewayProxy: GatewayAsyncService,
+    From: TxFromSpecified<InteractorEnvExec<'w, GatewayProxy>>,
+    To: TxToSpecified<InteractorEnvExec<'w, GatewayProxy>>,
+    Payment: TxPayment<InteractorEnvExec<'w, GatewayProxy>>,
+    Gas: TxGas<InteractorEnvExec<'w, GatewayProxy>>,
+{
+    type Result = ();
+
+    fn run(self) -> impl std::future::Future<Output = Self::Result> {
+        run_async_transfer(self)
+    }
+}
 
 impl<'w, GatewayProxy, From, To, Payment, Gas> InteractorPrepareAsync
     for Tx<InteractorEnvExec<'w, GatewayProxy>, From, To, Payment, Gas, (), ()>

--- a/framework/snippets-base/src/interactor_tx/interactor_exec_upgrade.rs
+++ b/framework/snippets-base/src/interactor_tx/interactor_exec_upgrade.rs
@@ -17,6 +17,7 @@ use crate::InteractorBase;
 
 use super::{InteractorEnvExec, InteractorExecStep, InteractorPrepareAsync, InteractorRunAsync};
 
+#[allow(clippy::type_complexity)]
 async fn run_async_upgrade<'w, GatewayProxy, From, To, Gas, CodeValue, RH>(
     tx: Tx<
         InteractorEnvExec<'w, GatewayProxy>,

--- a/framework/snippets-base/src/interactor_tx/interactor_exec_upgrade.rs
+++ b/framework/snippets-base/src/interactor_tx/interactor_exec_upgrade.rs
@@ -15,7 +15,58 @@ use multiversx_sdk::gateway::GatewayAsyncService;
 
 use crate::InteractorBase;
 
-use super::{InteractorEnvExec, InteractorExecStep, InteractorPrepareAsync};
+use super::{InteractorEnvExec, InteractorExecStep, InteractorPrepareAsync, InteractorRunAsync};
+
+async fn run_async_upgrade<'w, GatewayProxy, From, To, Gas, CodeValue, RH>(
+    tx: Tx<
+        InteractorEnvExec<'w, GatewayProxy>,
+        From,
+        To,
+        NotPayable,
+        Gas,
+        UpgradeCall<InteractorEnvExec<'w, GatewayProxy>, Code<CodeValue>>,
+        RH,
+    >,
+) -> <RH::ListReturns as NestedTupleFlatten>::Unpacked
+where
+    GatewayProxy: GatewayAsyncService,
+    From: TxFromSpecified<InteractorEnvExec<'w, GatewayProxy>>,
+    To: TxToSpecified<InteractorEnvExec<'w, GatewayProxy>>,
+    Gas: TxGas<InteractorEnvExec<'w, GatewayProxy>>,
+    CodeValue: TxCodeValue<InteractorEnvExec<'w, GatewayProxy>>,
+    RH: RHListExec<TxResponse, InteractorEnvExec<'w, GatewayProxy>>,
+    RH::ListReturns: NestedTupleFlatten,
+{
+    let mut step_wrapper = tx.tx_to_step();
+    step_wrapper.env.world.sc_call(&mut step_wrapper.step).await;
+    step_wrapper.process_result()
+}
+
+impl<'w, GatewayProxy, From, To, Gas, CodeValue, RH> InteractorRunAsync
+    for Tx<
+        InteractorEnvExec<'w, GatewayProxy>,
+        From,
+        To,
+        NotPayable,
+        Gas,
+        UpgradeCall<InteractorEnvExec<'w, GatewayProxy>, Code<CodeValue>>,
+        RH,
+    >
+where
+    GatewayProxy: GatewayAsyncService,
+    From: TxFromSpecified<InteractorEnvExec<'w, GatewayProxy>>,
+    To: TxToSpecified<InteractorEnvExec<'w, GatewayProxy>>,
+    Gas: TxGas<InteractorEnvExec<'w, GatewayProxy>>,
+    CodeValue: TxCodeValue<InteractorEnvExec<'w, GatewayProxy>>,
+    RH: RHListExec<TxResponse, InteractorEnvExec<'w, GatewayProxy>>,
+    RH::ListReturns: NestedTupleFlatten,
+{
+    type Result = <RH::ListReturns as NestedTupleFlatten>::Unpacked;
+
+    fn run(self) -> impl std::future::Future<Output = Self::Result> {
+        run_async_upgrade(self)
+    }
+}
 
 impl<'w, GatewayProxy, From, To, Gas, CodeValue, RH> InteractorPrepareAsync
     for Tx<

--- a/framework/snippets-base/src/interactor_tx/interactor_prepare_async.rs
+++ b/framework/snippets-base/src/interactor_tx/interactor_prepare_async.rs
@@ -20,3 +20,9 @@ pub trait InteractorPrepareAsync {
 
     fn prepare_async(self) -> Self::Exec;
 }
+
+pub trait InteractorRunAsync {
+    type Result;
+
+    fn run(self) -> impl std::future::Future<Output = Self::Result>;
+}

--- a/framework/snippets-base/src/interactor_tx/interactor_prepare_async.rs
+++ b/framework/snippets-base/src/interactor_tx/interactor_prepare_async.rs
@@ -18,6 +18,10 @@ where
 pub trait InteractorPrepareAsync {
     type Exec;
 
+    #[deprecated(
+        since = "0.54.0",
+        note = "Calling `.prepare_async()` no longer necessary, `.run()` can be called directly."
+    )]
     fn prepare_async(self) -> Self::Exec;
 }
 

--- a/framework/snippets-dapp/src/imports.rs
+++ b/framework/snippets-dapp/src/imports.rs
@@ -1,9 +1,11 @@
 pub use crate::multiversx_sc_scenario::imports::*;
 
 pub use multiversx_sc_snippets_base::{
-    dns_address_for_name, InteractorBase, InteractorPrepareAsync, StepBuffer,
+    dns_address_for_name, InteractorBase, InteractorPrepareAsync, InteractorRunAsync, StepBuffer,
 };
 
 pub use multiversx_sdk_dapp::{core::test_wallets, data::keystore::InsertPassword, wallet::Wallet};
+
+pub use crate::DappInteractor;
 
 pub use env_logger;

--- a/framework/snippets/src/imports.rs
+++ b/framework/snippets/src/imports.rs
@@ -1,7 +1,7 @@
 pub use multiversx_sc_snippets_base::multiversx_sc_scenario::imports::*;
 
 pub use multiversx_sc_snippets_base::{
-    dns_address_for_name, InteractorBase, InteractorPrepareAsync, StepBuffer,
+    dns_address_for_name, InteractorBase, InteractorPrepareAsync, InteractorRunAsync, StepBuffer,
 };
 
 pub use multiversx_sc_snippets_base::sdk::{

--- a/tools/interactor-system-func-calls/src/system_sc_interact.rs
+++ b/tools/interactor-system-func-calls/src/system_sc_interact.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)] // TODO: move prepare_async calls to a test for backwards compatibility and delete from here
+
 mod system_sc_interact_cli;
 mod system_sc_interact_config;
 mod system_sc_interact_state;


### PR DESCRIPTION
Turns out Rust now supports async in traits, but prefers it being spelled out explicitly `... -> std::future:Future<Output = ...>`