### PR TITLE
Add a clearer panic message if settings.json is malformed

### DIFF
--- a/framework/meta/src/cmd/install/install_debugger.rs
+++ b/framework/meta/src/cmd/install/install_debugger.rs
@@ -102,7 +102,9 @@ fn configure_vscode() {
 
     let script_full_path = get_script_path(home::home_dir().unwrap().join(TARGET_PATH));
     let json = fs::read_to_string(&path_to_settings).expect("Unable to read settings.json");
-    let mut sub_values: serde_json::Value = serde_json::from_str(&json).unwrap();
+    let mut sub_values: serde_json::Value = serde_json::from_str(&json).unwrap_or_else(
+        |err: serde_json::Error| panic!("Incorrectly formatted VSCode settings.json file. The error is locatted at line {}, column {}. This error might be caused either by a trailling comma in the settings file (which is, actually, pretty usual), or the settings file was not correctly edited and saved. Please check your file via a JSON linter and fix the settings file before attempting to run the install command again.", err.line(), err.column())
+    );
 
     let init_commands = sub_values
         .as_object_mut()


### PR DESCRIPTION
This commit aims to provide a clearer error message when attempting to install the available tools using the `sc-meta install all` command, in the rare case when a user has a malformed VSCode **settings.json** file.


For example, let's consider these two **settings.json** file examples:

1. Correct
```json

{
  "workbench.iconTheme": "vscode-icons",
  "[typescript]": {
    "editor.formatOnSave": true,
    "editor.defaultFormatter": "vscode.typescript-language-features"
  }
}
```
2. Wrong
```json

{
  "workbench.iconTheme": "vscode-icons",
  "[typescript]": {
    "editor.formatOnSave": true,
    "editor.defaultFormatter": "vscode.typescript-language-features",
  }
}
```

In the second case we have a trailling comma, after the end of the **editor.defaultFormatter** row. While this additional comma won't be a problem for VSCode to parse the settings file, this is inherently a malformed json, if we verify it with any online linter. This, in turn, will cause problems for serde. The fix is to just instruct the user to perform a lint check of its settings file, and then proceed with the installation.