### PR TITLE
unified syntax - result handler preprocessing methods rename

### DIFF
--- a/framework/base/src/types/interaction/result_handlers/returns_bt_reset.rs
+++ b/framework/base/src/types/interaction/result_handlers/returns_bt_reset.rs
@@ -20,7 +20,7 @@ impl<RawResult, Env, Original> RHListItemExec<RawResult, Env, Original>
 where
     Env: TxEnv,
 {
-    fn item_tx_expect(&self, prev: Env::RHExpect) -> Env::RHExpect {
+    fn item_preprocessing(&self, prev: Env::RHExpect) -> Env::RHExpect {
         // retrieval resets back-transfers
         // the result is of no interest
         let _ = BlockchainWrapper::<Env::Api>::new().get_back_transfers();

--- a/framework/base/src/types/interaction/tx_exec/tx_exec_deploy.rs
+++ b/framework/base/src/types/interaction/tx_exec/tx_exec_deploy.rs
@@ -98,7 +98,7 @@ where
 {
     /// Synchronously deploys a contract.
     pub fn sync_call(self) -> <RH::ListReturns as NestedTupleFlatten>::Unpacked {
-        self.result_handler.list_tx_expect();
+        self.result_handler.list_preprocessing();
         let (new_address, raw_results, result_handler) = self.execute_deploy_raw();
 
         let deploy_raw_result = DeployRawResult {
@@ -130,7 +130,7 @@ where
 {
     /// Synchronously deploys a contract from source.
     pub fn sync_call(self) -> <RH::ListReturns as NestedTupleFlatten>::Unpacked {
-        self.result_handler.list_tx_expect();
+        self.result_handler.list_preprocessing();
         let (new_address, raw_results, result_handler) = self.execute_deploy_from_source_raw();
 
         let deploy_raw_result = DeployRawResult {

--- a/framework/base/src/types/interaction/tx_exec/tx_exec_sync.rs
+++ b/framework/base/src/types/interaction/tx_exec/tx_exec_sync.rs
@@ -52,7 +52,7 @@ where
     ///
     /// Only works with contracts from the same shard.
     pub fn sync_call(self) -> <RH::ListReturns as NestedTupleFlatten>::Unpacked {
-        self.result_handler.list_tx_expect();
+        self.result_handler.list_preprocessing();
         let (raw_result, result_handler) = self.execute_sync_call_raw();
         let sync_raw_result = SyncCallRawResult(raw_result);
         let tuple_result = result_handler.list_process_result(&sync_raw_result);
@@ -87,7 +87,7 @@ where
     ///
     /// Only works with contracts from the same shard.
     pub fn sync_call_same_context(self) -> <RH::ListReturns as NestedTupleFlatten>::Unpacked {
-        self.result_handler.list_tx_expect();
+        self.result_handler.list_preprocessing();
         let (raw_result, result_handler) = self.execute_sync_call_same_context_raw();
         let sync_raw_result = SyncCallRawResult(raw_result);
         let tuple_result = result_handler.list_process_result(&sync_raw_result);
@@ -127,7 +127,7 @@ where
     ///
     /// Only works with contracts from the same shard.
     pub fn sync_call_readonly(self) -> <RH::ListReturns as NestedTupleFlatten>::Unpacked {
-        self.result_handler.list_tx_expect();
+        self.result_handler.list_preprocessing();
         let (raw_result, result_handler) = self.execute_sync_call_readonly_raw();
         let sync_raw_result = SyncCallRawResult(raw_result);
         let tuple_result = result_handler.list_process_result(&sync_raw_result);

--- a/framework/base/src/types/interaction/tx_result_handler_list/tx_result_handler_list_exec.rs
+++ b/framework/base/src/types/interaction/tx_result_handler_list/tx_result_handler_list_exec.rs
@@ -17,9 +17,7 @@ where
     /// which represents the "expect" field produces by the other result handlers.
     ///
     /// The default behavior is to leave it unchanged.
-    ///
-    /// TODO: rename to `item_preprocessing` on next minor release.
-    fn item_tx_expect(&self, prev: Env::RHExpect) -> Env::RHExpect {
+    fn item_preprocessing(&self, prev: Env::RHExpect) -> Env::RHExpect {
         prev
     }
 
@@ -38,7 +36,7 @@ where
     /// The operation starts with the default "expect" field, which normally has all fields unspecified, except
     /// for the "status", which is by default set to "0". This means that failing transactions will cause a panic
     /// unless explicitly stated in one of the result handlers.
-    fn list_tx_expect(&self) -> Env::RHExpect;
+    fn list_preprocessing(&self) -> Env::RHExpect;
 
     /// Aggregates the executions of all result handlers, as configured for a transaction.
     fn list_process_result(self, raw_result: &RawResult) -> Self::ListReturns;
@@ -48,7 +46,7 @@ impl<RawResult, Env> RHListExec<RawResult, Env> for ()
 where
     Env: TxEnv,
 {
-    fn list_tx_expect(&self) -> Env::RHExpect {
+    fn list_preprocessing(&self) -> Env::RHExpect {
         Env::RHExpect::default()
     }
 
@@ -59,7 +57,7 @@ impl<RawResult, Env, O> RHListExec<RawResult, Env> for OriginalResultMarker<O>
 where
     Env: TxEnv,
 {
-    fn list_tx_expect(&self) -> Env::RHExpect {
+    fn list_preprocessing(&self) -> Env::RHExpect {
         Env::RHExpect::default()
     }
 
@@ -72,8 +70,8 @@ where
     Head: RHListItemExec<RawResult, Env, Tail::OriginalResult>,
     Tail: RHListExec<RawResult, Env>,
 {
-    fn list_tx_expect(&self) -> Env::RHExpect {
-        self.head.item_tx_expect(self.tail.list_tx_expect())
+    fn list_preprocessing(&self) -> Env::RHExpect {
+        self.head.item_preprocessing(self.tail.list_preprocessing())
     }
 
     fn list_process_result(self, raw_result: &RawResult) -> Self::ListReturns {
@@ -89,8 +87,8 @@ where
     Head: RHListItemExec<RawResult, Env, Tail::OriginalResult, Returns = ()>,
     Tail: RHListExec<RawResult, Env>,
 {
-    fn list_tx_expect(&self) -> Env::RHExpect {
-        self.head.item_tx_expect(self.tail.list_tx_expect())
+    fn list_preprocessing(&self) -> Env::RHExpect {
+        self.head.item_preprocessing(self.tail.list_preprocessing())
     }
 
     fn list_process_result(self, raw_result: &RawResult) -> Self::ListReturns {

--- a/framework/scenario/src/facade/result_handlers/expect_error.rs
+++ b/framework/scenario/src/facade/result_handlers/expect_error.rs
@@ -19,7 +19,7 @@ impl<Env, Original> RHListItemExec<TxResponse, Env, Original> for ExpectError<'_
 where
     Env: TxEnv<RHExpect = TxExpect>,
 {
-    fn item_tx_expect(&self, mut prev: TxExpect) -> TxExpect {
+    fn item_preprocessing(&self, mut prev: TxExpect) -> TxExpect {
         prev.status = CheckValue::Equal(self.0.into());
         let expect_message_expr = BytesValue {
             value: self.1.to_string().into_bytes(),

--- a/framework/scenario/src/facade/result_handlers/expect_message.rs
+++ b/framework/scenario/src/facade/result_handlers/expect_message.rs
@@ -19,7 +19,7 @@ impl<Env, Original> RHListItemExec<TxResponse, Env, Original> for ExpectMessage<
 where
     Env: TxEnv<RHExpect = TxExpect>,
 {
-    fn item_tx_expect(&self, mut prev: TxExpect) -> TxExpect {
+    fn item_preprocessing(&self, mut prev: TxExpect) -> TxExpect {
         if prev.status.is_equal_to(U64Value::empty()) {
             prev.status = CheckValue::Star;
         }

--- a/framework/scenario/src/facade/result_handlers/expect_status.rs
+++ b/framework/scenario/src/facade/result_handlers/expect_status.rs
@@ -18,7 +18,7 @@ impl<Env, Original> RHListItemExec<TxResponse, Env, Original> for ExpectStatus
 where
     Env: TxEnv<RHExpect = TxExpect>,
 {
-    fn item_tx_expect(&self, mut prev: TxExpect) -> TxExpect {
+    fn item_preprocessing(&self, mut prev: TxExpect) -> TxExpect {
         prev.status = CheckValue::Equal(self.0.into());
         prev
     }

--- a/framework/scenario/src/facade/result_handlers/expect_value.rs
+++ b/framework/scenario/src/facade/result_handlers/expect_value.rs
@@ -26,7 +26,7 @@ where
     T: TopEncodeMulti,
     Original: TypeAbiFrom<T>,
 {
-    fn item_tx_expect(&self, mut prev: TxExpect) -> TxExpect {
+    fn item_preprocessing(&self, mut prev: TxExpect) -> TxExpect {
         let mut encoded = Vec::<Vec<u8>>::new();
         self.0.multi_encode(&mut encoded).expect("encoding error");
         let out_values = encoded

--- a/framework/scenario/src/facade/result_handlers/returns_handled_or_err.rs
+++ b/framework/scenario/src/facade/result_handlers/returns_handled_or_err.rs
@@ -79,7 +79,7 @@ where
     NHList: RHListExec<TxResponse, Env>,
     NHList::ListReturns: NestedTupleFlatten,
 {
-    fn item_tx_expect(&self, mut prev: TxExpect) -> TxExpect {
+    fn item_preprocessing(&self, mut prev: TxExpect) -> TxExpect {
         prev.status = CheckValue::Star;
         prev.message = CheckValue::Star;
         prev

--- a/framework/scenario/src/facade/result_handlers/returns_message.rs
+++ b/framework/scenario/src/facade/result_handlers/returns_message.rs
@@ -18,7 +18,7 @@ impl<Env, Original> RHListItemExec<TxResponse, Env, Original> for ReturnsMessage
 where
     Env: TxEnv<RHExpect = TxExpect>,
 {
-    fn item_tx_expect(&self, mut prev: TxExpect) -> TxExpect {
+    fn item_preprocessing(&self, mut prev: TxExpect) -> TxExpect {
         prev.message = CheckValue::Star;
         prev
     }

--- a/framework/scenario/src/facade/result_handlers/returns_status.rs
+++ b/framework/scenario/src/facade/result_handlers/returns_status.rs
@@ -18,7 +18,7 @@ impl<Env, Original> RHListItemExec<TxResponse, Env, Original> for ReturnsStatus
 where
     Env: TxEnv<RHExpect = TxExpect>,
 {
-    fn item_tx_expect(&self, mut prev: TxExpect) -> TxExpect {
+    fn item_preprocessing(&self, mut prev: TxExpect) -> TxExpect {
         if let CheckValue::Equal(U64Value {
             value: 0,
             original: _,

--- a/framework/scenario/src/scenario/tx_to_step/tx_to_step_call.rs
+++ b/framework/scenario/src/scenario/tx_to_step/tx_to_step_call.rs
@@ -29,7 +29,7 @@ where
             self.data,
         );
         step.explicit_tx_hash = self.env.take_tx_hash();
-        step.expect = Some(self.result_handler.list_tx_expect());
+        step.expect = Some(self.result_handler.list_preprocessing());
 
         StepWrapper {
             env: self.env,

--- a/framework/scenario/src/scenario/tx_to_step/tx_to_step_deploy.rs
+++ b/framework/scenario/src/scenario/tx_to_step/tx_to_step_deploy.rs
@@ -23,7 +23,7 @@ where
         let mut step =
             tx_to_sc_deploy_step(&self.env, self.from, self.payment, self.gas, self.data);
         step.explicit_tx_hash = self.env.take_tx_hash();
-        step.expect = Some(self.result_handler.list_tx_expect());
+        step.expect = Some(self.result_handler.list_preprocessing());
 
         StepWrapper {
             env: self.env,

--- a/framework/scenario/src/scenario/tx_to_step/tx_to_step_query.rs
+++ b/framework/scenario/src/scenario/tx_to_step/tx_to_step_query.rs
@@ -16,7 +16,7 @@ where
 
     fn tx_to_query_step(self) -> StepWrapper<Env, Self::Step, RH> {
         let mut step = tx_to_sc_query_step(&self.env, self.to, self.data);
-        step.expect = Some(self.result_handler.list_tx_expect());
+        step.expect = Some(self.result_handler.list_preprocessing());
 
         StepWrapper {
             env: self.env,

--- a/framework/scenario/src/scenario/tx_to_step/tx_to_step_upgrade.rs
+++ b/framework/scenario/src/scenario/tx_to_step/tx_to_step_upgrade.rs
@@ -25,7 +25,7 @@ where
     fn tx_to_step(self) -> StepWrapper<Env, Self::Step, RH> {
         let mut step =
             tx_to_sc_call_upgrade_step(&self.env, self.from, self.to, self.gas, self.data);
-        step.expect = Some(self.result_handler.list_tx_expect());
+        step.expect = Some(self.result_handler.list_preprocessing());
 
         StepWrapper {
             env: self.env,


### PR DESCRIPTION
Leftover TODO.