### PR TITLE
sc-meta - wasm32v1 default target, rustc target field config

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -16,7 +16,7 @@ jobs:
     name: Contracts
     uses: multiversx/mx-sc-actions/.github/workflows/contracts.yml@v4.2.2
     with:
-      rust-toolchain: 1.85
+      rust-toolchain: 1.87
       path-to-sc-meta: framework/meta
       mx-scenario-go-version: v4.0.0
       enable-interactor-tests: true

--- a/.github/workflows/lldb-formatter-tests.yml
+++ b/.github/workflows/lldb-formatter-tests.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           default: true
-          toolchain: 1.85
+          toolchain: 1.87
 
       - name: Download vscode-lldb
         uses: robinraju/release-downloader@v1.5

--- a/.github/workflows/plotter-test.yml
+++ b/.github/workflows/plotter-test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.85
+          toolchain: 1.87
           target: wasm32-unknown-unknown
 
       - name: Prerequisites

--- a/.github/workflows/proxy-compare.yml
+++ b/.github/workflows/proxy-compare.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.85
+          toolchain: 1.87
           target: wasm32-unknown-unknown
 
       - name: Install prerequisites

--- a/.github/workflows/template-test-current.yml
+++ b/.github/workflows/template-test-current.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.85
+          toolchain: 1.87
           target: wasm32-unknown-unknown
 
       - name: Install prerequisites

--- a/.github/workflows/template-test-released.yml
+++ b/.github/workflows/template-test-released.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.85
+          toolchain: 1.87
           target: wasm32-unknown-unknown
 
       - name: Install prerequisites

--- a/framework/meta-lib/src/contract/sc_config/contract_variant.rs
+++ b/framework/meta-lib/src/contract/sc_config/contract_variant.rs
@@ -102,7 +102,7 @@ impl ContractVariant {
         let wasm_file_name = format!("{}.wasm", &self.wasm_crate_name_snake_case());
 
         Path::new(&target_dir)
-            .join("wasm32-unknown-unknown")
+            .join(&self.settings.rustc_target)
             .join("release")
             .join(wasm_file_name)
     }

--- a/framework/meta-lib/src/contract/sc_config/contract_variant_builder.rs
+++ b/framework/meta-lib/src/contract/sc_config/contract_variant_builder.rs
@@ -6,7 +6,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::{ei::parse_check_ei, print_util::print_sc_config_main_deprecated};
+use crate::{ei::parse_check_ei, print_util::print_sc_config_main_deprecated, tools};
 
 use super::{
     contract_variant_settings::{parse_allocator, parse_stack_size},
@@ -81,6 +81,10 @@ impl ContractVariantBuilder {
                     default_features: cms.default_features,
                     kill_legacy_callback: cms.kill_legacy_callback,
                     profile: ContractVariantProfile::from_serde(&cms.profile),
+                    rustc_target: cms
+                        .rustc_target
+                        .clone()
+                        .unwrap_or_else(|| tools::build_target::default_target().to_owned()),
                 },
                 ..default
             },

--- a/framework/meta-lib/src/contract/sc_config/contract_variant_settings.rs
+++ b/framework/meta-lib/src/contract/sc_config/contract_variant_settings.rs
@@ -4,7 +4,7 @@ mod stack_size;
 pub use contract_allocator::{parse_allocator, ContractAllocator};
 pub use stack_size::*;
 
-use crate::ei::EIVersion;
+use crate::{ei::EIVersion, tools};
 
 use super::ContractVariantProfileSerde;
 
@@ -36,6 +36,8 @@ pub struct ContractVariantSettings {
     pub kill_legacy_callback: bool,
 
     pub profile: ContractVariantProfile,
+
+    pub rustc_target: String,
 }
 
 impl Default for ContractVariantSettings {
@@ -50,6 +52,7 @@ impl Default for ContractVariantSettings {
             default_features: None,
             kill_legacy_callback: false,
             profile: Default::default(),
+            rustc_target: tools::build_target::default_target().to_owned(),
         }
     }
 }

--- a/framework/meta-lib/src/contract/sc_config/sc_config_serde.rs
+++ b/framework/meta-lib/src/contract/sc_config/sc_config_serde.rs
@@ -64,6 +64,10 @@ pub struct ContractVariantSerde {
 
     #[serde(default)]
     pub profile: Option<ContractVariantProfileSerde>,
+
+    #[serde(default)]
+    #[serde(rename = "rustc-target")]
+    pub rustc_target: Option<String>,
 }
 
 #[derive(Deserialize, Default, Debug)]

--- a/framework/meta-lib/src/contract/sc_config/wasm_build.rs
+++ b/framework/meta-lib/src/contract/sc_config/wasm_build.rs
@@ -37,7 +37,9 @@ impl ContractVariant {
     fn compose_build_command(&self, build_args: &BuildArgs) -> Command {
         let mut command = Command::new("cargo");
         command
-            .args(["build", "--target=wasm32-unknown-unknown", "--release"])
+            .arg("build")
+            .arg(format!("--target={}", &self.settings.rustc_target))
+            .arg("--release")
             .current_dir(self.wasm_crate_path());
         if build_args.locked {
             command.arg("--locked");

--- a/framework/meta-lib/src/tools.rs
+++ b/framework/meta-lib/src/tools.rs
@@ -1,3 +1,4 @@
+pub mod build_target;
 mod find_workspace;
 mod git_describe;
 pub(crate) mod panic_report;

--- a/framework/meta-lib/src/tools/build_target.rs
+++ b/framework/meta-lib/src/tools/build_target.rs
@@ -1,0 +1,24 @@
+use rustc_version::{version_meta, Version};
+
+pub const WASM32_TARGET: &str = "wasm32-unknown-unknown";
+pub const WASM32V1_TARGET: &str = "wasm32v1-none";
+const FIRST_RUSTC_VERSION_WITH_WASM32V1_TARGET: Version = Version::new(1, 85, 0);
+
+/// Gets the rustc wasm32 target name.
+///
+/// It is currently "wasm32v1-none", except for before Rust 1.85, where we use "wasm32-unknown-unknown".
+pub fn default_target() -> &'static str {
+    if is_wasm32v1_available() {
+        WASM32V1_TARGET
+    } else {
+        WASM32_TARGET
+    }
+}
+
+pub fn is_wasm32v1_available() -> bool {
+    let Ok(version) = version_meta() else {
+        return false;
+    };
+
+    version.semver >= FIRST_RUSTC_VERSION_WITH_WASM32V1_TARGET
+}

--- a/framework/meta-lib/src/tools/wasm_opt.rs
+++ b/framework/meta-lib/src/tools/wasm_opt.rs
@@ -11,7 +11,11 @@ pub fn is_wasm_opt_installed() -> bool {
 
 pub fn run_wasm_opt(output_wasm_path: &str) {
     let exit_status = Command::new(WASM_OPT_NAME)
-        .args([output_wasm_path, "-Oz", "--output", output_wasm_path])
+        .arg(output_wasm_path)
+        .arg("-Oz")
+        .arg("--enable-bulk-memory")
+        .arg("--output")
+        .arg(output_wasm_path)
         .spawn()
         .expect("failed to spawn wasm-opt process")
         .wait()

--- a/framework/meta/src/cmd/code_report/generate_report.rs
+++ b/framework/meta/src/cmd/code_report/generate_report.rs
@@ -117,7 +117,7 @@ fn sanitize_output_path_from_report(reports: &mut [CodeReportJson]) {
         report.path = report
             .path
             .split('/')
-            .last()
+            .next_back()
             .unwrap_or(&report.path)
             .to_string();
     })

--- a/framework/meta/src/cmd/code_report/render_code_report.rs
+++ b/framework/meta/src/cmd/code_report/render_code_report.rs
@@ -68,7 +68,7 @@ impl<'a> CodeReportRender<'a> {
     ) {
         self.writeln(format!(
             "| {} | {} | {} | {} |",
-            path.split('/').last().unwrap_or(path),
+            path.split('/').next_back().unwrap_or(path),
             size,
             has_allocator,
             has_panic

--- a/framework/meta/src/cmd/install/install_wasm_tools.rs
+++ b/framework/meta/src/cmd/install/install_wasm_tools.rs
@@ -1,19 +1,28 @@
 use std::process::Command;
 
+use multiversx_sc_meta_lib::tools;
+
 pub fn install_wasm32_target() {
+    install_target(tools::build_target::WASM32_TARGET);
+    if tools::build_target::is_wasm32v1_available() {
+        install_target(tools::build_target::WASM32V1_TARGET);
+    }
+}
+
+fn install_target(target_name: &str) {
     let cmd = Command::new("rustup")
-        .args(vec!["target", "add", "wasm32-unknown-unknown"])
+        .args(["target", "add", target_name])
         .status()
         .expect("failed to execute `rustup`");
 
-    assert!(cmd.success(), "failed to install wasm32 target");
+    assert!(cmd.success(), "failed to install {target_name} target");
 
-    println!("wasm32 target installed successfully");
+    println!("{target_name} target installed successfully");
 }
 
 pub fn install_wasm_opt() {
     let cmd = Command::new("cargo")
-        .args(vec!["install", "wasm-opt"])
+        .args(["install", "wasm-opt"])
         .status()
         .expect("failed to execute `cargo`");
 


### PR DESCRIPTION
Now using target `wasm32v1-none` instead of `wasm32-unknown-unknown`, for rustc >=1.85, to avoid bulk memory operations.

Also added an override in `sc-config.toml`, if anyone ever needs it.

We might revert to `wasm32-unknown-unknown`, but only after we add bulk operation support in the VM.