### PR TITLE
docs: fix inverted storage-cost claim in UnorderedSetMapper doc comment

### DIFF
--- a/framework/base/src/storage/mappers/set_mapper.rs
+++ b/framework/base/src/storage/mappers/set_mapper.rs
@@ -58,8 +58,8 @@ const NODE_ID_IDENTIFIER: &[u8] = b".node_id";
 ///
 /// # Comparison with UnorderedSetMapper
 ///
-/// - **SetMapper**: Maintains insertion order, uses queue-based structure, slightly higher storage cost
-/// - **UnorderedSetMapper**: No ordering guarantees, uses vec-based structure, more compact storage
+/// - **SetMapper**: Maintains insertion order, uses queue-based structure, higher storage cost (3N + 1 entries)
+/// - **UnorderedSetMapper**: No ordering guarantees, uses vec-based structure, more compact storage (2N + 1 entries)
 ///
 /// # Use Cases
 ///

--- a/framework/base/src/storage/mappers/unordered_set_mapper.rs
+++ b/framework/base/src/storage/mappers/unordered_set_mapper.rs
@@ -43,8 +43,9 @@ const NULL_ENTRY: usize = 0;
 ///
 /// # Trade-offs
 ///
-/// - **Pros**: O(1) insert, remove, and contains operations; efficient for membership testing.
-/// - **Cons**: No ordering guarantees; removal changes element positions; uses more storage than `SetMapper`.
+/// - **Pros**: O(1) insert, remove, and contains operations; efficient for membership testing;
+///   more compact storage than `SetMapper` (2N + 1 entries vs 3N + 1).
+/// - **Cons**: No ordering guarantees; `swap_remove` changes the positions of other elements.
 ///
 /// # Example
 ///


### PR DESCRIPTION
`unordered_set_mapper.rs` lists "uses more storage than `SetMapper`" as a con, but the storage layouts documented in the two files give the opposite result.

`SetMapper`, from its own Storage Layout section:

- `base_key + ".info"` = 1
- `base_key + ".node_links" + node_id` = N
- `base_key + ".value" + node_id` = N
- `base_key + ".node_id" + encoded_value` = N

Total: 3N + 1

`UnorderedSetMapper`, from its own Storage Layout section:

- `base_key + ".len"` = 1
- `base_key + ".item" + index` = N
- `base_key + ".index" + encoded_value` = N

Total: 2N + 1

`set_mapper.rs` already has it the right way round, in two places:

- Cons: "Higher storage overhead than `UnorderedSetMapper` (uses QueueMapper internally)"
- Comparison with UnorderedSetMapper: "UnorderedSetMapper: ... more compact storage"

So the two files contradict each other today, and the reader has no way to tell which one is right without counting the layouts by hand.

This PR corrects the `unordered_set_mapper.rs` line and adds the entry counts to both comparisons, so the two descriptions cannot drift apart again. It also names `swap_remove` in the same con line, since that is the operation that actually moves elements.

Worth fixing because that con line is what a developer reads when choosing between the two mappers for a large set. Both give O(1) `contains()`, so storage cost and ordering are the entire decision, and the line as written points at the more expensive option.

Doc comments only, no code change.
