### PR TITLE
forwarder-legacy tests & cleanup

### DIFF
--- a/contracts/feature-tests/composability/forwarder-legacy/src/fwd_esdt_legacy.rs
+++ b/contracts/feature-tests/composability/forwarder-legacy/src/fwd_esdt_legacy.rs
@@ -18,18 +18,6 @@ pub type EsdtTokenDataMultiValue<M> = MultiValue9<
 
 #[multiversx_sc::module]
 pub trait ForwarderEsdtModule: fwd_storage_legacy::ForwarderStorageModule {
-    #[view(getFungibleEsdtBalance)]
-    fn get_fungible_esdt_balance(&self, token_identifier: &TokenIdentifier) -> BigUint {
-        self.blockchain()
-            .get_esdt_balance(&self.blockchain().get_sc_address(), token_identifier, 0)
-    }
-
-    #[view(getCurrentNftNonce)]
-    fn get_current_nft_nonce(&self, token_identifier: &TokenIdentifier) -> u64 {
-        self.blockchain()
-            .get_current_esdt_nft_nonce(&self.blockchain().get_sc_address(), token_identifier)
-    }
-
     #[endpoint]
     fn send_esdt(&self, to: &ManagedAddress, token_id: TokenIdentifier, amount: &BigUint) {
         self.send().direct_esdt(to, &token_id, 0, amount);
@@ -141,65 +129,5 @@ pub trait ForwarderEsdtModule: fwd_storage_legacy::ForwarderStorageModule {
     #[endpoint]
     fn local_burn(&self, token_identifier: TokenIdentifier, amount: BigUint) {
         self.send().esdt_local_burn(&token_identifier, 0, &amount);
-    }
-
-    #[view]
-    fn get_esdt_local_roles(&self, token_id: TokenIdentifier) -> MultiValueEncoded<ManagedBuffer> {
-        let roles = self.blockchain().get_esdt_local_roles(&token_id);
-        let mut result = MultiValueEncoded::new();
-        for role in roles.iter_roles() {
-            result.push(role.as_role_name().into());
-        }
-        result
-    }
-
-    #[view]
-    fn get_esdt_token_data(
-        &self,
-        address: ManagedAddress,
-        token_id: TokenIdentifier,
-        nonce: u64,
-    ) -> EsdtTokenDataMultiValue<Self::Api> {
-        let token_data = self
-            .blockchain()
-            .get_esdt_token_data(&address, &token_id, nonce);
-
-        (
-            token_data.token_type,
-            token_data.amount,
-            token_data.frozen,
-            token_data.hash,
-            token_data.name,
-            token_data.attributes,
-            token_data.creator,
-            token_data.royalties,
-            token_data.uris,
-        )
-            .into()
-    }
-
-    #[view]
-    fn is_esdt_frozen(
-        &self,
-        address: &ManagedAddress,
-        token_id: &TokenIdentifier,
-        nonce: u64,
-    ) -> bool {
-        self.blockchain().is_esdt_frozen(address, token_id, nonce)
-    }
-
-    #[view]
-    fn is_esdt_paused(&self, token_id: &TokenIdentifier) -> bool {
-        self.blockchain().is_esdt_paused(token_id)
-    }
-
-    #[view]
-    fn is_esdt_limited_transfer(&self, token_id: &TokenIdentifier) -> bool {
-        self.blockchain().is_esdt_limited_transfer(token_id)
-    }
-
-    #[view]
-    fn validate_token_identifier(&self, token_id: TokenIdentifier) -> bool {
-        token_id.is_valid_esdt_identifier()
     }
 }

--- a/contracts/feature-tests/composability/forwarder-legacy/src/fwd_nft_legacy.rs
+++ b/contracts/feature-tests/composability/forwarder-legacy/src/fwd_nft_legacy.rs
@@ -24,15 +24,6 @@ pub struct ComplexAttributes<M: ManagedTypeApi> {
 
 #[multiversx_sc::module]
 pub trait ForwarderNftModule: fwd_storage_legacy::ForwarderStorageModule {
-    #[view]
-    fn get_nft_balance(&self, token_identifier: &TokenIdentifier, nonce: u64) -> BigUint {
-        self.blockchain().get_esdt_balance(
-            &self.blockchain().get_sc_address(),
-            token_identifier,
-            nonce,
-        )
-    }
-
     #[payable("*")]
     #[endpoint]
     fn buy_nft(&self, nft_id: TokenIdentifier, nft_nonce: u64, nft_amount: BigUint) -> BigUint {

--- a/contracts/feature-tests/composability/forwarder-legacy/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/forwarder-legacy/wasm/src/lib.rs
@@ -5,9 +5,9 @@
 ////////////////////////////////////////////////////
 
 // Init:                                 1
-// Endpoints:                           67
+// Endpoints:                           66
 // Async Callback:                       1
-// Total number of exported functions:  69
+// Total number of exported functions:  68
 
 #![no_std]
 
@@ -62,7 +62,6 @@ multiversx_sc_wasm_adapter::endpoints! {
         local_mint => local_mint
         local_burn => local_burn
         get_esdt_local_roles => get_esdt_local_roles
-        get_esdt_token_data => get_esdt_token_data
         is_esdt_frozen => is_esdt_frozen
         is_esdt_paused => is_esdt_paused
         is_esdt_limited_transfer => is_esdt_limited_transfer

--- a/contracts/feature-tests/composability/tests/composability_scenario_rs_forwarder_legacy_test.rs
+++ b/contracts/feature-tests/composability/tests/composability_scenario_rs_forwarder_legacy_test.rs
@@ -1,0 +1,284 @@
+use multiversx_sc_scenario::imports::*;
+
+fn world() -> ScenarioWorld {
+    let mut blockchain = ScenarioWorld::new();
+    blockchain.set_current_dir_from_workspace("contracts/feature-tests/composability");
+
+    blockchain.register_contract(
+        "mxsc:forwarder/output/forwarder.mxsc.json",
+        forwarder_legacy::ContractBuilder,
+    );
+
+    let vault_sc_config =
+        meta::multi_contract_config::<vault::AbiProvider>(&blockchain.current_dir().join("vault"));
+    blockchain.register_contract_variant(
+        "mxsc:vault/output/vault.mxsc.json",
+        vault::ContractBuilder,
+        vault_sc_config.find_contract("vault"),
+    );
+    blockchain.register_contract_variant(
+        "mxsc:vault/output/vault-upgrade.mxsc.json",
+        vault::ContractBuilder,
+        vault_sc_config.find_contract("vault-upgrade"),
+    );
+    blockchain
+}
+
+#[test]
+fn legacy_forwarder_builtin_nft_add_quantity_rs() {
+    world().run("scenarios/forwarder_builtin_nft_add_quantity.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_builtin_nft_burn_rs() {
+    world().run("scenarios/forwarder_builtin_nft_burn.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_builtin_nft_create_rs() {
+    world().run("scenarios/forwarder_builtin_nft_create.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_builtin_nft_local_burn_rs() {
+    world().run("scenarios/forwarder_builtin_nft_local_burn.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_builtin_nft_local_mint_rs() {
+    world().run("scenarios/forwarder_builtin_nft_local_mint.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_call_async_accept_egld_rs() {
+    world().run("scenarios/forwarder_call_async_accept_egld.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_call_async_accept_esdt_rs() {
+    world().run("scenarios/forwarder_call_async_accept_esdt.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_call_async_accept_nft_rs() {
+    world().run("scenarios/forwarder_call_async_accept_nft.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_call_async_multi_transfer_rs() {
+    world().run("scenarios/forwarder_call_async_multi_transfer.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_call_async_retrieve_egld_rs() {
+    world().run("scenarios/forwarder_call_async_retrieve_egld.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_call_async_retrieve_esdt_rs() {
+    world().run("scenarios/forwarder_call_async_retrieve_esdt.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_call_async_retrieve_nft_rs() {
+    world().run("scenarios/forwarder_call_async_retrieve_nft.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_call_sync_accept_egld_rs() {
+    world().run("scenarios/forwarder_call_sync_accept_egld.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_call_sync_accept_esdt_rs() {
+    world().run("scenarios/forwarder_call_sync_accept_esdt.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_call_sync_accept_multi_transfer_rs() {
+    world().run("scenarios/forwarder_call_sync_accept_multi_transfer.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_call_sync_accept_nft_rs() {
+    world().run("scenarios/forwarder_call_sync_accept_nft.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_call_sync_accept_then_read_egld_rs() {
+    world().run("scenarios/forwarder_call_sync_accept_then_read_egld.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_call_sync_accept_then_read_esdt_rs() {
+    world().run("scenarios/forwarder_call_sync_accept_then_read_esdt.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_call_sync_accept_then_read_nft_rs() {
+    world().run("scenarios/forwarder_call_sync_accept_then_read_nft.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_call_sync_retrieve_egld_rs() {
+    world().run("scenarios/forwarder_call_sync_retrieve_egld.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_call_sync_retrieve_esdt_rs() {
+    world().run("scenarios/forwarder_call_sync_retrieve_esdt.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_call_sync_retrieve_nft_rs() {
+    world().run("scenarios/forwarder_call_sync_retrieve_nft.scen.json");
+}
+
+#[test]
+#[ignore = "TODO: fix logs"]
+fn legacy_forwarder_call_transf_exec_accept_return_values_rs() {
+    world().run("scenarios/forwarder_call_transf_exec_accept_return_values.scen.json");
+}
+
+#[test]
+#[ignore = "TODO: fix logs"]
+fn legacy_forwarder_call_transf_exec_egld_accept_rs() {
+    world().run("scenarios/forwarder_call_transf_exec_egld_accept.scen.json");
+}
+
+#[test]
+#[ignore = "TODO: fix logs"]
+fn legacy_forwarder_call_transf_exec_egld_accept_twice_rs() {
+    world().run("scenarios/forwarder_call_transf_exec_egld_accept_twice.scen.json");
+}
+
+#[test]
+#[ignore = "TODO: fix logs"]
+fn legacy_forwarder_call_transf_exec_multi_transfer_egld_accept_rs() {
+    world().run("scenarios/forwarder_call_transf_exec_multi_transfer_egld_accept.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_call_transf_exec_multi_transfer_egld_reject_rs() {
+    world().run("scenarios/forwarder_call_transf_exec_multi_transfer_egld_reject.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_call_transf_exec_multi_transfer_esdt_accept_rs() {
+    world().run("scenarios/forwarder_call_transf_exec_multi_transfer_esdt_accept.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_call_transf_exec_multi_transfer_esdt_reject_rs() {
+    world().run("scenarios/forwarder_call_transf_exec_multi_transfer_esdt_reject.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_call_transf_exec_single_esdt_accept_rs() {
+    world().run("scenarios/forwarder_call_transf_exec_single_esdt_accept.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_call_transf_exec_single_esdt_accept_twice_rs() {
+    world().run("scenarios/forwarder_call_transf_exec_single_esdt_accept_twice.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_call_transf_exec_single_nft_accept_rs() {
+    world().run("scenarios/forwarder_call_transf_exec_single_nft_accept.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_call_transf_exec_single_nft_reject_rs() {
+    world().run("scenarios/forwarder_call_transf_exec_single_nft_reject.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_call_transf_exec_single_sft_twice_accept_rs() {
+    world().run("scenarios/forwarder_call_transf_exec_single_sft_twice_accept.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_contract_change_owner_rs() {
+    world().run("scenarios/forwarder_contract_change_owner.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_contract_deploy_rs() {
+    world().run("scenarios/forwarder_contract_deploy.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_contract_upgrade_rs() {
+    world().run("scenarios/forwarder_contract_upgrade.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_nft_add_uri_rs() {
+    world().run("scenarios/forwarder_nft_add_uri.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_nft_create_rs() {
+    world().run("scenarios/forwarder_nft_create.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_nft_create_and_send_rs() {
+    world().run("scenarios/forwarder_nft_create_and_send.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_nft_decode_complex_attributes_rs() {
+    world().run("scenarios/forwarder_nft_decode_complex_attributes.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_nft_transfer_async_rs() {
+    world().run("scenarios/forwarder_nft_transfer_async.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_nft_transfer_exec_rs() {
+    world().run("scenarios/forwarder_nft_transfer_exec.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_nft_update_attributes_rs() {
+    world().run("scenarios/forwarder_nft_update_attributes.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_no_endpoint_rs() {
+    world().run("scenarios/forwarder_no_endpoint.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_retrieve_funds_with_accept_func_rs() {
+    world().run("scenarios/forwarder_retrieve_funds_with_accept_func.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_send_esdt_multi_transfer_rs() {
+    world().run("scenarios/forwarder_send_esdt_multi_transfer.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_sync_echo_rs() {
+    world().run("scenarios/forwarder_sync_echo.scen.json");
+}
+
+#[test]
+fn legacy_forwarder_transfer_esdt_with_fees_rs() {
+    world().run("scenarios/forwarder_transfer_esdt_with_fees.scen.json");
+}
+
+#[test]
+fn legacy_send_egld_rs() {
+    world().run("scenarios/send_egld.scen.json");
+}
+
+#[test]
+fn legacy_send_esdt_rs() {
+    world().run("scenarios/send_esdt.scen.json");
+}


### PR DESCRIPTION
`forwarder-legacy` was missing tests. It was copied from `forwarder` some time ago, so most mandos tests are identical.

I set up another test suite which tests the same scenarios with `forwarder-legacy` instead of `forwarder`. Deleted everything that was not relevant.

Did not bother to set up mandos-go tests, only mandos-rs (although it should be possible).

Also found and deleted some code in `forwarder-legacy` that was not in fact testing anything legacy, it was just duplicate.

`forwarder-legacy` will probably not be kept forever anyway.