### PR TITLE
ManagedVecItem - ref for EsdtTokenPayment

### DIFF
--- a/chain/core/src/types/flags/esdt_token_type.rs
+++ b/chain/core/src/types/flags/esdt_token_type.rs
@@ -13,7 +13,7 @@ const ESDT_TYPE_INVALID: &[u8] = &[];
 
 // Note: In the current implementation, SemiFungible is never returned
 
-#[derive(TopDecode, TopEncode, NestedDecode, NestedEncode, Clone, PartialEq, Eq, Debug)]
+#[derive(TopDecode, TopEncode, NestedDecode, NestedEncode, Clone, Copy, PartialEq, Eq, Debug)]
 pub enum EsdtTokenType {
     Fungible,
     NonFungible,

--- a/contracts/core/wegld-swap/src/wegld.rs
+++ b/contracts/core/wegld-swap/src/wegld.rs
@@ -39,10 +39,10 @@ pub trait EgldEsdtSwap: multiversx_sc_modules::pause::PauseModule {
         let (payment_token, payment_amount) = self.call_value().single_fungible_esdt();
         let wrapped_egld_token_id = self.wrapped_egld_token_id().get();
 
-        require!(payment_token == wrapped_egld_token_id, "Wrong esdt token");
-        require!(payment_amount > 0u32, "Must pay more than 0 tokens!");
+        require!(*payment_token == wrapped_egld_token_id, "Wrong esdt token");
+        require!(*payment_amount > 0u32, "Must pay more than 0 tokens!");
         require!(
-            payment_amount <= self.get_locked_egld_balance(),
+            *payment_amount <= self.get_locked_egld_balance(),
             "Contract does not have enough funds"
         );
 
@@ -51,7 +51,7 @@ pub trait EgldEsdtSwap: multiversx_sc_modules::pause::PauseModule {
 
         // 1 wrapped eGLD = 1 eGLD, so we pay back the same amount
         let caller = self.blockchain().get_caller();
-        self.tx().to(&caller).egld(&payment_amount).transfer();
+        self.tx().to(&caller).egld(&*payment_amount).transfer();
     }
 
     #[view(getLockedEgldBalance)]

--- a/contracts/examples/digital-cash/src/pay_fee_and_fund.rs
+++ b/contracts/examples/digital-cash/src/pay_fee_and_fund.rs
@@ -7,8 +7,8 @@ pub trait PayFeeAndFund: storage::StorageModule + helpers::HelpersModule {
     #[endpoint(payFeeAndFundESDT)]
     #[payable("*")]
     fn pay_fee_and_fund_esdt(&self, address: ManagedAddress, valability: u64) {
-        let mut payments = self.call_value().all_esdt_transfers().clone_value();
-        let fee = EgldOrEsdtTokenPayment::from(payments.get(0));
+        let mut payments = self.call_value().all_esdt_transfers().clone();
+        let fee = EgldOrEsdtTokenPayment::from(payments.get(0).clone());
         let caller_address = self.blockchain().get_caller();
         self.update_fees(caller_address, &address, fee);
 

--- a/contracts/examples/esdt-transfer-with-fee/src/esdt_transfer_with_fee.rs
+++ b/contracts/examples/esdt-transfer-with-fee/src/esdt_transfer_with_fee.rs
@@ -71,13 +71,13 @@ pub trait EsdtTransferWithFee {
                         "Mismatching payment for covering fees"
                     );
                     let _ = self.get_payment_after_fees(fee_type, &next_payment);
-                    new_payments.push(payment);
+                    new_payments.push(payment.clone());
                 },
                 Fee::Percentage(_) => {
                     new_payments.push(self.get_payment_after_fees(fee_type, &payment));
                 },
                 Fee::Unset => {
-                    new_payments.push(payment);
+                    new_payments.push(payment.clone());
                 },
             }
         }

--- a/contracts/examples/fractional-nfts/src/fractional_nfts.rs
+++ b/contracts/examples/fractional-nfts/src/fractional_nfts.rs
@@ -74,7 +74,7 @@ pub trait FractionalNfts: default_issue_callbacks::DefaultIssueCallbacksModule {
         let fractional_token = fractional_token_mapper.get_token_id_ref();
         let hash = ManagedBuffer::new();
         let fractional_info =
-            FractionalUriInfo::new(original_payment, initial_fractional_amount.clone());
+            FractionalUriInfo::new(original_payment.clone(), initial_fractional_amount.clone());
         let uris = fractional_info.to_uris();
 
         let fractional_nonce = self.send().esdt_nft_create(

--- a/contracts/examples/nft-subscription/src/lib.rs
+++ b/contracts/examples/nft-subscription/src/lib.rs
@@ -49,34 +49,54 @@ pub trait NftSubscription:
     #[payable("*")]
     #[endpoint]
     fn update_attributes(&self, attributes: ManagedBuffer) {
-        let (id, nonce, _) = self.call_value().single_esdt().into_tuple();
-        self.update_subscription_attributes::<ManagedBuffer>(&id, nonce, attributes);
+        let payment = self.call_value().single_esdt();
+        self.update_subscription_attributes::<ManagedBuffer>(
+            &payment.token_identifier,
+            payment.token_nonce,
+            attributes,
+        );
         self.tx()
             .to(ToCaller)
-            .single_esdt(&id, nonce, &BigUint::from(1u8))
+            .single_esdt(
+                &payment.token_identifier,
+                payment.token_nonce,
+                &BigUint::from(1u8),
+            )
             .transfer();
     }
 
     #[payable("*")]
     #[endpoint]
     fn renew(&self, duration: u64) {
-        let (id, nonce, _) = self.call_value().single_esdt().into_tuple();
-        self.renew_subscription::<ManagedBuffer>(&id, nonce, duration);
+        let payment = self.call_value().single_esdt();
+        self.renew_subscription::<ManagedBuffer>(
+            &payment.token_identifier,
+            payment.token_nonce,
+            duration,
+        );
         self.tx()
             .to(ToCaller)
-            .single_esdt(&id, nonce, &BigUint::from(1u8))
+            .single_esdt(
+                &payment.token_identifier,
+                payment.token_nonce,
+                &BigUint::from(1u8),
+            )
             .transfer();
     }
 
     #[payable("*")]
     #[endpoint]
     fn cancel(&self) {
-        let (id, nonce, _) = self.call_value().single_esdt().into_tuple();
-        self.cancel_subscription::<ManagedBuffer>(&id, nonce);
+        let payment = self.call_value().single_esdt();
+        self.cancel_subscription::<ManagedBuffer>(&payment.token_identifier, payment.token_nonce);
 
         self.tx()
             .to(ToCaller)
-            .single_esdt(&id, nonce, &BigUint::from(1u8))
+            .single_esdt(
+                &payment.token_identifier,
+                payment.token_nonce,
+                &BigUint::from(1u8),
+            )
             .transfer();
     }
 

--- a/contracts/examples/order-book/pair/src/validation.rs
+++ b/contracts/examples/order-book/pair/src/validation.rs
@@ -72,22 +72,28 @@ pub trait ValidationModule: common::CommonModule {
         let (token_id, amount) = self.call_value().single_fungible_esdt();
         let second_token_id = self.second_token_id().get();
         require!(
-            token_id == second_token_id,
+            *token_id == second_token_id,
             "Token in and second token id should be the same"
         );
 
-        Payment { token_id, amount }
+        Payment {
+            token_id: token_id.clone(),
+            amount: amount.clone(),
+        }
     }
 
     fn require_valid_sell_payment(&self) -> Payment<Self::Api> {
         let (token_id, amount) = self.call_value().single_fungible_esdt();
         let first_token_id = self.first_token_id().get();
         require!(
-            token_id == first_token_id,
+            *token_id == first_token_id,
             "Token in and first token id should be the same"
         );
 
-        Payment { token_id, amount }
+        Payment {
+            token_id: token_id.clone(),
+            amount: amount.clone(),
+        }
     }
 
     fn require_valid_match_input_order_ids(&self, order_ids: &ManagedVec<u64>) {

--- a/contracts/examples/seed-nft-minter/src/seed_nft_minter.rs
+++ b/contracts/examples/seed-nft-minter/src/seed_nft_minter.rs
@@ -102,7 +102,7 @@ pub trait SeedNftMinter:
             } else {
                 esdt_payments
                     .try_get(0)
-                    .map(|esdt_payment| esdt_payment.amount)
+                    .map(|esdt_payment| esdt_payment.amount.clone())
                     .unwrap_or_default()
             };
             total_amount += amount;

--- a/contracts/feature-tests/basic-features/src/storage_mapper_fungible_token.rs
+++ b/contracts/feature-tests/basic-features/src/storage_mapper_fungible_token.rs
@@ -61,8 +61,9 @@ pub trait FungibleTokenMapperFeatures:
     fn custom_issue_non_zero_supply_cb(&self, #[call_result] result: ManagedAsyncCallResult<()>) {
         match result {
             ManagedAsyncCallResult::Ok(()) => {
-                let token_identifier = self.call_value().single_esdt().token_identifier;
-                self.fungible_token_mapper().set_token_id(token_identifier);
+                let token_identifier = &self.call_value().single_esdt().token_identifier;
+                self.fungible_token_mapper()
+                    .set_token_id(token_identifier.clone());
             },
             ManagedAsyncCallResult::Err(_) => {
                 self.fungible_token_mapper().clear();
@@ -128,9 +129,9 @@ pub trait FungibleTokenMapperFeatures:
     #[payable("*")]
     #[endpoint]
     fn require_same_token_fungible(&self) {
-        let payment_token = self.call_value().single_esdt().token_identifier;
+        let payment_token = &self.call_value().single_esdt().token_identifier;
         self.fungible_token_mapper()
-            .require_same_token(&payment_token);
+            .require_same_token(payment_token);
     }
 
     #[payable("*")]

--- a/contracts/feature-tests/composability/esdt-contract-pair/first-contract/src/lib.rs
+++ b/contracts/feature-tests/composability/esdt-contract-pair/first-contract/src/lib.rs
@@ -25,7 +25,7 @@ pub trait FirstContract {
         let expected_token_identifier = self.get_contract_esdt_token_identifier();
 
         require!(
-            actual_token_identifier == expected_token_identifier,
+            *actual_token_identifier == expected_token_identifier,
             "Wrong esdt token"
         );
 
@@ -45,13 +45,13 @@ pub trait FirstContract {
         let expected_token_identifier = self.get_contract_esdt_token_identifier();
 
         require!(
-            actual_token_identifier == expected_token_identifier,
+            *actual_token_identifier == expected_token_identifier,
             "Wrong esdt token"
         );
 
         self.call_esdt_second_contract(
             &expected_token_identifier,
-            &(esdt_value / 2u32),
+            &(esdt_value.clone() / 2u32),
             &self.get_second_contract_address(),
             &ManagedBuffer::from(SECOND_CONTRACT_ACCEPT_ESDT_PAYMENT),
             &ManagedVec::new(),
@@ -65,7 +65,7 @@ pub trait FirstContract {
         let expected_token_identifier = self.get_contract_esdt_token_identifier();
 
         require!(
-            actual_token_identifier == expected_token_identifier,
+            *actual_token_identifier == expected_token_identifier,
             "Wrong esdt token"
         );
 
@@ -86,7 +86,7 @@ pub trait FirstContract {
         let expected_token_identifier = self.get_contract_esdt_token_identifier();
 
         require!(
-            actual_token_identifier == expected_token_identifier,
+            *actual_token_identifier == expected_token_identifier,
             "Wrong esdt token"
         );
 
@@ -107,7 +107,7 @@ pub trait FirstContract {
         let expected_token_identifier = self.get_contract_esdt_token_identifier();
 
         require!(
-            actual_token_identifier == expected_token_identifier,
+            *actual_token_identifier == expected_token_identifier,
             "Wrong esdt token"
         );
 

--- a/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/child/src/lib.rs
+++ b/contracts/feature-tests/composability/execute-on-dest-esdt-issue-callback/child/src/lib.rs
@@ -46,7 +46,7 @@ pub trait Child {
     #[callback]
     fn esdt_issue_callback(&self, #[call_result] _result: IgnoreValue) {
         let (token_identifier, _amount) = self.call_value().single_fungible_esdt();
-        self.wrapped_egld_token_identifier().set(&token_identifier);
+        self.wrapped_egld_token_identifier().set(token_identifier);
     }
 
     // storage

--- a/contracts/feature-tests/composability/forwarder-legacy/src/fwd_call_transf_exec_legacy.rs
+++ b/contracts/feature-tests/composability/forwarder-legacy/src/fwd_call_transf_exec_legacy.rs
@@ -28,7 +28,7 @@ pub trait ForwarderTransferExecuteModule {
         self.vault_proxy()
             .contract(to)
             .accept_funds()
-            .payment((payment.token_identifier, 0, payment.amount))
+            .single_esdt(&payment.token_identifier, 0, &payment.amount)
             .transfer_execute();
     }
 

--- a/contracts/feature-tests/composability/forwarder-legacy/src/fwd_esdt_legacy.rs
+++ b/contracts/feature-tests/composability/forwarder-legacy/src/fwd_esdt_legacy.rs
@@ -39,8 +39,8 @@ pub trait ForwarderEsdtModule: fwd_storage_legacy::ForwarderStorageModule {
     #[endpoint]
     fn send_esdt_with_fees(&self, to: ManagedAddress, percentage_fees: BigUint) {
         let (token_id, payment) = self.call_value().single_fungible_esdt();
-        let fees = &payment * &percentage_fees / PERCENTAGE_TOTAL;
-        let amount_to_send = payment - fees;
+        let fees = &*payment * &percentage_fees / PERCENTAGE_TOTAL;
+        let amount_to_send = payment.clone() - fees;
 
         self.send().direct_esdt(&to, &token_id, 0, &amount_to_send);
     }

--- a/contracts/feature-tests/composability/forwarder-raw/src/forwarder_raw.rs
+++ b/contracts/feature-tests/composability/forwarder-raw/src/forwarder_raw.rs
@@ -37,9 +37,9 @@ pub trait ForwarderRaw:
         } else {
             for payment in payments.iter() {
                 let _ = self.callback_payments().push(&(
-                    EgldOrEsdtTokenIdentifier::esdt(payment.token_identifier),
+                    EgldOrEsdtTokenIdentifier::esdt(payment.token_identifier.clone()),
                     payment.token_nonce,
-                    payment.amount,
+                    payment.amount.clone(),
                 ));
             }
         }

--- a/contracts/feature-tests/composability/forwarder-raw/src/forwarder_raw_async.rs
+++ b/contracts/feature-tests/composability/forwarder-raw/src/forwarder_raw_async.rs
@@ -114,8 +114,8 @@ pub trait ForwarderRawAsync: super::forwarder_raw_common::ForwarderRawCommon {
         let (token, payment) = self.call_value().single_fungible_esdt();
         self.forward_contract_call(
             to,
-            EgldOrEsdtTokenIdentifier::esdt(token),
-            payment,
+            EgldOrEsdtTokenIdentifier::esdt(token.clone()),
+            payment.clone(),
             endpoint_name,
             args,
         )

--- a/contracts/feature-tests/composability/forwarder/src/fwd_esdt.rs
+++ b/contracts/feature-tests/composability/forwarder/src/fwd_esdt.rs
@@ -42,8 +42,8 @@ pub trait ForwarderEsdtModule: fwd_storage::ForwarderStorageModule {
     #[endpoint]
     fn send_esdt_with_fees(&self, to: ManagedAddress, percentage_fees: BigUint) {
         let (token_id, payment) = self.call_value().single_fungible_esdt();
-        let fees = &payment * &percentage_fees / PERCENTAGE_TOTAL;
-        let amount_to_send = payment - fees;
+        let fees = percentage_fees * &*payment / PERCENTAGE_TOTAL;
+        let amount_to_send = payment.clone() - fees;
 
         self.tx()
             .to(&to)

--- a/contracts/feature-tests/composability/promises-features/src/fwd_call_promises_bt.rs
+++ b/contracts/feature-tests/composability/promises-features/src/fwd_call_promises_bt.rs
@@ -45,15 +45,19 @@ pub trait CallPromisesBackTransfersModule: common::CommonModule {
         }
 
         for esdt_transfer in &back_transfers.esdt_payments {
-            let (token, nonce, payment) = esdt_transfer.into_tuple();
-            let esdt_token_id = EgldOrEsdtTokenIdentifier::esdt(token);
-            self.retrieve_funds_callback_event(&esdt_token_id, nonce, &payment);
+            let esdt_token_id =
+                EgldOrEsdtTokenIdentifier::esdt(esdt_transfer.token_identifier.clone());
+            self.retrieve_funds_callback_event(
+                &esdt_token_id,
+                esdt_transfer.token_nonce,
+                &esdt_transfer.amount,
+            );
 
             let _ = self.callback_data().push(&CallbackData {
                 callback_name: ManagedBuffer::from(b"retrieve_funds_callback"),
                 token_identifier: esdt_token_id,
-                token_nonce: nonce,
-                token_amount: payment,
+                token_nonce: esdt_transfer.token_nonce,
+                token_amount: esdt_transfer.amount.clone(),
                 args: ManagedVec::new(),
             });
         }

--- a/contracts/feature-tests/composability/vault/src/vault.rs
+++ b/contracts/feature-tests/composability/vault/src/vault.rs
@@ -240,9 +240,9 @@ pub trait Vault {
             );
 
             new_tokens.push(EsdtTokenPayment::new(
-                payment.token_identifier,
+                payment.token_identifier.clone(),
                 new_token_nonce,
-                payment.amount,
+                payment.amount.clone(),
             ));
         }
 

--- a/contracts/feature-tests/payable-features/src/payable_features.rs
+++ b/contracts/feature-tests/payable-features/src/payable_features.rs
@@ -35,7 +35,7 @@ pub trait PayableFeatures {
     #[payable("*")]
     fn payment_array_3(&self) -> MultiValue3<EsdtTokenPayment, EsdtTokenPayment, EsdtTokenPayment> {
         let [payment_a, payment_b, payment_c] = self.call_value().multi_esdt();
-        (payment_a, payment_b, payment_c).into()
+        (payment_a.clone(), payment_b.clone(), payment_c.clone()).into()
     }
 
     #[endpoint]
@@ -129,7 +129,7 @@ pub trait PayableFeatures {
         &self,
         #[payment] payment: BigUint,
     ) -> MultiValue2<BigUint, TokenIdentifier> {
-        let token = self.call_value().single_esdt().token_identifier;
+        let token = self.call_value().single_esdt().token_identifier.clone();
         (payment, token).into()
     }
 
@@ -140,14 +140,14 @@ pub trait PayableFeatures {
         #[payment_token] token: EgldOrEsdtTokenIdentifier,
     ) -> MultiValue2<BigUint, EgldOrEsdtTokenIdentifier> {
         let payment = self.call_value().single_esdt();
-        (payment.amount, token).into()
+        (payment.amount.clone(), token).into()
     }
 
     #[endpoint]
     #[payable("PAYABLE-FEATURES-TOKEN")]
     fn payable_token_4(&self) -> MultiValue2<BigUint, TokenIdentifier> {
-        let payment = self.call_value().single_esdt().amount;
-        let token = self.call_value().single_esdt().token_identifier;
+        let payment = self.call_value().single_esdt().amount.clone();
+        let token = self.call_value().single_esdt().token_identifier.clone();
         (payment, token).into()
     }
 }

--- a/contracts/feature-tests/rust-testing-framework-tester/src/lib.rs
+++ b/contracts/feature-tests/rust-testing-framework-tester/src/lib.rs
@@ -71,7 +71,7 @@ pub trait RustTestingFrameworkTester: dummy_module::DummyModule {
     #[endpoint]
     fn receive_esdt(&self) -> (TokenIdentifier, BigUint) {
         let payment = self.call_value().single_esdt();
-        (payment.token_identifier, payment.amount)
+        (payment.token_identifier.clone(), payment.amount.clone())
     }
 
     #[payable("*")]
@@ -84,7 +84,7 @@ pub trait RustTestingFrameworkTester: dummy_module::DummyModule {
     #[endpoint]
     fn receive_esdt_half(&self) {
         let payment = self.call_value().single_esdt();
-        let amount = payment.amount / 2u32;
+        let amount = &payment.amount / 2u32;
 
         self.tx()
             .to(ToCaller)

--- a/contracts/feature-tests/use-module/src/token_merge_mod_impl.rs
+++ b/contracts/feature-tests/use-module/src/token_merge_mod_impl.rs
@@ -55,7 +55,7 @@ pub trait TokenMergeModImpl:
     ) -> ManagedVec<EsdtTokenPayment> {
         let payment = self.call_value().single_esdt();
         let attributes_creator = DefaultMergedAttributesWrapper::new();
-        self.split_token_partial(payment, tokens_to_remove, &attributes_creator)
+        self.split_token_partial(payment.clone(), tokens_to_remove, &attributes_creator)
     }
 }
 

--- a/contracts/modules/src/bonding_curve/utils/user_endpoints.rs
+++ b/contracts/modules/src/bonding_curve/utils/user_endpoints.rs
@@ -21,11 +21,14 @@ pub trait UserEndpointsModule: storage::StorageModule + events::EventsModule {
             + PartialEq
             + Default,
     {
-        let (offered_token, nonce, sell_amount) = self.call_value().single_esdt().into_tuple();
-        let _ = self.check_owned_return_payment_token::<T>(&offered_token, &sell_amount);
+        let esdt_payment = self.call_value().single_esdt();
+        let offered_token = &esdt_payment.token_identifier;
+        let nonce = esdt_payment.token_nonce;
+        let sell_amount = &esdt_payment.amount;
+        let _ = self.check_owned_return_payment_token::<T>(offered_token, sell_amount);
 
         let (calculated_price, payment_token) =
-            self.bonding_curve(&offered_token).update(|buffer| {
+            self.bonding_curve(offered_token).update(|buffer| {
                 let serializer = ManagedSerializer::new();
 
                 let mut bonding_curve: BondingCurve<Self::Api, T> =
@@ -35,9 +38,9 @@ pub trait UserEndpointsModule: storage::StorageModule + events::EventsModule {
                     bonding_curve.sell_availability,
                     "Selling is not available on this token"
                 );
-                let price = self.compute_sell_price::<T>(&offered_token, &sell_amount);
+                let price = self.compute_sell_price::<T>(offered_token, sell_amount);
                 bonding_curve.payment.amount -= &price;
-                bonding_curve.arguments.balance += &sell_amount;
+                bonding_curve.arguments.balance += sell_amount;
                 let payment_token = bonding_curve.payment_token();
                 *buffer = serializer.top_encode_to_managed_buffer(&bonding_curve);
                 (price, payment_token)
@@ -45,7 +48,7 @@ pub trait UserEndpointsModule: storage::StorageModule + events::EventsModule {
 
         let caller = self.blockchain().get_caller();
 
-        self.nonce_amount(&offered_token, nonce)
+        self.nonce_amount(offered_token, nonce)
             .update(|val| *val += sell_amount);
 
         self.tx()
@@ -53,7 +56,7 @@ pub trait UserEndpointsModule: storage::StorageModule + events::EventsModule {
             .egld_or_single_esdt(&payment_token, 0u64, &calculated_price)
             .transfer();
 
-        self.token_details(&offered_token)
+        self.token_details(offered_token)
             .update(|details| details.add_nonce(nonce));
 
         self.sell_token_event(&caller, &calculated_price);

--- a/contracts/modules/src/default_issue_callbacks.rs
+++ b/contracts/modules/src/default_issue_callbacks.rs
@@ -35,7 +35,7 @@ pub trait DefaultIssueCallbacksModule {
         let key = StorageKey::from(storage_key);
         match result {
             ManagedAsyncCallResult::Ok(()) => {
-                let token_id = self.call_value().single_esdt().token_identifier;
+                let token_id = self.call_value().single_esdt().token_identifier.clone();
                 storage_set(key.as_ref(), &TokenMapperState::Token(token_id));
             },
             ManagedAsyncCallResult::Err(_) => {

--- a/contracts/modules/src/governance/mod.rs
+++ b/contracts/modules/src/governance/mod.rs
@@ -435,7 +435,7 @@ pub trait GovernanceModule:
             payment.token_identifier == self.governance_token_id().get(),
             "Only Governance token accepted as payment"
         );
-        payment
+        payment.clone()
     }
 
     fn require_valid_proposal_id(&self, proposal_id: usize) {

--- a/contracts/modules/src/token_merge/mod.rs
+++ b/contracts/modules/src/token_merge/mod.rs
@@ -69,7 +69,7 @@ pub trait TokenMergeModule:
         }
 
         for single_token_instance in single_tokens {
-            all_merged_instances.add_or_update_instance(single_token_instance);
+            all_merged_instances.add_or_update_instance(single_token_instance.clone());
         }
 
         let merged_token_payment =

--- a/framework/base/src/types/interaction/contract_call_legacy/contract_call_convert.rs
+++ b/framework/base/src/types/interaction/contract_call_legacy/contract_call_convert.rs
@@ -20,7 +20,7 @@ where
     ) -> Self {
         match payments.len() {
             0 => self,
-            1 => self.convert_to_single_transfer_esdt_call(payments.get(0)),
+            1 => self.convert_to_single_transfer_esdt_call(payments.get(0).clone()),
             _ => self.convert_to_multi_transfer_esdt_call(payments),
         }
     }

--- a/framework/base/src/types/interaction/contract_call_legacy/contract_call_exec.rs
+++ b/framework/base/src/types/interaction/contract_call_legacy/contract_call_exec.rs
@@ -208,7 +208,7 @@ where
     pub(super) fn transfer_execute_esdt(self, payments: ManagedVec<SA, EsdtTokenPayment<SA>>) {
         match payments.len() {
             0 => self.transfer_execute_egld(BigUint::zero()),
-            1 => self.transfer_execute_single_esdt(payments.get(0)),
+            1 => self.transfer_execute_single_esdt(payments.get(0).clone()),
             _ => self.transfer_execute_multi_esdt(payments),
         }
     }

--- a/framework/base/src/types/interaction/result_handlers/returns_bt_single_esdt.rs
+++ b/framework/base/src/types/interaction/result_handlers/returns_bt_single_esdt.rs
@@ -28,6 +28,7 @@ where
             Env::Api::error_api_impl().signal_error(b"Back transfers expected to be a single ESDT")
         }
 
-        esdt_payments.get(0)
+        let x = esdt_payments.get(0).clone();
+        x
     }
 }

--- a/framework/base/src/types/managed/wrapped/esdt_token_payment.rs
+++ b/framework/base/src/types/managed/wrapped/esdt_token_payment.rs
@@ -15,7 +15,7 @@ use crate::{
 
 use super::{
     managed_vec_item_read_from_payload_index, managed_vec_item_save_to_payload_index, ManagedVec,
-    ManagedVecItemPayloadBuffer,
+    ManagedVecItemPayloadBuffer, ManagedVecRef,
 };
 
 #[type_abi]
@@ -168,7 +168,7 @@ impl<M: ManagedTypeApi> IntoMultiValue for EsdtTokenPayment<M> {
 impl<M: ManagedTypeApi> ManagedVecItem for EsdtTokenPayment<M> {
     type PAYLOAD = ManagedVecItemPayloadBuffer<16>;
     const SKIPS_RESERIALIZATION: bool = false;
-    type Ref<'a> = Self;
+    type Ref<'a> = ManagedVecRef<'a, Self>;
 
     fn read_from_payload(payload: &Self::PAYLOAD) -> Self {
         let mut index = 0;
@@ -182,8 +182,7 @@ impl<M: ManagedTypeApi> ManagedVecItem for EsdtTokenPayment<M> {
     }
 
     unsafe fn borrow_from_payload<'a>(payload: &Self::PAYLOAD) -> Self::Ref<'a> {
-        // TODO: managed ref
-        Self::read_from_payload(payload)
+        ManagedVecRef::new(Self::read_from_payload(payload))
     }
 
     fn save_to_payload(self, payload: &mut Self::PAYLOAD) {

--- a/framework/scenario/src/scenario/tx_to_step/tx_to_step_call.rs
+++ b/framework/scenario/src/scenario/tx_to_step/tx_to_step_call.rs
@@ -71,7 +71,7 @@ where
         step.tx.esdt_value = full_payment_data
             .multi_esdt
             .iter()
-            .map(TxESDT::from)
+            .map(|item| TxESDT::from(item.clone()))
             .collect();
     }
 

--- a/framework/scenario/src/scenario/tx_to_step/tx_to_step_transfer.rs
+++ b/framework/scenario/src/scenario/tx_to_step/tx_to_step_transfer.rs
@@ -52,7 +52,7 @@ where
         step.tx.esdt_value = full_payment_data
             .multi_esdt
             .iter()
-            .map(TxESDT::from)
+            .map(|item| TxESDT::from(item.clone()))
             .collect();
     }
 


### PR DESCRIPTION
ManagedVecItem for EsdtTokenPayment wraps its reference. in a ManagedVecRef. This cascades into a lot of changes across all contracts.

All these changes in fact patch possible vulnerabilities. EsdtTokenPayment updates were possible before that, leading to possible subtle bugs.