### PR TITLE
Event identifier fix + test

### DIFF
--- a/contracts/feature-tests/abi-tester/abi_tester_expected_main.abi.json
+++ b/contracts/feature-tests/abi-tester/abi_tester_expected_main.abi.json
@@ -492,6 +492,10 @@
                     "indexed": true
                 }
             ]
+        },
+        {
+            "identifier": "empty_identifier_event",
+            "inputs": []
         }
     ],
     "esdtAttributes": [

--- a/contracts/feature-tests/abi-tester/abi_tester_expected_view.abi.json
+++ b/contracts/feature-tests/abi-tester/abi_tester_expected_view.abi.json
@@ -97,6 +97,10 @@
                     "indexed": true
                 }
             ]
+        },
+        {
+            "identifier": "empty_identifier_event",
+            "inputs": []
         }
     ],
     "esdtAttributes": [

--- a/contracts/feature-tests/abi-tester/src/abi_tester.rs
+++ b/contracts/feature-tests/abi-tester/src/abi_tester.rs
@@ -219,6 +219,9 @@ pub trait AbiTester {
     #[event("address-h256-event")]
     fn address_h256_event(&self, #[indexed] address: &Address, #[indexed] h256: &H256);
 
+    #[event]
+    fn empty_identifier_event(&self);
+
     #[endpoint]
     #[label("label1")]
     fn label_a(&self) {}

--- a/contracts/feature-tests/basic-features/src/event_features.rs
+++ b/contracts/feature-tests/basic-features/src/event_features.rs
@@ -19,7 +19,8 @@ pub trait EventFeatures {
         }
     }
 
-    #[event("event_b")]
+    /// If event identifier is missing, the name of the method will be used.
+    #[event]
     fn event_b(
         &self,
         #[indexed] arg1: &BigUint,

--- a/framework/derive/src/parse/auto_impl_parse.rs
+++ b/framework/derive/src/parse/auto_impl_parse.rs
@@ -22,7 +22,11 @@ pub fn process_event_attribute(attr: &syn::Attribute, method: &mut Method) -> bo
     EventAttribute::parse(attr)
         .map(|event_attr| {
             assert_no_other_auto_impl(&*method);
-            let event_identifier = event_attr.identifier;
+            let event_identifier = if event_attr.identifier.is_empty() {
+                method.name.to_string()
+            } else {
+                event_attr.identifier.clone()
+            };
             method.implementation = MethodImpl::Generated(AutoImpl::Event {
                 identifier: event_identifier,
             });


### PR DESCRIPTION
Added some tests on top of gfusee's PR: https://github.com/multiversx/mx-sdk-rs/pull/2038

It fixes a bug where #[event] set "" as the event's identifier, instead of the method's name like the #[endpoint] macro.