### PR TITLE
Fixed empty event identifier when not specified in #[event]

### DIFF
--- a/framework/derive/src/parse/auto_impl_parse.rs
+++ b/framework/derive/src/parse/auto_impl_parse.rs
@@ -22,7 +22,11 @@ pub fn process_event_attribute(attr: &syn::Attribute, method: &mut Method) -> bo
     EventAttribute::parse(attr)
         .map(|event_attr| {
             assert_no_other_auto_impl(&*method);
-            let event_identifier = event_attr.identifier;
+            let event_identifier = if event_attr.identifier.is_empty() {
+                method.name.to_string()
+            } else {
+                event_attr.identifier.clone()
+            };
             method.implementation = MethodImpl::Generated(AutoImpl::Event {
                 identifier: event_identifier,
             });


### PR DESCRIPTION
I found a bug where #[event] set "" as the event's identifier, instead of the method's name like the #[endpoint] macro.

This PR fixes this.