### PR TITLE
unified syntax - PassValue

### DIFF
--- a/contracts/examples/multisig/interact/src/multisig_interact.rs
+++ b/contracts/examples/multisig/interact/src/multisig_interact.rs
@@ -246,13 +246,14 @@ impl MultisigInteract {
                     .gas(gas_expr)
                     .typed(multisig_proxy::MultisigProxy)
                     .perform_action_endpoint(action_id)
+                    .returns(PassValue(action_id))
                     .returns(ReturnsResult)
             });
         }
 
-        let deployed_addresses = buffer.run().await;
+        let result = buffer.run().await;
 
-        for (action_id, address) in deployed_addresses.iter().enumerate() {
+        for (action_id, address) in result {
             println!("successfully performed action `{action_id}`");
             if address.is_some() {
                 println!(

--- a/contracts/feature-tests/scenario-tester/tests/st_blackbox_test.rs
+++ b/contracts/feature-tests/scenario-tester/tests/st_blackbox_test.rs
@@ -302,7 +302,7 @@ fn st_blackbox_returns_result_or_error() {
         .commit();
 
     // deploy
-    let (result, check_tx_hash) = world
+    let (result, check_tx_hash, pass_value_2) = world
         .tx()
         .from(OWNER_ADDRESS)
         .typed(scenario_tester_proxy::ScenarioTesterProxy)
@@ -314,16 +314,20 @@ fn st_blackbox_returns_result_or_error() {
             ReturnsHandledOrError::new()
                 .returns(ReturnsNewAddress)
                 .returns(ReturnsResultAs::<String>::new())
+                .returns(PassValue("pass-value-1"))
                 .returns(ReturnsTxHash),
         )
         .returns(ReturnsTxHash)
+        .returns(PassValue("pass-value-2"))
         .run();
 
     assert_eq!(check_tx_hash.as_array(), &[33u8; 32]);
-    let (new_address, out_value, also_check_tx_hash) = result.unwrap();
+    let (new_address, out_value, pass_value_1, also_check_tx_hash) = result.unwrap();
     assert_eq!(new_address, ST_ADDRESS.to_address());
     assert_eq!(out_value, "init-result");
+    assert_eq!(pass_value_1, "pass-value-1");
     assert_eq!(also_check_tx_hash.as_array(), &[33u8; 32]);
+    assert_eq!(pass_value_2, "pass-value-2");
 
     // query - ok
     let result = world

--- a/framework/base/src/types/interaction/result_handlers.rs
+++ b/framework/base/src/types/interaction/result_handlers.rs
@@ -1,3 +1,4 @@
+mod pass_value;
 mod returns_bt;
 mod returns_new_address;
 mod returns_new_managed_address;
@@ -10,6 +11,7 @@ mod with_raw_result;
 mod with_result;
 mod with_result_as;
 
+pub use pass_value::PassValue;
 pub use returns_bt::*;
 pub use returns_new_address::*;
 pub use returns_new_managed_address::*;

--- a/framework/base/src/types/interaction/result_handlers/pass_value.rs
+++ b/framework/base/src/types/interaction/result_handlers/pass_value.rs
@@ -1,0 +1,24 @@
+use crate::types::{RHListItem, RHListItemExec, TxEnv};
+
+/// Simply passes a value to the result.
+///
+/// The value is constant with respect to the tx, will always be returned, irrespective of the tx execution.
+///
+/// It is especially useful in multi-calls, since it can pass context from the setup section to the result processing section.
+pub struct PassValue<T>(pub T);
+
+impl<Env, Original, T> RHListItem<Env, Original> for PassValue<T>
+where
+    Env: TxEnv,
+{
+    type Returns = T;
+}
+
+impl<RawResult, Env, Original, T> RHListItemExec<RawResult, Env, Original> for PassValue<T>
+where
+    Env: TxEnv,
+{
+    fn item_process_result(self, _raw_result: &RawResult) -> T {
+        self.0
+    }
+}


### PR DESCRIPTION
Simply passes a value to the result.

The value is constant with respect to the tx, will always be returned, irrespective of the tx execution.

It is especially useful in multi-calls, since it can pass context from the setup section to the result processing section.
