### PR TITLE
Legacy reimagined: execute_on_dest_context_fallible

### DIFF
--- a/contracts/feature-tests/composability/forwarder-legacy/src/forwarder_legacy_main.rs
+++ b/contracts/feature-tests/composability/forwarder-legacy/src/forwarder_legacy_main.rs
@@ -9,6 +9,7 @@ pub mod fwd_call_transf_exec_legacy;
 pub mod fwd_change_owner_legacy;
 pub mod fwd_deploy_legacy;
 pub mod fwd_esdt_legacy;
+pub mod fwd_fallible_legacy;
 pub mod fwd_nft_legacy;
 pub mod fwd_roles_legacy;
 pub mod fwd_sft_legacy;
@@ -27,6 +28,7 @@ pub trait ForwarderLegacy:
     + fwd_deploy_legacy::DeployContractModule
     + fwd_upgrade_legacy::UpgradeContractModule
     + fwd_esdt_legacy::ForwarderEsdtModule
+    + fwd_fallible_legacy::ForwarderFallibleModule
     + fwd_sft_legacy::ForwarderSftModule
     + fwd_nft_legacy::ForwarderNftModule
     + fwd_roles_legacy::ForwarderRolesModule

--- a/contracts/feature-tests/composability/forwarder-legacy/src/fwd_fallible_legacy.rs
+++ b/contracts/feature-tests/composability/forwarder-legacy/src/fwd_fallible_legacy.rs
@@ -1,0 +1,90 @@
+multiversx_sc::imports!();
+
+#[multiversx_sc::module]
+pub trait ForwarderFallibleModule {
+    #[proxy]
+    fn vault_proxy(&self) -> vault::Proxy<Self::Api>;
+
+    #[endpoint]
+    fn sync_call_fallible(
+        &self,
+        to: ManagedAddress,
+        endpoint_name: ManagedBuffer,
+        args: MultiValueEncoded<ManagedBuffer>,
+    ) {
+        let half_gas = self.blockchain().get_gas_left() / 2;
+
+        let result: Result<MultiValueEncoded<ManagedBuffer>, u32> = self
+            .tx()
+            .to(&to)
+            .gas(half_gas)
+            .raw_call(endpoint_name)
+            .arguments_raw(args.to_arg_buffer())
+            .execute_on_dest_context_fallible();
+
+        match result {
+            Ok(success) => {
+                self.sync_call_fallible_success(success.into_vec_of_buffers());
+            }
+            Err(error_code) => {
+                self.sync_call_fallible_error(error_code);
+            }
+        }
+    }
+
+    #[endpoint]
+    fn forward_sync_fallible_accept_funds_multi_transfer(
+        &self,
+        to: ManagedAddress,
+        payment_args: MultiValueEncoded<MultiValue3<EgldOrEsdtTokenIdentifier, u64, BigUint>>,
+    ) -> bool {
+        let result: Result<(), u32> = self
+            .vault_proxy()
+            .contract(to)
+            .accept_funds()
+            .payment(payment_args.convert_payment_multi_triples())
+            .execute_on_dest_context_fallible();
+
+        self.log_result(result);
+
+        result.is_ok()
+    }
+
+    #[endpoint]
+    fn forward_sync_reject_funds_multi_transfer(
+        &self,
+        to: ManagedAddress,
+        payment_args: MultiValueEncoded<MultiValue3<EgldOrEsdtTokenIdentifier, u64, BigUint>>,
+    ) -> bool {
+        let half_gas = self.blockchain().get_gas_left() / 2;
+
+        let result = self
+            .vault_proxy()
+            .contract(to)
+            .reject_funds()
+            .gas(half_gas)
+            .payment(payment_args.convert_payment_multi_triples())
+            .execute_on_dest_context_fallible::<()>();
+
+        self.log_result(result);
+
+        result.is_ok()
+    }
+
+    fn log_result(&self, result: Result<(), u32>) {
+        match result {
+            Ok(()) => {
+                self.sync_call_fallible_success(ManagedVec::new());
+            }
+            Err(error_code) => {
+                self.sync_call_fallible_error(error_code);
+            }
+        }
+    }
+
+    #[event("sync_call_fallible_success")]
+    fn sync_call_fallible_success(&self, result: ManagedVec<Self::Api, ManagedBuffer>);
+
+    #[event("sync_call_fallible_error")]
+    fn sync_call_fallible_error(&self, error_code: u32);
+}

--- a/contracts/feature-tests/composability/forwarder-legacy/wasm/src/lib.rs
+++ b/contracts/feature-tests/composability/forwarder-legacy/wasm/src/lib.rs
@@ -5,9 +5,9 @@
 ////////////////////////////////////////////////////
 
 // Init:                                 1
-// Endpoints:                           58
+// Endpoints:                           61
 // Async Callback:                       1
-// Total number of exported functions:  60
+// Total number of exported functions:  63
 
 #![no_std]
 
@@ -59,6 +59,9 @@ multiversx_sc_wasm_adapter::endpoints! {
         issue_fungible_token => issue_fungible_token
         local_mint => local_mint
         local_burn => local_burn
+        sync_call_fallible => sync_call_fallible
+        forward_sync_fallible_accept_funds_multi_transfer => forward_sync_fallible_accept_funds_multi_transfer
+        forward_sync_reject_funds_multi_transfer => forward_sync_reject_funds_multi_transfer
         sft_issue => sft_issue
         buy_nft => buy_nft
         nft_issue => nft_issue

--- a/contracts/feature-tests/composability/scenarios/forw_raw_sync_fallible_legacy.scen.json
+++ b/contracts/feature-tests/composability/scenarios/forw_raw_sync_fallible_legacy.scen.json
@@ -1,0 +1,121 @@
+{
+    "steps": [
+        {
+            "step": "setState",
+            "accounts": {
+                "address:a_user": {
+                    "nonce": "0",
+                    "balance": "2000"
+                },
+                "sc:vault": {
+                    "nonce": "0",
+                    "balance": "0",
+                    "code": "mxsc:../vault/output/vault.mxsc.json"
+                },
+                "sc:forwarder": {
+                    "nonce": "0",
+                    "balance": "0",
+                    "code": "mxsc:../forwarder-legacy/output/forwarder-legacy.mxsc.json"
+                }
+            }
+        },
+        {
+            "step": "scCall",
+            "id": "sync_call_fallible-success",
+            "tx": {
+                "from": "address:a_user",
+                "to": "sc:forwarder",
+                "function": "sync_call_fallible",
+                "arguments": [
+                    "sc:vault",
+                    "str:echo_arguments",
+                    "1",
+                    "2"
+                ],
+                "gasLimit": "50,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "out": [],
+                "status": "0",
+                "logs": [
+                    {
+                        "address": "sc:forwarder",
+                        "endpoint": "str:transferValueOnly",
+                        "topics": [
+                            "0",
+                            "sc:vault"
+                        ],
+                        "data": [
+                            "str:ExecuteOnDestContext",
+                            "str:echo_arguments",
+                            "1",
+                            "2"
+                        ]
+                    },
+                    {
+                        "address": "sc:forwarder",
+                        "endpoint": "str:sync_call_fallible",
+                        "topics": [
+                            "str:sync_call_fallible_success"
+                        ],
+                        "data": [
+                            {
+                                "0-echoed-args": [
+                                    "biguint:1",
+                                    "biguint:2"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "scCall",
+            "id": "sync_call_fallible-error",
+            "tx": {
+                "from": "address:a_user",
+                "to": "sc:forwarder",
+                "function": "sync_call_fallible",
+                "arguments": [
+                    "sc:vault",
+                    "str:explicit_panic"
+                ],
+                "gasLimit": "50,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "out": [],
+                "status": "0",
+                "logs": [
+                    {
+                        "address": "sc:forwarder",
+                        "endpoint": "str:sync_call_fallible",
+                        "topics": [
+                            "str:sync_call_fallible_error"
+                        ],
+                        "data": [
+                            "1"
+                        ]
+                    },
+                    {
+                        "address": "address:a_user",
+                        "endpoint": "str:internalVMErrors",
+                        "topics": [
+                            "sc:forwarder",
+                            "str:sync_call_fallible"
+                        ],
+                        "data": [
+                            "*"
+                        ]
+                    }
+                ],
+                "gas": "*",
+                "refund": "*"
+            }
+        }
+    ]
+}

--- a/contracts/feature-tests/composability/tests/composability_scenario_go_test.rs
+++ b/contracts/feature-tests/composability/tests/composability_scenario_go_test.rs
@@ -121,6 +121,11 @@ fn forw_raw_sync_fallible_go() {
 }
 
 #[test]
+fn forw_raw_sync_fallible_legacy_go() {
+    world().run("scenarios/forw_raw_sync_fallible_legacy.scen.json");
+}
+
+#[test]
 fn forw_raw_sync_readonly_go() {
     world().run("scenarios/forw_raw_sync_readonly.scen.json");
 }

--- a/contracts/feature-tests/composability/tests/composability_scenario_rs_test.rs
+++ b/contracts/feature-tests/composability/tests/composability_scenario_rs_test.rs
@@ -168,6 +168,12 @@ fn forw_raw_sync_fallible_rs() {
 }
 
 #[test]
+#[ignore = "requires Barnard, unavailable: managed_execute_on_dest_context_with_error_return"]
+fn forw_raw_sync_fallible_legacy_rs() {
+    world().run("scenarios/forw_raw_sync_fallible_legacy.scen.json");
+}
+
+#[test]
 fn forw_raw_sync_readonly_rs() {
     world().run("scenarios/forw_raw_sync_readonly.scen.json");
 }

--- a/framework/base/src/types/interaction/tx_exec/tx_exec_sync.rs
+++ b/framework/base/src/types/interaction/tx_exec/tx_exec_sync.rs
@@ -5,8 +5,9 @@ use crate::{
     contract_base::{SendRawWrapper, SyncCallRawResult, SyncCallRawResultOrError},
     tuple_util::NestedTupleFlatten,
     types::{
-        decode_result, BackTransfersLegacy, ManagedBuffer, ManagedVec, OriginalResultMarker,
-        RHListExec, Tx, TxDataFunctionCall, TxGas, TxNoPayment, TxPayment, TxScEnv, TxToSpecified,
+        decode_result, BackTransfersLegacy, ManagedBuffer, ManagedVec, RHListExec, Tx,
+        TxDataFunctionCall, TxEmptyResultHandler, TxGas, TxNoPayment, TxPayment, TxResultHandler,
+        TxScEnv, TxToSpecified,
     },
 };
 
@@ -17,8 +18,7 @@ where
     Payment: TxPayment<TxScEnv<Api>>,
     Gas: TxGas<TxScEnv<Api>>,
     FC: TxDataFunctionCall<TxScEnv<Api>>,
-    RH: RHListExec<SyncCallRawResult<Api>, TxScEnv<Api>>,
-    RH::ListReturns: NestedTupleFlatten,
+    RH: TxResultHandler<TxScEnv<Api>>,
 {
     fn execute_sync_call_raw(self) -> (SyncCallRawResult<Api>, RH) {
         let gas_limit = self.gas.gas_value(&self.env);
@@ -43,7 +43,18 @@ where
 
         (raw_result, self.result_handler)
     }
+}
 
+impl<Api, To, Payment, Gas, FC, RH> Tx<TxScEnv<Api>, (), To, Payment, Gas, FC, RH>
+where
+    Api: CallTypeApi,
+    To: TxToSpecified<TxScEnv<Api>>,
+    Payment: TxPayment<TxScEnv<Api>>,
+    Gas: TxGas<TxScEnv<Api>>,
+    FC: TxDataFunctionCall<TxScEnv<Api>>,
+    RH: RHListExec<SyncCallRawResult<Api>, TxScEnv<Api>>,
+    RH::ListReturns: NestedTupleFlatten,
+{
     /// Executes transaction synchronously.
     ///
     /// Only works with contracts from the same shard.
@@ -99,10 +110,9 @@ where
     Payment: TxPayment<TxScEnv<Api>>,
     Gas: TxGas<TxScEnv<Api>>,
     FC: TxDataFunctionCall<TxScEnv<Api>>,
-    RH: RHListExec<SyncCallRawResultOrError<Api>, TxScEnv<Api>>,
-    RH::ListReturns: NestedTupleFlatten,
+    RH: TxResultHandler<TxScEnv<Api>>,
 {
-    fn execute_sync_call_return_error_raw(self) -> (SyncCallRawResultOrError<Api>, RH) {
+    fn execute_sync_call_fallible_raw(self) -> (SyncCallRawResultOrError<Api>, RH) {
         let gas_limit = self.gas.gas_value(&self.env);
 
         let raw_result = self.payment.with_normalized(
@@ -125,7 +135,18 @@ where
 
         (raw_result, self.result_handler)
     }
+}
 
+impl<Api, To, Payment, Gas, FC, RH> Tx<TxScEnv<Api>, (), To, Payment, Gas, FC, RH>
+where
+    Api: CallTypeApi,
+    To: TxToSpecified<TxScEnv<Api>>,
+    Payment: TxPayment<TxScEnv<Api>>,
+    Gas: TxGas<TxScEnv<Api>>,
+    FC: TxDataFunctionCall<TxScEnv<Api>>,
+    RH: RHListExec<SyncCallRawResultOrError<Api>, TxScEnv<Api>>,
+    RH::ListReturns: NestedTupleFlatten,
+{
     /// Executes transaction synchronously.
     ///
     /// Only works with contracts from the same shard.
@@ -134,7 +155,7 @@ where
     /// The execution will not stop, the error code will be available to result handler.
     pub fn sync_call_fallible(self) -> <RH::ListReturns as NestedTupleFlatten>::Unpacked {
         self.result_handler.list_preprocessing();
-        let (result_or_err, result_handler) = self.execute_sync_call_return_error_raw();
+        let (result_or_err, result_handler) = self.execute_sync_call_fallible_raw();
         let tuple_result = result_handler.list_process_result(&result_or_err);
         tuple_result.flatten_unpack()
     }
@@ -180,16 +201,19 @@ where
     }
 }
 
-impl<Api, To, Payment, Gas, FC, OriginalResult>
-    Tx<TxScEnv<Api>, (), To, Payment, Gas, FC, OriginalResultMarker<OriginalResult>>
+impl<Api, To, Payment, Gas, FC, RH> Tx<TxScEnv<Api>, (), To, Payment, Gas, FC, RH>
 where
     Api: CallTypeApi,
     To: TxToSpecified<TxScEnv<Api>>,
     Payment: TxPayment<TxScEnv<Api>>,
     Gas: TxGas<TxScEnv<Api>>,
     FC: TxDataFunctionCall<TxScEnv<Api>>,
+    RH: TxEmptyResultHandler<TxScEnv<Api>>,
 {
     /// Backwards compatibility.
+    ///
+    /// Incompatible with result handlers.
+    #[deprecated(since = "0.61.0", note = "Please use `.sync_call()` instead.")]
     pub fn execute_on_dest_context<RequestedResult>(self) -> RequestedResult
     where
         RequestedResult: TopDecodeMulti,
@@ -199,6 +223,12 @@ where
     }
 
     /// Backwards compatibility.
+    ///
+    /// Incompatible with result handlers.
+    #[deprecated(
+        since = "0.61.0",
+        note = "Please use `.returns(ReturnsBackTransfers).sync_call()` instead."
+    )]
     pub fn execute_on_dest_context_with_back_transfers<RequestedResult>(
         self,
     ) -> (RequestedResult, BackTransfersLegacy<Api>)
@@ -210,5 +240,24 @@ where
             crate::contract_base::BlockchainWrapper::<Api>::new().get_back_transfers_legacy();
 
         (result, back_transfers)
+    }
+
+    /// Reimagined, based on the old syntax. Please use `.returns(ReturnsHandledOrError::new().returns(...)).sync_call_fallible()` instead.
+    ///
+    /// Incompatible with result handlers.
+    #[deprecated(
+        since = "0.61.0",
+        note = "Please use `.returns(ReturnsHandledOrError::new().returns(...)).sync_call_fallible()` instead."
+    )]
+    pub fn execute_on_dest_context_fallible<RequestedResult>(self) -> Result<RequestedResult, u32>
+    where
+        RequestedResult: TopDecodeMulti,
+    {
+        let (raw_result, _) = self.execute_sync_call_fallible_raw();
+
+        match raw_result {
+            SyncCallRawResultOrError::Success(result) => Ok(decode_result(result.0)),
+            SyncCallRawResultOrError::Error(err_code) => return Err(err_code),
+        }
     }
 }

--- a/framework/base/src/types/interaction/tx_exec/tx_exec_sync.rs
+++ b/framework/base/src/types/interaction/tx_exec/tx_exec_sync.rs
@@ -257,7 +257,7 @@ where
 
         match raw_result {
             SyncCallRawResultOrError::Success(result) => Ok(decode_result(result.0)),
-            SyncCallRawResultOrError::Error(err_code) => return Err(err_code),
+            SyncCallRawResultOrError::Error(err_code) => Err(err_code),
         }
     }
 }


### PR DESCRIPTION
Requested by @dorin-iancu, because he doesn't like the unified syntax.